### PR TITLE
Improve OAuth error logging with response details

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+---
+release type: patch
+---
+
+This release improves error logging in the OAuth2 flow to aid debugging
+authentication failures.
+
+- `get_user_info` now logs the endpoint URL, HTTP status code, response body,
+  and granted token scope when the provider API returns an error.
+- `exchange_code` now logs the token type, granted scope, and expiry after a
+  successful token exchange (at DEBUG level).
+- GitHub provider's email fetch logs the same details on failure.

--- a/src/cross_auth/_route.py
+++ b/src/cross_auth/_route.py
@@ -11,11 +11,11 @@ class Form:
     pass
 
 
-def _get_fastapi_request_type(route: "Route") -> type[Any]:
+def _get_fastapi_request_type(route: "Route") -> Any:
     from fastapi import Request as FastAPIRequest
     from fastapi.params import Form as FastAPIForm
 
-    RequestType: type[Any] = FastAPIRequest
+    RequestType: Any = FastAPIRequest
 
     if route.request_type is not None:
         RequestType = route.request_type
@@ -23,7 +23,7 @@ def _get_fastapi_request_type(route: "Route") -> type[Any]:
         args = get_args(RequestType)
 
         if any(isinstance(arg, Form) for arg in args):
-            RequestType = Annotated[RequestType, FastAPIForm()]  # type: ignore[assignment]
+            RequestType = Annotated[RequestType, FastAPIForm()]
 
     return RequestType
 

--- a/src/cross_auth/social_providers/github.py
+++ b/src/cross_auth/social_providers/github.py
@@ -160,8 +160,24 @@ class GitHubProvider(OAuth2Provider):
                 info["email"] = None
                 info["email_verified"] = None
 
+        except httpx.HTTPStatusError as e:
+            logger.error(
+                "Failed to fetch user emails from %s: %s (status=%d, body=%s, scope=%s)",
+                self.emails_endpoint,
+                e,
+                e.response.status_code,
+                e.response.text,
+                token_response.scope,
+            )
+            info["email"] = None
+            info["email_verified"] = None
         except Exception as e:
-            logger.error("Failed to fetch user emails: %s", e)
+            logger.error(
+                "Failed to fetch user emails from %s: %s (scope=%s)",
+                self.emails_endpoint,
+                e,
+                token_response.scope,
+            )
             info["email"] = None
             info["email_verified"] = None
 

--- a/src/cross_auth/social_providers/oauth.py
+++ b/src/cross_auth/social_providers/oauth.py
@@ -736,6 +736,14 @@ class OAuth2Provider:
                     error="server_error",
                     error_description="Unexpected token response format",
                 )
+
+            logger.debug(
+                "Token exchange succeeded (token_type=%s, scope=%s, expires_in=%s)",
+                token_response.root.token_type,
+                token_response.root.scope,
+                token_response.root.expires_in,
+            )
+
             return token_response.root
 
         except httpx.HTTPStatusError as e:
@@ -784,8 +792,26 @@ class OAuth2Provider:
             )
             response.raise_for_status()
             user_info = response.json()
+        except httpx.HTTPStatusError as e:
+            logger.error(
+                "Failed to fetch user info from %s: %s (status=%d, body=%s, scope=%s)",
+                self.user_info_endpoint,
+                e,
+                e.response.status_code,
+                e.response.text,
+                token_response.scope,
+            )
+            raise OAuth2Exception(
+                error="server_error",
+                error_description="Failed to fetch user info",
+            ) from e
         except Exception as e:
-            logger.error("Failed to fetch user info: %s", e)
+            logger.error(
+                "Failed to fetch user info from %s: %s (scope=%s)",
+                self.user_info_endpoint,
+                e,
+                token_response.scope,
+            )
             raise OAuth2Exception(
                 error="server_error",
                 error_description="Failed to fetch user info",

--- a/src/cross_auth/social_providers/oidc.py
+++ b/src/cross_auth/social_providers/oidc.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import time
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import httpx
 import jwt
@@ -67,7 +67,7 @@ class OIDCProvider(OAuth2Provider):
         """Find a public key by key ID in a JWKS dict."""
         for key in keys.get("keys", []):
             if key.get("kid") == kid:
-                return RSAAlgorithm.from_jwk(key)  # type: ignore[return-value]
+                return cast("RSAPublicKey", RSAAlgorithm.from_jwk(key))
         return None
 
     def _get_public_key(


### PR DESCRIPTION
## Summary

- When provider API calls fail (e.g. GitHub returning 403 on `/user`), logs now include the endpoint URL, HTTP status code, response body, and granted token scope
- Added `logger.debug` after successful token exchange logging token type, scope, and expiry
- Same improvements for GitHub provider's `/user/emails` fetch
- Fixed pre-existing `ty` type-checking errors in `_route.py` and `oidc.py`

## Context

Investigated a [Sentry issue](https://fastapilabs.sentry.io/issues/7365877296/) where GitHub returned 403 on `/user` during OAuth callback. The existing logs only captured the exception string — no response body, no status code, no scope info — making it impossible to determine root cause without reproducing.

## Test plan

- [x] All existing tests pass
- [x] All pre-commit hooks pass (including `ty`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced OAuth2 error logging with more detailed diagnostic information (HTTP status codes, response bodies, and granted scopes) when authentication fails
  * Improved logging during token exchanges to include token type and expiration information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->