### PR TITLE
fix: Fallback to GitHub username when name is not set

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+# GitHub provider: fallback to username when name is not set
+
+Some GitHub users don't have a display name configured on their profile. Previously, this would result in `name` being `null` in the user info. Now, we fall back to using the GitHub username (`login`) when `name` is not set, ensuring users always have a display name.

--- a/src/cross_auth/social_providers/github.py
+++ b/src/cross_auth/social_providers/github.py
@@ -120,4 +120,8 @@ class GitHubProvider(OAuth2Provider):
         if not info["email"]:
             raise ValueError("No verified email found")
 
+        # Ensure name is always a string, falling back to login (username)
+        if not info.get("name"):
+            info["name"] = info["login"]
+
         return info


### PR DESCRIPTION
## Summary

- Adds fallback to use GitHub username (`login`) when display name is not set on user profile

Some GitHub users do not have a display name configured on their profile. Previously, this would result in `name` being `null` in the user info. Now we ensure users always have a display name.

## Test plan

- [x] Existing tests pass