### PR TITLE
Improve GitHub OAuth email selection

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,14 @@
+---
+release type: minor
+---
+
+Improve GitHub OAuth email selection.
+
+- **Email selection by flow**: login prefers the stored email (falls back to
+  primary, then any verified); signup prefers the verified primary email (falls
+  back to any verified).
+- **Noreply filtering**: GitHub noreply emails
+  (`123+user@users.noreply.github.com`) are now rejected by default. Pass
+  `allow_noreply_emails=True` to `GitHubProvider` to allow them.
+- **Breaking**: failures to fetch `/user/emails` from GitHub now raise
+  `OAuth2Exception` instead of silently setting email to `None`.

--- a/src/cross_auth/_session.py
+++ b/src/cross_auth/_session.py
@@ -43,7 +43,7 @@ _SESSION_CONFIG_DEFAULTS: SessionConfig = {
 def resolve_config(config: SessionConfig | None) -> SessionConfig:
     if config is None:
         return _SESSION_CONFIG_DEFAULTS
-    return {**_SESSION_CONFIG_DEFAULTS, **config}  # type: ignore[typeddict-item]
+    return {**_SESSION_CONFIG_DEFAULTS, **config}
 
 
 def create_session(

--- a/src/cross_auth/social_providers/github/__init__.py
+++ b/src/cross_auth/social_providers/github/__init__.py
@@ -1,0 +1,1 @@
+from .provider import GitHubProvider as GitHubProvider

--- a/src/cross_auth/social_providers/github/provider.py
+++ b/src/cross_auth/social_providers/github/provider.py
@@ -2,12 +2,20 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Any, cast
+from typing import Annotated, Any, cast
+from urllib.parse import urlparse
 
 import httpx
-from pydantic import AnyUrl, BaseModel, EmailStr, Field
+from pydantic import AnyUrl, BaseModel, EmailStr, Field, TypeAdapter
 
-from .oauth import OAuth2Provider, UserInfo
+from ..oauth import (
+    NoEmailError,
+    NoVerifiedEmailError,
+    OAuth2Exception,
+    OAuth2Provider,
+    ResolvedEmail,
+    UserInfo,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +90,15 @@ class GitHubUser(BaseModel):
     ldap_dn: str | None = None
 
 
+class Email(BaseModel):
+    email: Annotated[EmailStr, Field(examples=["octocat@github.com"])]
+    primary: Annotated[bool, Field(examples=[True])]
+    verified: Annotated[bool, Field(examples=[True])]
+
+
+EmailResponse = TypeAdapter(list[Email])
+
+
 class GitHubProvider(OAuth2Provider):
     id = "github"
 
@@ -101,6 +118,7 @@ class GitHubProvider(OAuth2Provider):
         authorization_endpoint: str | None = None,
         token_endpoint: str | None = None,
         api_base_url: str | None = None,
+        allow_noreply_emails: bool = False,
     ):
         """
         Initialize the GitHub OAuth2 provider.
@@ -114,8 +132,13 @@ class GitHubProvider(OAuth2Provider):
             token_endpoint: Custom token exchange URL (for server-to-server calls).
             api_base_url: Custom API base URL for user info and emails
                 (for server-to-server calls). Should not include trailing slash.
+            allow_noreply_emails: If True, GitHub noreply emails
+                (e.g. ``123+user@users.noreply.github.com``) are accepted.
+                Default: False.
         """
         super().__init__(client_id, client_secret, trust_email)
+        self._allow_noreply_emails = allow_noreply_emails
+        self._noreply_suffix = "@users.noreply.github.com"
 
         if authorization_endpoint is not None:
             self.authorization_endpoint = authorization_endpoint
@@ -125,33 +148,44 @@ class GitHubProvider(OAuth2Provider):
             api_base_url = api_base_url.rstrip("/")
             self.user_info_endpoint = f"{api_base_url}/user"
             self.emails_endpoint = f"{api_base_url}/user/emails"
+            host = urlparse(api_base_url).hostname or "github.com"
+            self._noreply_suffix = f"@users.noreply.{host}"
+
+    def _fetch_user_emails(self, access_token: str) -> list[Email]:
+        response = httpx.get(
+            self.emails_endpoint,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        response.raise_for_status()
+
+        return EmailResponse.validate_json(response.text)
 
     def fetch_user_info(self, access_token: str) -> UserInfo:
         # Cast to dict[str, Any] since GitHub API returns more fields than UserInfo
         info = cast(dict[str, Any], super().fetch_user_info(access_token))
 
         try:
-            response = httpx.get(
-                self.emails_endpoint,
-                headers={"Authorization": f"Bearer {access_token}"},
-            )
-
-            response.raise_for_status()
-
-            emails = response.json()
-
-            # Always use the primary email
-            primary = next((e for e in emails if e["primary"]), None)
-
-            if primary:
-                info["email"] = primary["email"]
-                info["email_verified"] = primary["verified"]
-            else:
-                info["email"] = None
-                info["email_verified"] = None
-
+            emails = self._fetch_user_emails(access_token)
         except Exception as e:
-            logger.error(f"Failed to fetch user emails: {e}")
+            logger.error(f"Failed to fetch user emails: {str(e)}")
+            raise OAuth2Exception(
+                error="server_error",
+                error_description="Failed to fetch user emails from GitHub",
+            ) from e
+
+        # Stash emails in user_info for resolve_email (called later by the
+        # base-class callback).  Using the dict avoids instance-level state
+        # that would be unsafe under concurrent requests.
+        info["_github_emails"] = emails
+
+        # Set default email from primary (may be overridden by resolve_email)
+        primary = next((e for e in emails if e.primary), None)
+
+        if primary:
+            info["email"] = primary.email
+            info["email_verified"] = primary.verified
+        else:
             info["email"] = None
             info["email_verified"] = None
 
@@ -160,3 +194,90 @@ class GitHubProvider(OAuth2Provider):
             info["name"] = info["login"]
 
         return cast(UserInfo, info)
+
+    def resolve_email(
+        self,
+        user_info: dict[str, Any],
+        is_login: bool,
+        stored_email: str | None = None,
+    ) -> ResolvedEmail:
+        """Select the appropriate email based on login/signup context.
+
+        Expects ``fetch_user_info`` to be called first in the same flow, which
+        stashes ``/user/emails`` response data in *user_info* for
+        deterministic, concurrency-safe selection.
+        """
+        emails: list[Email] | None = user_info.pop("_github_emails", None)
+
+        if emails is None:
+            raise OAuth2Exception(
+                error="server_error",
+                error_description="GitHub emails were not fetched before resolve_email",
+            )
+
+        if not emails:
+            raise NoEmailError("No emails available from GitHub")
+
+        selected = self._select_email(emails, is_login, stored_email)
+
+        # _select_email only returns verified emails
+        return ResolvedEmail(email=selected, email_verified=True)
+
+    def _select_email(
+        self,
+        emails: list[Email],
+        is_login: bool,
+        stored_email: str | None = None,
+    ) -> str:
+        """Select email based on flow type.
+
+        Login: prefer stored email, fall back to primary, then any verified.
+        Signup: prefer verified primary, fall back to any verified.
+        """
+        if not self._allow_noreply_emails:
+            emails = [e for e in emails if not e.email.endswith(self._noreply_suffix)]
+
+        verified = [e for e in emails if e.verified]
+
+        if not verified:
+            raise NoVerifiedEmailError("No verified email found on GitHub account")
+
+        if is_login:
+            return self._select_email_for_login(verified, stored_email)
+        return self._select_email_for_signup(emails, verified)
+
+    def _select_email_for_login(
+        self,
+        verified: list[Email],
+        stored_email: str | None,
+    ) -> str:
+        """Select email for login: prefer stored, then primary, then first."""
+        if stored_email:
+            stored_lower = stored_email.lower()
+            for email in verified:
+                if email.email.lower() == stored_lower:
+                    return email.email
+
+        for email in verified:
+            if email.primary:
+                return email.email
+
+        return verified[0].email
+
+    def _select_email_for_signup(
+        self,
+        candidates: list[Email],
+        verified: list[Email],
+    ) -> str:
+        """Select email for signup: prefer verified primary, then any verified."""
+        primary = next((e for e in candidates if e.primary), None)
+
+        if primary and primary.verified:
+            return primary.email
+
+        # Primary missing or unverified — fall back to any verified
+        for email in verified:
+            if not email.primary:
+                return email.email
+
+        return verified[0].email

--- a/src/cross_auth/social_providers/oauth.py
+++ b/src/cross_auth/social_providers/oauth.py
@@ -40,6 +40,12 @@ class UserInfo(TypedDict, total=True):
 
 
 @dataclass
+class ResolvedEmail:
+    email: str
+    email_verified: bool | None
+
+
+@dataclass
 class ValidatedUserInfo:
     email: str
     provider_user_id: str
@@ -50,6 +56,38 @@ class OAuth2Exception(Exception):
     def __init__(self, error: str, error_description: str):
         self.error = error
         self.error_description = error_description
+
+
+class NoEmailError(OAuth2Exception):
+    """No emails available from the provider."""
+
+    def __init__(self, error_description: str = "No emails available"):
+        super().__init__(error="no_email", error_description=error_description)
+
+
+class NoVerifiedEmailError(OAuth2Exception):
+    """No verified email found on the provider account."""
+
+    def __init__(self, error_description: str = "No verified email found on account"):
+        super().__init__(error="no_verified_email", error_description=error_description)
+
+
+class EmailNotVerifiedError(OAuth2Exception):
+    """A required email is not verified."""
+
+    def __init__(self, error_description: str = "Email is not verified"):
+        super().__init__(
+            error="email_not_verified", error_description=error_description
+        )
+
+
+class EmailPolicyError(OAuth2Exception):
+    """Email selection violates the configured policy."""
+
+    def __init__(self, error_description: str = "Email policy violation"):
+        super().__init__(
+            error="email_policy_error", error_description=error_description
+        )
 
 
 class OAuth2AuthorizationRequestData(BaseModel):
@@ -383,6 +421,28 @@ class OAuth2Provider:
             )
 
             user_info = self.fetch_user_info(token_response.access_token)
+            provider_user_id = self._get_provider_user_id(user_info)
+
+            # Check if this is login (existing social account) or signup
+            social_account = context.accounts_storage.find_social_account(
+                provider=self.id,
+                provider_user_id=provider_user_id,
+            )
+
+            is_login = social_account is not None
+            stored_email = None
+            if social_account:
+                existing_user = context.accounts_storage.find_user_by_id(
+                    social_account.user_id
+                )
+                stored_email = existing_user.email if existing_user else None
+
+            # Resolve email based on login/signup context
+            user_info_dict = cast(dict[str, Any], user_info)
+            resolved = self.resolve_email(user_info_dict, is_login, stored_email)
+            user_info_dict["email"] = resolved.email
+            user_info_dict["email_verified"] = resolved.email_verified
+
             validated = self.validate_user_info(user_info)
         except OAuth2Exception as e:
             return Response.error_redirect(
@@ -391,11 +451,6 @@ class OAuth2Provider:
                 error_description=e.error_description,
                 state=provider_data.client_state,
             )
-
-        social_account = context.accounts_storage.find_social_account(
-            provider=self.id,
-            provider_user_id=validated.provider_user_id,
-        )
 
         if social_account:
             context.accounts_storage.update_social_account(
@@ -692,6 +747,17 @@ class OAuth2Provider:
 
         return user_info
 
+    def _get_provider_user_id(self, user_info: UserInfo) -> str:
+        """Extract and validate provider user ID from user info."""
+        provider_user_id = user_info.get("id")
+        if not provider_user_id:
+            logger.error("No provider user ID found in user info")
+            raise OAuth2Exception(
+                error="server_error",
+                error_description="No provider user ID found in user info",
+            )
+        return str(provider_user_id)
+
     def validate_user_info(self, user_info: UserInfo) -> ValidatedUserInfo:
         """
         Validate and extract user info from provider response.
@@ -703,23 +769,37 @@ class OAuth2Provider:
 
         if not email:
             logger.error("No email found in user info")
+
             raise OAuth2Exception(
                 error="server_error",
                 error_description="No email found in user info",
             )
 
-        provider_user_id = user_info.get("id")
-
-        if not provider_user_id:
-            logger.error("No provider user ID found in user info")
-            raise OAuth2Exception(
-                error="server_error",
-                error_description="No provider user ID found in user info",
-            )
-
         return ValidatedUserInfo(
             email=email,
-            provider_user_id=str(provider_user_id),
+            provider_user_id=self._get_provider_user_id(user_info),
+            email_verified=user_info.get("email_verified"),
+        )
+
+    def resolve_email(
+        self,
+        user_info: dict[str, Any],
+        is_login: bool,
+        stored_email: str | None = None,
+    ) -> ResolvedEmail:
+        """Resolve the email to use based on login/signup context.
+
+        Override in subclasses for provider-specific email selection.
+        Default returns the email already in user_info.
+        """
+        email = user_info.get("email")
+        if not email:
+            raise OAuth2Exception(
+                error="server_error",
+                error_description="No email found in user info",
+            )
+        return ResolvedEmail(
+            email=email,
             email_verified=user_info.get("email_verified"),
         )
 
@@ -824,6 +904,26 @@ class OAuth2Provider:
             )
 
             user_info = self.fetch_user_info(token_response.access_token)
+            provider_user_id = self._get_provider_user_id(user_info)
+
+            # Check if this provider is already linked
+            social_account = context.accounts_storage.find_social_account(
+                provider=self.id,
+                provider_user_id=provider_user_id,
+            )
+
+            # For link flow, always use login rules (the user already exists).
+            # This ensures provider-specific login policies are enforced even
+            # when linking for the first time.
+            is_login = True
+            stored_email = user.email
+
+            # Resolve email based on context
+            user_info_dict = cast(dict[str, Any], user_info)
+            resolved = self.resolve_email(user_info_dict, is_login, stored_email)
+            user_info_dict["email"] = resolved.email
+            user_info_dict["email_verified"] = resolved.email_verified
+
             validated = self.validate_user_info(user_info)
         except OAuth2Exception as e:
             return Response.error(
@@ -851,11 +951,6 @@ class OAuth2Provider:
                 "email_mismatch",
                 error_description="Provider email does not match account email.",
             )
-
-        social_account = context.accounts_storage.find_social_account(
-            provider=self.id,
-            provider_user_id=validated.provider_user_id,
-        )
 
         if social_account:
             if social_account.user_id != user.id:

--- a/tests/providers/conftest.py
+++ b/tests/providers/conftest.py
@@ -1,5 +1,9 @@
-import pytest
+import json
 
+import pytest
+from cross_web import AsyncHTTPRequest, TestingRequestAdapter
+
+from cross_auth._context import SecondaryStorage
 from cross_auth.social_providers.oauth import OAuth2Provider
 
 pytestmark = pytest.mark.asyncio
@@ -22,4 +26,34 @@ class TestOAuth2Provider(OAuth2Provider):
 def oauth_provider() -> TestOAuth2Provider:
     return TestOAuth2Provider(
         client_id="test_client_id", client_secret="test_client_secret"
+    )
+
+
+@pytest.fixture
+def valid_callback_request(secondary_storage: SecondaryStorage) -> AsyncHTTPRequest:
+    secondary_storage.set(
+        "oauth:authorization_request:test_state",
+        json.dumps(
+            {
+                "client_id": "my_app_client_id",
+                "redirect_uri": "http://valid-frontend.com/callback",
+                "login_hint": "test_login_hint",
+                "state": "test_state",
+                "client_state": "test_client_state",
+                "code_challenge": "test",
+                "code_challenge_method": "S256",
+                "provider_code_verifier": "test_provider_verifier",
+            }
+        ),
+    )
+
+    return AsyncHTTPRequest(
+        TestingRequestAdapter(
+            method="GET",
+            url="http://localhost:8000/test/callback",
+            query_params={
+                "code": "test_code",
+                "state": "test_state",
+            },
+        )
     )

--- a/tests/providers/github/conftest.py
+++ b/tests/providers/github/conftest.py
@@ -81,3 +81,21 @@ def mock_emails_unverified_primary() -> list[dict]:
 def mock_emails_empty() -> list[dict]:
     """GitHub emails response with no emails."""
     return []
+
+
+@pytest.fixture
+def mock_emails() -> list[dict]:
+    return [
+        {
+            "email": "octocat@github.com",
+            "verified": True,
+            "primary": True,
+            "visibility": "public",
+        },
+        {
+            "email": "octocat@example.com",
+            "verified": True,
+            "primary": False,
+            "visibility": "private",
+        },
+    ]

--- a/tests/providers/github/test_callback.py
+++ b/tests/providers/github/test_callback.py
@@ -1,0 +1,190 @@
+from collections.abc import Callable
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+import respx
+import time_machine
+from cross_web import AsyncHTTPRequest, TestingRequestAdapter
+from inline_snapshot import snapshot
+from respx import MockRouter
+
+from cross_auth._context import Context, SecondaryStorage
+from cross_auth._storage import AccountsStorage, User
+from cross_auth.social_providers.github import GitHubProvider
+from tests.conftest import MemoryAccountsStorage
+
+pytestmark = pytest.mark.asyncio
+
+
+class MockGithubProvider(GitHubProvider):
+    def _generate_code(self) -> str:
+        return "a-totally-valid-code"
+
+
+MockGithubFactory = Callable[..., MockGithubProvider]
+
+
+@pytest.fixture
+def mock_github(respx_mock: MockRouter) -> MockGithubFactory:
+    """Factory that creates a MockGithubProvider and wires up respx mocks."""
+
+    def _create(
+        *,
+        allow_noreply_emails: bool = False,
+        user_id: str = "pollo",
+        name: str = "Pollo",
+        emails: list[dict] | None = None,
+    ) -> MockGithubProvider:
+        provider = MockGithubProvider(
+            client_id="test_client_id",
+            client_secret="test_client_secret",
+            allow_noreply_emails=allow_noreply_emails,
+        )
+        if emails is None:
+            emails = [{"email": "pollo@example.com", "primary": True, "verified": True}]
+
+        respx_mock.post(provider.token_endpoint).mock(
+            return_value=httpx.Response(
+                status_code=200,
+                json={
+                    "access_token": "test_access_token",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                    "scope": "openid email profile",
+                },
+            )
+        )
+        respx_mock.get(provider.user_info_endpoint).mock(
+            return_value=httpx.Response(
+                status_code=200, json={"id": user_id, "name": name}
+            )
+        )
+        respx_mock.get(provider.emails_endpoint).mock(
+            return_value=httpx.Response(status_code=200, json=emails)
+        )
+        return provider
+
+    return _create
+
+
+@respx.mock
+async def test_callback_signup_with_verified_primary(
+    context: Context,
+    mock_github: MockGithubFactory,
+    valid_callback_request: AsyncHTTPRequest,
+    accounts_storage: MemoryAccountsStorage,
+):
+    provider = mock_github()
+
+    response = await provider.callback(valid_callback_request, context)
+
+    assert response.status_code == 302
+    assert response.headers is not None
+    assert response.headers["Location"] == snapshot(
+        "http://valid-frontend.com/callback?code=a-totally-valid-code&state=test_client_state"
+    )
+
+    account = accounts_storage.find_user_by_email("pollo@example.com")
+    assert account is not None
+    assert account.email == "pollo@example.com"
+
+
+@respx.mock
+async def test_callback_rejects_noreply_email_by_default(
+    context: Context,
+    mock_github: MockGithubFactory,
+    valid_callback_request: AsyncHTTPRequest,
+):
+    provider = mock_github(
+        emails=[
+            {
+                "email": "123+user@users.noreply.github.com",
+                "primary": True,
+                "verified": True,
+            }
+        ],
+    )
+
+    response = await provider.callback(valid_callback_request, context)
+
+    assert response.status_code == 302
+    assert response.headers is not None
+    assert "error=no_verified_email" in response.headers["Location"]
+
+
+@respx.mock
+async def test_callback_allows_noreply_when_configured(
+    context: Context,
+    mock_github: MockGithubFactory,
+    valid_callback_request: AsyncHTTPRequest,
+    accounts_storage: MemoryAccountsStorage,
+):
+    provider = mock_github(
+        allow_noreply_emails=True,
+        emails=[
+            {
+                "email": "123+user@users.noreply.github.com",
+                "primary": True,
+                "verified": True,
+            }
+        ],
+    )
+
+    response = await provider.callback(valid_callback_request, context)
+
+    assert response.status_code == 302
+    assert "error" not in (response.headers or {}).get("Location", "")
+
+    account = accounts_storage.find_user_by_email("123+user@users.noreply.github.com")
+    assert account is not None
+
+
+@time_machine.travel(datetime(2012, 10, 1, 1, 0, tzinfo=timezone.utc), tick=False)
+@respx.mock
+async def test_finalize_link_uses_login_rules(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+    logged_in_user: User,
+    mock_github: MockGithubFactory,
+    valid_link_code: str,
+) -> None:
+    """finalize_link should pass is_login=True and the user's stored email."""
+
+    def _get_user_from_request(request: AsyncHTTPRequest) -> User | None:
+        if request.headers.get("Authorization") == "Bearer test":
+            return logged_in_user
+        return None
+
+    link_context = Context(
+        secondary_storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        create_token=lambda id: (f"token-{id}", 0),
+        get_user_from_request=_get_user_from_request,
+        trusted_origins=["valid-frontend.com"],
+        config={"account_linking": {"enabled": True}},
+    )
+
+    provider = mock_github(
+        user_id="new_github_user",
+        emails=[
+            {"email": "test@example.com", "primary": True, "verified": True},
+        ],
+    )
+
+    response = await provider.finalize_link(
+        AsyncHTTPRequest(
+            TestingRequestAdapter(
+                method="POST",
+                url="http://localhost:8000/test/finalize-link",
+                json={
+                    "link_code": valid_link_code,
+                    "code_verifier": "test",
+                },
+                headers={"Authorization": "Bearer test"},
+            )
+        ),
+        link_context,
+    )
+
+    assert response.status_code == 200

--- a/tests/providers/github/test_config.py
+++ b/tests/providers/github/test_config.py
@@ -1,0 +1,15 @@
+from cross_auth.social_providers.github import GitHubProvider
+
+
+def test_noreply_disabled_by_default() -> None:
+    provider = GitHubProvider(client_id="id", client_secret="secret")
+
+    assert provider._allow_noreply_emails is False
+
+
+def test_noreply_can_be_enabled() -> None:
+    provider = GitHubProvider(
+        client_id="id", client_secret="secret", allow_noreply_emails=True
+    )
+
+    assert provider._allow_noreply_emails is True

--- a/tests/providers/github/test_email_handling.py
+++ b/tests/providers/github/test_email_handling.py
@@ -1,3 +1,5 @@
+"""Tests for how fetch_user_info handles different email states."""
+
 import pytest
 import respx
 
@@ -7,32 +9,12 @@ pytestmark = pytest.mark.asyncio
 
 
 @respx.mock
-async def test_verified_primary_email(
-    github_provider: GitHubProvider,
-    mock_user_info: dict[str, str],
-    mock_emails_verified_primary: list[dict[str, str]],
-):
-    """Primary email is verified → email_verified=True."""
-    respx.get("https://api.github.com/user").mock(
-        return_value=respx.MockResponse(200, json=mock_user_info)
-    )
-    respx.get("https://api.github.com/user/emails").mock(
-        return_value=respx.MockResponse(200, json=mock_emails_verified_primary)
-    )
-
-    user_info = github_provider.fetch_user_info("test_token")
-
-    assert user_info["email"] == "octocat@github.com"
-    assert user_info["email_verified"] is True
-
-
-@respx.mock
 async def test_unverified_primary_email(
     github_provider: GitHubProvider,
-    mock_user_info: dict[str, str],
-    mock_emails_unverified_primary: list[dict[str, str]],
+    mock_user_info: dict,
+    mock_emails_unverified_primary: list[dict],
 ):
-    """Primary email is unverified → email_verified=False."""
+    """Primary email is unverified -> email_verified=False."""
     respx.get("https://api.github.com/user").mock(
         return_value=respx.MockResponse(200, json=mock_user_info)
     )
@@ -49,34 +31,15 @@ async def test_unverified_primary_email(
 @respx.mock
 async def test_empty_emails_list(
     github_provider: GitHubProvider,
-    mock_user_info: dict[str, str],
-    mock_emails_empty: list[dict[str, str]],
+    mock_user_info: dict,
+    mock_emails_empty: list[dict],
 ):
-    """No emails returned → email=None."""
+    """No emails returned -> email=None."""
     respx.get("https://api.github.com/user").mock(
         return_value=respx.MockResponse(200, json=mock_user_info)
     )
     respx.get("https://api.github.com/user/emails").mock(
         return_value=respx.MockResponse(200, json=mock_emails_empty)
-    )
-
-    user_info = github_provider.fetch_user_info("test_token")
-
-    assert user_info["email"] is None
-    assert user_info["email_verified"] is None
-
-
-@respx.mock
-async def test_emails_endpoint_fails_gracefully(
-    github_provider: GitHubProvider,
-    mock_user_info: dict[str, str],
-):
-    """Emails endpoint fails → email=None (graceful degradation)."""
-    respx.get("https://api.github.com/user").mock(
-        return_value=respx.MockResponse(200, json=mock_user_info)
-    )
-    respx.get("https://api.github.com/user/emails").mock(
-        return_value=respx.MockResponse(500, json={"message": "Internal Server Error"})
     )
 
     user_info = github_provider.fetch_user_info("test_token")

--- a/tests/providers/github/test_email_selection.py
+++ b/tests/providers/github/test_email_selection.py
@@ -1,0 +1,151 @@
+"""Tests for GitHubProvider email selection."""
+
+import pytest
+
+from cross_auth.social_providers.github import GitHubProvider
+from cross_auth.social_providers.github.provider import Email
+from cross_auth.social_providers.oauth import (
+    NoEmailError,
+    NoVerifiedEmailError,
+    OAuth2Exception,
+)
+
+
+def test_signup_uses_primary_verified_email():
+    provider = GitHubProvider(client_id="id", client_secret="secret")
+    emails = [
+        Email(email="primary@example.com", primary=True, verified=True),
+        Email(email="other@example.com", primary=False, verified=True),
+    ]
+    result = provider._select_email(emails, is_login=False)
+
+    assert result == "primary@example.com"
+
+
+def test_signup_falls_back_when_primary_unverified():
+    provider = GitHubProvider(client_id="id", client_secret="secret")
+
+    emails = [
+        Email(email="primary@example.com", primary=True, verified=False),
+        Email(email="other@example.com", primary=False, verified=True),
+    ]
+    result = provider._select_email(emails, is_login=False)
+
+    assert result == "other@example.com"
+
+
+def test_signup_blocks_noreply_emails_by_default():
+    provider = GitHubProvider(client_id="id", client_secret="secret")
+    emails = [
+        Email(email="123+user@users.noreply.github.com", primary=True, verified=True),
+    ]
+    with pytest.raises(NoVerifiedEmailError):
+        provider._select_email(emails, is_login=False)
+
+
+def test_signup_allows_noreply_when_configured():
+    provider = GitHubProvider(
+        client_id="id", client_secret="secret", allow_noreply_emails=True
+    )
+    emails = [
+        Email(email="123+user@users.noreply.github.com", primary=True, verified=True),
+    ]
+    result = provider._select_email(emails, is_login=False)
+    assert result == "123+user@users.noreply.github.com"
+
+
+def test_signup_blocks_ghe_noreply_emails():
+    """GHE noreply emails should be filtered when api_base_url is set."""
+    provider = GitHubProvider(
+        client_id="id",
+        client_secret="secret",
+        api_base_url="https://github.example.com/api/v3",
+    )
+    emails = [
+        Email(
+            email="123+user@users.noreply.github.example.com",
+            primary=True,
+            verified=True,
+        ),
+    ]
+    with pytest.raises(NoVerifiedEmailError):
+        provider._select_email(emails, is_login=False)
+
+
+def test_login_accepts_any_verified_email_by_default():
+    provider = GitHubProvider(client_id="id", client_secret="secret")
+    emails = [
+        Email(email="new@example.com", primary=True, verified=True),
+    ]
+    result = provider._select_email(
+        emails, is_login=True, stored_email="old@example.com"
+    )
+    assert result == "new@example.com"
+
+
+def test_login_prefers_stored_email_if_still_verified():
+    provider = GitHubProvider(client_id="id", client_secret="secret")
+    emails = [
+        Email(email="new@example.com", primary=True, verified=True),
+        Email(email="stored@example.com", primary=False, verified=True),
+    ]
+    result = provider._select_email(
+        emails, is_login=True, stored_email="stored@example.com"
+    )
+    assert result == "stored@example.com"
+
+
+def test_login_matches_stored_email_case_insensitively():
+    """Stored email should match even when local part differs in case."""
+    provider = GitHubProvider(client_id="id", client_secret="secret")
+    emails = [
+        Email(email="new@example.com", primary=True, verified=True),
+        # EmailStr normalizes domain; local part casing is preserved
+        Email(email="Stored@example.com", primary=False, verified=True),
+    ]
+    result = provider._select_email(
+        emails, is_login=True, stored_email="stored@example.com"
+    )
+    assert result == "Stored@example.com"
+
+
+def test_login_blocks_noreply_by_default():
+    provider = GitHubProvider(client_id="id", client_secret="secret")
+    emails = [
+        Email(email="123+user@users.noreply.github.com", primary=True, verified=True),
+    ]
+    with pytest.raises(NoVerifiedEmailError):
+        provider._select_email(emails, is_login=True)
+
+
+def test_resolve_email_uses_stashed_emails():
+    provider = GitHubProvider(client_id="id", client_secret="secret")
+    user_info: dict = {
+        "id": 123,
+        "email": "ignored@example.com",
+        "_github_emails": [
+            Email(email="test@example.com", primary=True, verified=True),
+        ],
+    }
+
+    result = provider.resolve_email(user_info, is_login=False)
+
+    assert result.email == "test@example.com"
+    assert result.email_verified is True
+    assert "_github_emails" not in user_info  # Should be consumed
+
+
+def test_resolve_email_requires_stashed_emails():
+    provider = GitHubProvider(client_id="id", client_secret="secret")
+    user_info: dict = {"id": 123}
+
+    with pytest.raises(OAuth2Exception):
+        provider.resolve_email(user_info, is_login=False)
+
+
+def test_resolve_email_raises_when_no_emails():
+    provider = GitHubProvider(client_id="id", client_secret="secret")
+    user_info: dict = {"id": 123, "_github_emails": []}
+
+    with pytest.raises(NoEmailError):
+        provider.resolve_email(user_info, is_login=False)

--- a/tests/providers/github/test_fetch_user_info.py
+++ b/tests/providers/github/test_fetch_user_info.py
@@ -6,6 +6,7 @@ import pytest
 import respx
 
 from cross_auth.social_providers.github import GitHubProvider
+from cross_auth.social_providers.oauth import OAuth2Exception
 
 pytestmark = pytest.mark.asyncio
 
@@ -32,12 +33,32 @@ async def test_fetch_user_info_success(
 
 
 @respx.mock
+async def test_fetch_user_info_without_email_in_profile(
+    github_provider: GitHubProvider, mock_user_info: dict, mock_emails: list[dict]
+):
+    """Email not in /user response -> still resolved from /user/emails."""
+    mock_user_info.pop("email", None)
+
+    respx.get("https://api.github.com/user").mock(
+        return_value=respx.MockResponse(200, json=mock_user_info)
+    )
+    respx.get("https://api.github.com/user/emails").mock(
+        return_value=respx.MockResponse(200, json=mock_emails)
+    )
+
+    user_info = github_provider.fetch_user_info("test_token")
+
+    assert user_info["email"] == "octocat@github.com"
+    assert user_info["email_verified"] is True
+
+
+@respx.mock
 async def test_name_fallback_to_login(
     github_provider: GitHubProvider,
     mock_user_info: dict,
     mock_emails_verified_primary: list[dict],
 ):
-    """User with no name → fallback to login."""
+    """User with no name -> fallback to login."""
     mock_user_info["name"] = None
 
     respx.get("https://api.github.com/user").mock(
@@ -50,3 +71,54 @@ async def test_name_fallback_to_login(
     user_info = cast(dict[str, Any], github_provider.fetch_user_info("test_token"))
 
     assert user_info["name"] == "octocat"
+
+
+@respx.mock
+async def test_emails_stashed_in_user_info(
+    github_provider: GitHubProvider, mock_user_info: dict, mock_emails: list[dict]
+):
+    """Emails should be stashed in user_info dict for resolve_email."""
+    respx.get("https://api.github.com/user").mock(
+        return_value=respx.MockResponse(200, json=mock_user_info)
+    )
+    respx.get("https://api.github.com/user/emails").mock(
+        return_value=respx.MockResponse(200, json=mock_emails)
+    )
+
+    user_info = cast(dict[str, Any], github_provider.fetch_user_info("test_token"))
+
+    assert "_github_emails" in user_info
+    assert len(user_info["_github_emails"]) == 2
+
+
+@respx.mock
+async def test_email_fetch_error_raises(
+    github_provider: GitHubProvider, mock_user_info: dict
+):
+    """Emails endpoint fails -> raises OAuth2Exception."""
+    mock_user_info.pop("email", None)
+
+    respx.get("https://api.github.com/user").mock(
+        return_value=respx.MockResponse(200, json=mock_user_info)
+    )
+    respx.get("https://api.github.com/user/emails").mock(
+        return_value=respx.MockResponse(500, json={"message": "Internal Server Error"})
+    )
+
+    with pytest.raises(OAuth2Exception) as exc:
+        github_provider.fetch_user_info("test_token")
+
+    assert "Failed to fetch user emails" in exc.value.error_description
+
+
+@respx.mock
+async def test_user_info_endpoint_error_raises(github_provider: GitHubProvider):
+    """User info endpoint fails -> raises OAuth2Exception."""
+    respx.get("https://api.github.com/user").mock(
+        return_value=respx.MockResponse(500, json={"message": "Internal Server Error"})
+    )
+
+    with pytest.raises(OAuth2Exception) as exc:
+        github_provider.fetch_user_info("test_token")
+
+    assert "Failed to fetch user info" in exc.value.error_description

--- a/tests/providers/test_oauth_callback.py
+++ b/tests/providers/test_oauth_callback.py
@@ -17,36 +17,6 @@ from ..conftest import MemoryAccountsStorage
 pytestmark = pytest.mark.asyncio
 
 
-@pytest.fixture
-def valid_callback_request(secondary_storage: SecondaryStorage) -> AsyncHTTPRequest:
-    secondary_storage.set(
-        "oauth:authorization_request:test_state",
-        json.dumps(
-            {
-                "client_id": "my_app_client_id",
-                "redirect_uri": "http://valid-frontend.com/callback",
-                "login_hint": "test_login_hint",
-                "state": "test_state",
-                "client_state": "test_client_state",
-                "code_challenge": "test",
-                "code_challenge_method": "S256",
-                "provider_code_verifier": "test_provider_verifier",
-            }
-        ),
-    )
-
-    return AsyncHTTPRequest(
-        TestingRequestAdapter(
-            method="GET",
-            url="http://localhost:8000/test/callback",
-            query_params={
-                "code": "test_code",
-                "state": "test_state",
-            },
-        )
-    )
-
-
 async def test_fails_if_there_were_no_provider_data_in_secondary_storage(
     oauth_provider: OAuth2Provider, context: Context
 ):


### PR DESCRIPTION
## Summary

- **Email selection by flow**: login prefers stored email (falls back to primary, then any verified); signup prefers verified primary (falls back to any verified).
- **Noreply filtering**: GitHub noreply emails are rejected by default. Pass `allow_noreply_emails=True` to `GitHubProvider` to allow them.
- **Strict error handling**: `/user/emails` API failures now raise `OAuth2Exception` instead of silently setting email to `None`.
- **`resolve_email` hook**: new override point on `OAuth2Provider` base class for provider-specific email selection logic.

## Breaking changes

- `/user/emails` failures now raise instead of silently degrading to `email=None`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved GitHub email selection: login uses stored email (with fallback); signup prioritizes verified primary email.
  * GitHub noreply email filtering enabled by default; configure `allow_noreply_emails=True` to allow them.

* **Bug Fixes**
  * Failures to fetch user emails from GitHub now raise exceptions instead of silently setting email to None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->