### PR TITLE
fix: Update autopub to 1.0.0a51

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Check
         id: check
         run: |
-          if uvx --from autopub==1.0.0a50 --with pygithub autopub check; then
+          if uvx --from autopub==1.0.0a51 --with pygithub autopub check; then
             echo "has_release=true" >> $GITHUB_OUTPUT
           else
             echo "has_release=false" >> $GITHUB_OUTPUT
@@ -84,11 +84,11 @@ jobs:
       - name: Build and publish
         run: |
           echo "✨ Preparing..."
-          uvx --from autopub==1.0.0a50 --with pygithub autopub prepare
+          uvx --from autopub==1.0.0a51 --with pygithub autopub prepare
           echo "✨ Building..."
-          uvx --from autopub==1.0.0a50 --with pygithub autopub build
+          uvx --from autopub==1.0.0a51 --with pygithub autopub build
           echo "✨ Publishing..."
-          uvx --from autopub==1.0.0a50 --with pygithub autopub publish
+          uvx --from autopub==1.0.0a51 --with pygithub autopub publish
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Updates autopub to 1.0.0a51 which fixes PR detection for merge commits

## Fixes
- Uses `head_commit` instead of `commits[0]` to find the merge commit
- Gracefully handles missing PR context instead of asserting