### PR TITLE
Add provider override hooks for OAuth callback flow

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+---
+release type: minor
+---
+
+This release adds provider-level hooks for advanced OAuth flows. Providers now
+receive the incoming request when building authorization URLs, can intercept
+callbacks before the standard OAuth handler runs, and can post-process final
+redirect responses.

--- a/src/cross_auth/_auth_flow.py
+++ b/src/cross_auth/_auth_flow.py
@@ -165,6 +165,7 @@ async def start_session_flow(
     authorization_url = provider.build_authorization_url(
         state=state,
         redirect_uri=_proxy_redirect_uri(request, context),
+        request=request,
         code_challenge=challenge,
         code_challenge_method=challenge_method,
         login_hint=request.query_params.get("login_hint"),
@@ -215,6 +216,7 @@ async def start_connect_flow(
     authorization_url = provider.build_authorization_url(
         state=state,
         redirect_uri=_proxy_redirect_uri(request, context),
+        request=request,
         code_challenge=challenge,
         code_challenge_method=challenge_method,
     )
@@ -325,6 +327,7 @@ async def start_token_flow(
     authorization_url = provider.build_authorization_url(
         state=state,
         redirect_uri=_proxy_redirect_uri(request, context),
+        request=request,
         code_challenge=challenge,
         code_challenge_method=challenge_method,
         login_hint=login_hint,
@@ -344,7 +347,24 @@ async def handle_callback(
     completion: session (cookie + redirect to next_url), token (authorization code
     to client), connect (attach account to current user + redirect), or link
     (stash a link code).
+
+    The provider can short-circuit via `intercept_callback` (for non-OAuth
+    callback variants) and post-process the final redirect via
+    `finalize_redirect`.
     """
+    if intercepted := await provider.intercept_callback(request, context):
+        return intercepted
+
+    response = await _handle_oauth_callback(provider, request, context)
+    return await provider.finalize_redirect(request, response)
+
+
+async def _handle_oauth_callback(
+    provider: OAuth2Provider,
+    request: AsyncHTTPRequest,
+    context: Context,
+) -> Response:
+    """Handle the standard OAuth callback path after provider interception."""
     callback_data = await provider.extract_callback_params(request)
     state = callback_data.state
     auth_request = _load_auth_request(context, state) if state else None
@@ -786,6 +806,7 @@ async def start_link_flow(
     authorization_url = provider.build_authorization_url(
         state=state,
         redirect_uri=_proxy_redirect_uri(request, context),
+        request=request,
         code_challenge=challenge,
         code_challenge_method=challenge_method,
     )

--- a/src/cross_auth/social_providers/apple.py
+++ b/src/cross_auth/social_providers/apple.py
@@ -150,6 +150,7 @@ class AppleProvider(OIDCProvider):
         state: str,
         redirect_uri: str,
         *,
+        request: AsyncHTTPRequest | None = None,
         code_challenge: str | None = None,
         code_challenge_method: str | None = None,
         login_hint: str | None = None,

--- a/src/cross_auth/social_providers/oauth.py
+++ b/src/cross_auth/social_providers/oauth.py
@@ -7,9 +7,7 @@ import httpx
 from cross_web import AsyncHTTPRequest
 from pydantic import BaseModel, ValidationError
 
-from cross_auth.utils._response import (
-    Response,  # noqa: F401  (re-exported for subclasses)
-)
+from cross_auth.utils._response import Response
 
 from .._context import Context
 from ..models.oauth_token_response import (
@@ -123,6 +121,7 @@ class OAuth2Provider:
         state: str,
         redirect_uri: str,
         *,
+        request: AsyncHTTPRequest | None = None,
         code_challenge: str | None = None,
         code_challenge_method: str | None = None,
         login_hint: str | None = None,
@@ -130,7 +129,8 @@ class OAuth2Provider:
         """Build the query-string params sent to the provider's authorization endpoint.
 
         Override for providers that need different params (e.g., Apple uses
-        response_mode=form_post and space-separated scopes).
+        response_mode=form_post and space-separated scopes). The incoming
+        `request` is forwarded so overrides can branch on its query params.
         """
         params: dict[str, str] = {
             "client_id": self.client_id,
@@ -156,19 +156,51 @@ class OAuth2Provider:
         state: str,
         redirect_uri: str,
         *,
+        request: AsyncHTTPRequest | None = None,
         code_challenge: str | None = None,
         code_challenge_method: str | None = None,
         login_hint: str | None = None,
     ) -> str:
-        """Return the full URL to redirect the user to at the provider."""
+        """Return the full URL to redirect the user to at the provider.
+
+        Providers can override to return a different URL based on the incoming
+        request.
+        """
         params = self.build_authorization_params(
             state=state,
             redirect_uri=redirect_uri,
+            request=request,
             code_challenge=code_challenge,
             code_challenge_method=code_challenge_method,
             login_hint=login_hint,
         )
         return f"{self.authorization_endpoint}?{urlencode(params)}"
+
+    async def intercept_callback(
+        self,
+        request: AsyncHTTPRequest,
+        context: Context,
+    ) -> Response | None:
+        """Inspect an incoming callback before the normal OAuth flow runs.
+
+        Return a Response to short-circuit the callback handler (e.g., the
+        provider sent a non-OAuth callback variant that should be routed
+        elsewhere), or None to continue with the standard flow.
+        """
+        return None
+
+    async def finalize_redirect(
+        self,
+        request: AsyncHTTPRequest,
+        response: Response,
+    ) -> Response:
+        """Post-process the Response a flow handler is about to return.
+
+        Providers can rewrite the Location header or otherwise adjust the
+        response (e.g., append a provider-specific query parameter to the
+        final redirect). The default is a no-op.
+        """
+        return response
 
     async def extract_callback_params(self, request: AsyncHTTPRequest) -> CallbackData:
         """Extract code, state, and error from callback request.

--- a/tests/router/test_provider_hooks.py
+++ b/tests/router/test_provider_hooks.py
@@ -1,0 +1,173 @@
+"""Router-level tests for the provider override hooks."""
+
+from __future__ import annotations
+
+from typing import Generator
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+import pytest
+import respx
+from cross_auth._context import Context
+from cross_auth._storage import AccountsStorage, SecondaryStorage
+from cross_auth.utils._response import Response
+from cross_web import AsyncHTTPRequest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from .conftest import (
+    FakeProvider,
+    _build_auth,
+    mock_token_and_userinfo,
+    start_provider_auth,
+)
+
+
+def _append_query(url: str, params: dict[str, str]) -> str:
+    parsed = urlparse(url)
+    query = parse_qs(parsed.query)
+    for key, value in params.items():
+        query[key] = [value]
+    return urlunparse(parsed._replace(query=urlencode(query, doseq=True)))
+
+
+class HookedFakeProvider(FakeProvider):
+    def build_authorization_url(
+        self,
+        state: str,
+        redirect_uri: str,
+        *,
+        request: AsyncHTTPRequest | None = None,
+        code_challenge: str | None = None,
+        code_challenge_method: str | None = None,
+        login_hint: str | None = None,
+    ) -> str:
+        url = super().build_authorization_url(
+            state,
+            redirect_uri,
+            request=request,
+            code_challenge=code_challenge,
+            code_challenge_method=code_challenge_method,
+            login_hint=login_hint,
+        )
+        if request is None or not (audience := request.query_params.get("audience")):
+            return url
+        return _append_query(url, {"audience": audience})
+
+    async def intercept_callback(
+        self,
+        request: AsyncHTTPRequest,
+        context: Context,
+    ) -> Response | None:
+        if request.query_params.get("provider_status") == "pending":
+            return Response(
+                status_code=302,
+                headers={"Location": "/oauth/pending?provider=fake"},
+            )
+        return None
+
+    async def finalize_redirect(
+        self,
+        request: AsyncHTTPRequest,
+        response: Response,
+    ) -> Response:
+        if (
+            request.query_params.get("include_provider") == "true"
+            and response.status_code == 302
+            and response.headers
+            and (location := response.headers.get("Location"))
+        ):
+            new_headers = dict(response.headers)
+            new_headers["Location"] = _append_query(location, {"provider": self.id})
+            return Response(
+                status_code=302,
+                body=response.body,
+                cookies=response.cookies,
+                headers=new_headers,
+            )
+        return response
+
+
+@pytest.fixture
+def hooked_provider() -> HookedFakeProvider:
+    return HookedFakeProvider(client_id="fake-client-id", client_secret="fake-secret")
+
+
+@pytest.fixture
+def client(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+    hooked_provider: HookedFakeProvider,
+) -> Generator[TestClient, None, None]:
+    auth = _build_auth(
+        storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        providers=[hooked_provider],
+    )
+    app = FastAPI()
+    app.include_router(auth.router)
+    with TestClient(app, follow_redirects=False) as c:
+        yield c
+
+
+def test_build_authorization_url_receives_request(client: TestClient):
+    resp, _ = start_provider_auth(
+        client,
+        "/fake/login",
+        params={"audience": "internal"},
+    )
+
+    query = parse_qs(urlparse(resp.headers["location"]).query)
+    assert query["audience"] == ["internal"]
+
+
+def test_build_authorization_url_default_branch_unaffected(client: TestClient):
+    resp, _ = start_provider_auth(client, "/fake/login")
+    query = parse_qs(urlparse(resp.headers["location"]).query)
+    assert "audience" not in query
+
+
+def test_intercept_callback_short_circuits_callback(client: TestClient):
+    resp = client.get(
+        "/fake/callback",
+        params={"provider_status": "pending"},
+    )
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/oauth/pending?provider=fake"
+
+
+@respx.mock
+def test_finalize_redirect_can_rewrite_session_redirect(
+    client: TestClient,
+):
+    mock_token_and_userinfo(email="alice@example.com")
+
+    _, state = start_provider_auth(client, "/fake/login", params={"next": "/dashboard"})
+
+    resp = client.get(
+        "/fake/callback",
+        params={
+            "code": "provider-code",
+            "state": state,
+            "include_provider": "true",
+        },
+    )
+    assert resp.status_code == 302
+
+    location = resp.headers["location"]
+    parsed = urlparse(location)
+    assert parsed.path == "/dashboard"
+    assert parse_qs(parsed.query) == {"provider": ["fake"]}
+
+
+@respx.mock
+def test_finalize_redirect_noop_by_default(client: TestClient):
+    mock_token_and_userinfo(email="alice@example.com")
+
+    _, state = start_provider_auth(client, "/fake/login", params={"next": "/dashboard"})
+
+    resp = client.get(
+        "/fake/callback",
+        params={"code": "provider-code", "state": state},
+    )
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/dashboard"


### PR DESCRIPTION
Introduces three hooks on OAuth2Provider so subclasses can customize
provider-specific behavior without knowing about session/token/link/connect
flows:

- `build_authorization_url(..., request=...)`: can return a different URL
  based on incoming request query params (e.g., ?install=true).
- `intercept_callback(request, context) -> Response | None`: short-circuit
  the callback handler for non-OAuth callback variants.
- `finalize_redirect(request, response) -> Response`: rewrite the final
  redirect (e.g., append provider-specific query parameters).

The canonical use case is the GitHub App combined install + OAuth flow,
which was the motivating example and is exercised by the new tests.

## Summary by Sourcery

Add extensibility hooks to the OAuth callback flow so providers can customize authorization URLs, intercept callbacks, and adjust final redirects without changing core flows.

New Features:
- Allow OAuth providers to receive the incoming request when building authorization URLs so they can vary parameters based on query data.
- Add an intercept_callback hook that lets providers short-circuit the standard OAuth callback handling for alternative callback variants.
- Add a finalize_redirect hook that lets providers modify the final redirect response returned by OAuth flows.

Enhancements:
- Update all OAuth flows (session, connect, token, link) to pass the request object into provider authorization URL construction.
- Extend the Apple provider authorization params signature to accept the forwarded request parameter.

Documentation:
- Add a release note describing the new provider-level OAuth hooks and their behavior.

Tests:
- Add router-level tests covering provider hooks for authorization URL customization, callback interception, and final redirect rewriting.