### PR TITLE
Make it easier to override callbacks

### DIFF
--- a/src/cross_auth/__init__.py
+++ b/src/cross_auth/__init__.py
@@ -1,6 +1,8 @@
+from cross_auth._auth_flow import PreparedLink
 from cross_auth._context import Context
 from cross_auth._session import SessionConfig, SessionData
 from cross_auth._storage import AccountsStorage, SecondaryStorage, User
+from cross_auth.exceptions import CrossAuthException
 from cross_auth.models.oauth_token_response import TokenResponse
 from cross_auth.social_providers.oauth import (
     CallbackData,
@@ -15,9 +17,11 @@ __all__ = [
     "AccountsStorage",
     "CallbackData",
     "Context",
+    "CrossAuthException",
     "OAuth2Exception",
     "OAuth2Provider",
     "OIDCProvider",
+    "PreparedLink",
     "SecondaryStorage",
     "SessionConfig",
     "SessionData",

--- a/src/cross_auth/_auth_flow.py
+++ b/src/cross_auth/_auth_flow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import secrets
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Literal, cast
 
@@ -13,9 +14,9 @@ from ._context import Context
 from ._issuer import AuthorizationCodeGrantData
 from ._storage import User
 from .exceptions import CrossAuthException
-from .social_providers.oauth import (
+from .social_providers._shared import (
     OAuth2Exception,
-    OAuth2Provider,
+    OAuth2ProviderProtocol,
     ValidatedUserInfo,
 )
 from .utils._pkce import (
@@ -86,6 +87,12 @@ class InitiateLinkResponse(BaseModel):
     authorization_url: str
 
 
+@dataclass
+class PreparedLink:
+    state: str
+    authorization_url: str
+
+
 _AUTH_REQUEST_KEY = "oauth:authorization_request:{state}"
 _LINK_CODE_KEY = "oauth:link_request:{code}"
 _AUTH_CODE_KEY = "oauth:code:{code}"
@@ -112,7 +119,7 @@ def _load_auth_request(context: Context, state: str) -> AuthRequest | None:
 
 
 def _generate_provider_pkce(
-    provider: OAuth2Provider,
+    provider: OAuth2ProviderProtocol,
 ) -> tuple[str | None, str | None, str | None]:
     if not provider.supports_pkce:
         return None, None, None
@@ -135,7 +142,7 @@ def _is_safe_next_url(next_url: str) -> bool:
 
 
 async def start_session_flow(
-    provider: OAuth2Provider,
+    provider: OAuth2ProviderProtocol,
     request: AsyncHTTPRequest,
     context: Context,
 ) -> Response:
@@ -174,7 +181,7 @@ async def start_session_flow(
 
 
 async def start_connect_flow(
-    provider: OAuth2Provider,
+    provider: OAuth2ProviderProtocol,
     request: AsyncHTTPRequest,
     context: Context,
 ) -> Response:
@@ -223,7 +230,7 @@ async def start_connect_flow(
 
 
 async def start_token_flow(
-    provider: OAuth2Provider,
+    provider: OAuth2ProviderProtocol,
     request: AsyncHTTPRequest,
     context: Context,
 ) -> Response:
@@ -334,7 +341,7 @@ async def start_token_flow(
 
 
 async def handle_callback(
-    provider: OAuth2Provider,
+    provider: OAuth2ProviderProtocol,
     request: AsyncHTTPRequest,
     context: Context,
 ) -> Response:
@@ -479,7 +486,7 @@ def _flow_error(
 
 def resolve_or_create_user(
     *,
-    provider: OAuth2Provider,
+    provider: OAuth2ProviderProtocol,
     context: Context,
     validated: ValidatedUserInfo,
     user_info: dict[str, Any],
@@ -575,7 +582,7 @@ def resolve_or_create_user(
 def _complete_connect(
     *,
     auth_request: AuthRequest,
-    provider: OAuth2Provider,
+    provider: OAuth2ProviderProtocol,
     context: Context,
     validated: ValidatedUserInfo,
     user_info: dict[str, Any],
@@ -725,7 +732,7 @@ def _complete_link(
 
 
 async def start_link_flow(
-    provider: OAuth2Provider,
+    provider: OAuth2ProviderProtocol,
     request: AsyncHTTPRequest,
     context: Context,
 ) -> Response:
@@ -733,9 +740,37 @@ async def start_link_flow(
 
     Body: InitiateLinkRequest (JSON). Returns 200 with authorization URL.
     """
+    try:
+        prepared = await prepare_link(provider, request, context)
+    except CrossAuthException as e:
+        return Response.error(
+            e.error,
+            error_description=e.error_description,
+            status_code=e.status_code,
+        )
+
+    return Response(
+        status_code=200,
+        body=InitiateLinkResponse(
+            authorization_url=prepared.authorization_url
+        ).model_dump_json(),
+        headers={"Content-Type": "application/json"},
+    )
+
+
+async def prepare_link(
+    provider: OAuth2ProviderProtocol,
+    request: AsyncHTTPRequest,
+    context: Context,
+) -> PreparedLink:
+    """Validate and store link-flow state before building the provider URL.
+
+    This is intentionally separate from ``start_link_flow`` so provider
+    subclasses can customize the final response without scraping JSON output.
+    """
     user = context.get_user_from_request(request)
     if not user:
-        return Response.error(
+        raise CrossAuthException(
             "unauthorized",
             error_description="User must be authenticated to initiate link flow",
             status_code=401,
@@ -743,7 +778,7 @@ async def start_link_flow(
 
     account_linking = context.config.get("account_linking", {})
     if not account_linking.get("enabled", False):
-        return Response.error(
+        raise CrossAuthException(
             "linking_disabled",
             error_description="Account linking is not enabled",
         )
@@ -752,17 +787,19 @@ async def start_link_flow(
         link_request = InitiateLinkRequest.model_validate_json(await request.get_body())
     except (json.JSONDecodeError, ValidationError) as e:
         logger.error("Invalid request body: %s", e)
-        return Response.error(
+        raise CrossAuthException(
             "invalid_request", error_description="Invalid request body"
-        )
+        ) from e
 
     if not context.is_valid_redirect_uri(link_request.redirect_uri):
-        return Response.error(
+        raise CrossAuthException(
             "invalid_redirect_uri", error_description="Invalid redirect_uri"
         )
 
     if not context.is_valid_client_id(link_request.client_id):
-        return Response.error("invalid_client", error_description="Invalid client_id")
+        raise CrossAuthException(
+            "invalid_client", error_description="Invalid client_id"
+        )
 
     state = secrets.token_hex(16)
     verifier, challenge, challenge_method = _generate_provider_pkce(provider)
@@ -790,17 +827,14 @@ async def start_link_flow(
         code_challenge_method=challenge_method,
     )
 
-    return Response(
-        status_code=200,
-        body=InitiateLinkResponse(
-            authorization_url=authorization_url
-        ).model_dump_json(),
-        headers={"Content-Type": "application/json"},
+    return PreparedLink(
+        state=state,
+        authorization_url=authorization_url,
     )
 
 
 async def finalize_link(
-    provider: OAuth2Provider,
+    provider: OAuth2ProviderProtocol,
     request: AsyncHTTPRequest,
     context: Context,
 ) -> Response:

--- a/src/cross_auth/router.py
+++ b/src/cross_auth/router.py
@@ -1,19 +1,10 @@
 import logging
-from collections.abc import Awaitable, Callable
-from functools import partial
+from collections.abc import Callable
 from typing import Any
 
-from cross_web import AsyncHTTPRequest, Response
+from cross_web import AsyncHTTPRequest
 from fastapi import APIRouter
 
-from ._auth_flow import (
-    finalize_link,
-    handle_callback,
-    start_connect_flow,
-    start_link_flow,
-    start_session_flow,
-    start_token_flow,
-)
 from ._config import Config
 from ._context import AccountsStorage, Context, SecondaryStorage, User
 from ._issuer import Issuer
@@ -24,52 +15,44 @@ from .social_providers.oauth import OAuth2Provider
 logger = logging.getLogger(__name__)
 
 
-FlowHandler = Callable[[OAuth2Provider, AsyncHTTPRequest, Context], Awaitable[Response]]
-
-
 def _provider_routes(provider: OAuth2Provider) -> list[Route]:
     prefix = f"/{provider.id}"
-
-    def bound(
-        handler: FlowHandler,
-    ) -> Callable[[AsyncHTTPRequest, Context], Awaitable[Response]]:
-        return partial(handler, provider)
 
     return [
         Route(
             path=f"{prefix}/login",
             methods=["GET"],
-            function=bound(start_session_flow),
+            function=provider.login,
             operation_id=f"{provider.id}_login",
         ),
         Route(
             path=f"{prefix}/connect",
             methods=["GET"],
-            function=bound(start_connect_flow),
+            function=provider.connect,
             operation_id=f"{provider.id}_connect",
         ),
         Route(
             path=f"{prefix}/authorize",
             methods=["GET"],
-            function=bound(start_token_flow),
+            function=provider.authorize,
             operation_id=f"{provider.id}_authorize",
         ),
         Route(
             path=f"{prefix}/callback",
             methods=["GET", "POST"],  # POST for Apple (response_mode=form_post)
-            function=bound(handle_callback),
+            function=provider.callback,
             operation_id=f"{provider.id}_callback",
         ),
         Route(
             path=f"{prefix}/link",
             methods=["POST"],
-            function=bound(start_link_flow),
+            function=provider.initiate_link,
             operation_id=f"{provider.id}_link",
         ),
         Route(
             path=f"{prefix}/finalize-link",
             methods=["POST"],
-            function=bound(finalize_link),
+            function=provider.finalize_link,
             operation_id=f"{provider.id}_finalize_link",
         ),
     ]

--- a/src/cross_auth/social_providers/_shared.py
+++ b/src/cross_auth/social_providers/_shared.py
@@ -1,0 +1,89 @@
+from dataclasses import dataclass
+from typing import Any, NotRequired, Protocol, TypedDict
+
+from cross_web import AsyncHTTPRequest
+from pydantic import BaseModel
+
+from .._context import Context
+from ..models.oauth_token_response import TokenResponse
+
+
+class UserInfo(TypedDict, total=True):
+    email: str | None
+    id: str | int
+    email_verified: bool | None
+    name: NotRequired[str | None]
+
+
+@dataclass
+class ValidatedUserInfo:
+    email: str | None
+    provider_user_id: str
+    email_verified: bool | None
+
+
+class TokenExchangeParams(TypedDict, total=False):
+    grant_type: str
+    code: str
+    redirect_uri: str
+    client_id: str
+    client_secret: str
+    code_verifier: str
+
+
+class OAuth2Exception(Exception):
+    def __init__(self, error: str, error_description: str):
+        self.error = error
+        self.error_description = error_description
+
+
+class CallbackData(BaseModel):
+    code: str | None
+    state: str | None
+    error: str | None
+    extra: dict[str, Any] | None = None  # Provider-specific data
+
+
+class OAuth2ProviderProtocol(Protocol):
+    id: str
+    supports_pkce: bool
+    trust_email: bool
+
+    def can_auto_link(self, context: Context, email_verified: bool | None) -> bool: ...
+
+    def allows_different_emails(
+        self,
+        context: Context,
+        provider_email: str | None,
+        user_email: str | None,
+    ) -> bool: ...
+
+    def build_authorization_url(
+        self,
+        state: str,
+        redirect_uri: str,
+        *,
+        code_challenge: str | None = None,
+        code_challenge_method: str | None = None,
+        login_hint: str | None = None,
+    ) -> str: ...
+
+    async def extract_callback_params(
+        self, request: AsyncHTTPRequest
+    ) -> CallbackData: ...
+
+    def exchange_code(
+        self,
+        code: str,
+        redirect_uri: str,
+        code_verifier: str | None = None,
+    ) -> TokenResponse: ...
+
+    def fetch_user_info(
+        self,
+        token_response: TokenResponse,
+        context: Context,
+        extra: dict[str, Any] | None = None,
+    ) -> UserInfo: ...
+
+    def validate_user_info(self, user_info: UserInfo) -> ValidatedUserInfo: ...

--- a/src/cross_auth/social_providers/oauth.py
+++ b/src/cross_auth/social_providers/oauth.py
@@ -1,60 +1,40 @@
 import logging
-from dataclasses import dataclass
-from typing import Any, ClassVar, NotRequired, TypedDict
+from typing import Any, ClassVar
 from urllib.parse import urlencode
 
 import httpx
 from cross_web import AsyncHTTPRequest
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 
 from cross_auth.utils._response import (
     Response,  # noqa: F401  (re-exported for subclasses)
 )
 
+from .._auth_flow import (
+    PreparedLink,
+    finalize_link,
+    handle_callback,
+    prepare_link,
+    start_connect_flow,
+    start_link_flow,
+    start_session_flow,
+    start_token_flow,
+)
 from .._context import Context
 from ..models.oauth_token_response import (
     OAuth2TokenEndpointResponse,
     TokenErrorResponse,
     TokenResponse,
 )
+from ._shared import (
+    CallbackData,
+    OAuth2Exception,
+    TokenExchangeParams,
+    UserInfo,
+    ValidatedUserInfo,
+)
 
 logger = logging.getLogger(__name__)
-
-
-class UserInfo(TypedDict, total=True):
-    email: str | None
-    id: str | int
-    email_verified: bool | None
-    name: NotRequired[str | None]
-
-
-@dataclass
-class ValidatedUserInfo:
-    email: str | None
-    provider_user_id: str
-    email_verified: bool | None
-
-
-class TokenExchangeParams(TypedDict, total=False):
-    grant_type: str
-    code: str
-    redirect_uri: str
-    client_id: str
-    client_secret: str
-    code_verifier: str
-
-
-class OAuth2Exception(Exception):
-    def __init__(self, error: str, error_description: str):
-        self.error = error
-        self.error_description = error_description
-
-
-class CallbackData(BaseModel):
-    code: str | None
-    state: str | None
-    error: str | None
-    extra: dict[str, Any] | None = None  # Provider-specific data
 
 
 class OAuth2Provider:
@@ -180,6 +160,40 @@ class OAuth2Provider:
             state=request.query_params.get("state"),
             error=request.query_params.get("error"),
         )
+
+    async def login(self, request: AsyncHTTPRequest, context: Context) -> Response:
+        """Start the session-based social login flow for this provider."""
+        return await start_session_flow(self, request, context)
+
+    async def connect(self, request: AsyncHTTPRequest, context: Context) -> Response:
+        """Start the connect flow for linking a provider to the current session."""
+        return await start_connect_flow(self, request, context)
+
+    async def authorize(self, request: AsyncHTTPRequest, context: Context) -> Response:
+        """Start the token-based OAuth authorization flow for this provider."""
+        return await start_token_flow(self, request, context)
+
+    async def callback(self, request: AsyncHTTPRequest, context: Context) -> Response:
+        """Handle the provider callback for any supported flow."""
+        return await handle_callback(self, request, context)
+
+    async def prepare_link(
+        self, request: AsyncHTTPRequest, context: Context
+    ) -> PreparedLink:
+        """Validate the link request and return the provider URL plus generated state."""
+        return await prepare_link(self, request, context)
+
+    async def initiate_link(
+        self, request: AsyncHTTPRequest, context: Context
+    ) -> Response:
+        """Start the account-linking flow for this provider."""
+        return await start_link_flow(self, request, context)
+
+    async def finalize_link(
+        self, request: AsyncHTTPRequest, context: Context
+    ) -> Response:
+        """Redeem a link code and persist the social account."""
+        return await finalize_link(self, request, context)
 
     def build_token_exchange_params(
         self, code: str, redirect_uri: str, code_verifier: str | None = None

--- a/tests/router/test_provider_overrides.py
+++ b/tests/router/test_provider_overrides.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from cross_web import AsyncHTTPRequest, TestingRequestAdapter
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cross_auth._context import Context
+from cross_auth._storage import AccountsStorage, SecondaryStorage, User
+from cross_auth.social_providers.oauth import OAuth2Provider, Response
+
+from .conftest import FakeProvider, _build_auth, load_auth_request
+
+
+class CustomRouteProvider(FakeProvider):
+    async def callback(self, request: AsyncHTTPRequest, context: Context) -> Response:
+        return Response(status_code=204)
+
+    async def initiate_link(
+        self, request: AsyncHTTPRequest, context: Context
+    ) -> Response:
+        return Response(
+            status_code=200,
+            body='{"installation_url":"https://example.com/install"}',
+            headers={"Content-Type": "application/json"},
+        )
+
+
+def _make_client(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+    provider: OAuth2Provider,
+) -> TestClient:
+    auth = _build_auth(
+        storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        providers=[provider],
+        config={"account_linking": {"enabled": True}},
+    )
+    app = FastAPI()
+    app.include_router(auth.router)
+    return TestClient(app, follow_redirects=False)
+
+
+def test_router_uses_provider_callback_override(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+) -> None:
+    provider = CustomRouteProvider(
+        client_id="custom-client-id",
+        client_secret="custom-secret",
+    )
+
+    with _make_client(secondary_storage, accounts_storage, provider) as client:
+        response = client.get("/fake/callback")
+
+    assert response.status_code == 204
+
+
+def test_router_uses_provider_link_override(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+) -> None:
+    provider = CustomRouteProvider(
+        client_id="custom-client-id",
+        client_secret="custom-secret",
+    )
+
+    with _make_client(secondary_storage, accounts_storage, provider) as client:
+        response = client.post("/fake/link")
+
+    assert response.status_code == 200
+    assert response.json() == {"installation_url": "https://example.com/install"}
+
+
+@pytest.mark.asyncio
+async def test_prepare_link_returns_state_and_authorization_url(
+    fake_provider: FakeProvider,
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+) -> None:
+    def resolve_user(request: AsyncHTTPRequest) -> User | None:
+        if request.headers.get("Authorization") == "Bearer test":
+            return accounts_storage.find_user_by_id("test")
+        return None
+
+    context = Context(
+        secondary_storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        create_token=lambda user_id: (f"token-{user_id}", 0),
+        trusted_origins=["client.example"],
+        get_user_from_request=resolve_user,
+        config={"account_linking": {"enabled": True}},
+    )
+
+    request = AsyncHTTPRequest(
+        TestingRequestAdapter(
+            method="POST",
+            url="http://localhost:8000/fake/link",
+            headers={"Authorization": "Bearer test"},
+            json={
+                "redirect_uri": "http://client.example/cb",
+                "code_challenge": "challenge",
+                "code_challenge_method": "S256",
+                "client_id": "app-client",
+                "state": "client-state",
+            },
+        )
+    )
+
+    prepared = await fake_provider.prepare_link(request, context)
+
+    qs = parse_qs(urlparse(prepared.authorization_url).query)
+    assert prepared.state == qs["state"][0]
+    assert prepared.authorization_url.startswith("https://fake.example/oauth/authorize")
+
+    auth_request = load_auth_request(secondary_storage, prepared.state)
+    assert auth_request.flow == "link"
+    assert auth_request.client_state == "client-state"
+    assert auth_request.client_redirect_uri == "http://client.example/cb"


### PR DESCRIPTION
## Summary by Sourcery

Refactor OAuth provider routing and link flow to allow providers to override callbacks and customize link initiation responses while exposing the prepared link data type.

New Features:
- Expose high-level OAuth2Provider flow methods (login, connect, authorize, callback, initiate_link, finalize_link) that can be overridden per provider.
- Introduce a prepare_link helper that returns a PreparedLink object with state and authorization URL for customizable link flows.
- Export PreparedLink and CrossAuthException from the package public API.

Enhancements:
- Simplify router bindings to call provider methods directly instead of partially applying shared handlers.
- Adjust link flow error handling to raise CrossAuthException and consolidate response building in start_link_flow.

Tests:
- Add router tests verifying that provider overrides for callback and link routes are honored.
- Add tests ensuring prepare_link returns state and authorization URL and correctly persists link-flow state.