### PR TITLE
Release disconnection feature

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,18 @@
+---
+release type: minor
+---
+
+This release adds support for disconnecting linked OAuth provider accounts.
+
+Applications can now expose `DELETE /{provider}/social-accounts` to disconnect
+the current user's provider account when only one account for that provider is
+connected, or `DELETE /{provider}/social-accounts/{social_account_id}` to
+disconnect a specific linked account.
+
+Cross Auth prevents users from removing their only login method by checking for
+a usable password or another login-enabled social account. The new
+`oauth.disconnect` hooks let applications block disconnects, revoke provider
+tokens, clear caches, or audit successful account removals.
+
+Storage backends can support this flow through new social-account lookup,
+listing, and deletion methods on the accounts storage protocol.

--- a/src/cross_auth/_auth_flow.py
+++ b/src/cross_auth/_auth_flow.py
@@ -192,7 +192,7 @@ async def disconnect_provider(
     request: AsyncHTTPRequest,
     context: Context,
 ) -> Response:
-    """DELETE /{provider}/connect[/{social_account_id}] — detach provider account."""
+    """DELETE /{provider}/social-accounts[/{social_account_id}] — detach account."""
     if (user := context.get_user_from_request(request)) is None:
         return Response.error(
             "unauthorized",

--- a/src/cross_auth/router.py
+++ b/src/cross_auth/router.py
@@ -51,13 +51,13 @@ def _provider_routes(provider: OAuth2Provider) -> list[Route]:
             operation_id=f"{provider.id}_connect",
         ),
         Route(
-            path=f"{prefix}/connect",
+            path=f"{prefix}/social-accounts",
             methods=["DELETE"],
             function=bound(disconnect_provider),
             operation_id=f"{provider.id}_disconnect",
         ),
         Route(
-            path=f"{prefix}/connect/{{social_account_id}}",
+            path=f"{prefix}/social-accounts/{{social_account_id}}",
             methods=["DELETE"],
             function=bound(disconnect_provider),
             operation_id=f"{provider.id}_disconnect_account",

--- a/tests/router/test_disconnect_flow.py
+++ b/tests/router/test_disconnect_flow.py
@@ -35,7 +35,7 @@ def _add_social_account(
 
 
 def test_disconnect_requires_authentication(client: TestClient):
-    resp = client.delete("/fake/connect")
+    resp = client.delete("/fake/social-accounts")
 
     assert resp.status_code == 401
     assert resp.json() == {
@@ -45,7 +45,9 @@ def test_disconnect_requires_authentication(client: TestClient):
 
 
 def test_disconnect_requires_connected_account(client: TestClient):
-    resp = client.delete("/fake/connect", headers={"Authorization": "Bearer test"})
+    resp = client.delete(
+        "/fake/social-accounts", headers={"Authorization": "Bearer test"}
+    )
 
     assert resp.status_code == 400
     assert resp.json() == {
@@ -57,7 +59,9 @@ def test_disconnect_requires_connected_account(client: TestClient):
 def test_disconnect_deletes_provider_account(client: TestClient, accounts_storage):
     _add_social_account(accounts_storage)
 
-    resp = client.delete("/fake/connect", headers={"Authorization": "Bearer test"})
+    resp = client.delete(
+        "/fake/social-accounts", headers={"Authorization": "Bearer test"}
+    )
 
     assert resp.status_code == 200
     assert resp.json() == {"message": "fake account disconnected"}
@@ -79,7 +83,9 @@ def test_disconnect_by_provider_requires_specific_account_when_provider_has_mult
         provider_user_id="fake-user-2",
     )
 
-    resp = client.delete("/fake/connect", headers={"Authorization": "Bearer test"})
+    resp = client.delete(
+        "/fake/social-accounts", headers={"Authorization": "Bearer test"}
+    )
 
     assert resp.status_code == 400
     assert resp.json() == {
@@ -109,7 +115,7 @@ def test_disconnect_by_id_deletes_selected_account_when_provider_has_multiple_ac
     )
 
     resp = client.delete(
-        "/fake/connect/fake-account-2", headers={"Authorization": "Bearer test"}
+        "/fake/social-accounts/fake-account-2", headers={"Authorization": "Bearer test"}
     )
 
     assert resp.status_code == 200
@@ -129,7 +135,7 @@ def test_disconnect_rejects_account_for_different_provider(
     )
 
     resp = client.delete(
-        "/fake/connect/other-account", headers={"Authorization": "Bearer test"}
+        "/fake/social-accounts/other-account", headers={"Authorization": "Bearer test"}
     )
 
     assert resp.status_code == 400
@@ -159,7 +165,7 @@ def test_disconnect_rejects_account_for_different_user(
     )
 
     resp = client.delete(
-        "/fake/connect/other-user-fake-account",
+        "/fake/social-accounts/other-user-fake-account",
         headers={"Authorization": "Bearer test"},
     )
 
@@ -181,7 +187,7 @@ def test_disconnect_blocks_only_login_method(client: TestClient, accounts_storag
     _add_social_account(accounts_storage, is_login_method=True)
 
     resp = client.delete(
-        "/fake/connect/fake-account", headers={"Authorization": "Bearer test"}
+        "/fake/social-accounts/fake-account", headers={"Authorization": "Bearer test"}
     )
 
     assert resp.status_code == 400
@@ -207,7 +213,7 @@ def test_disconnect_allows_alternative_social_login(
     )
 
     resp = client.delete(
-        "/fake/connect/fake-account", headers={"Authorization": "Bearer test"}
+        "/fake/social-accounts/fake-account", headers={"Authorization": "Bearer test"}
     )
 
     assert resp.status_code == 200
@@ -225,7 +231,7 @@ def test_disconnect_allows_non_login_account_without_password(
     _add_social_account(accounts_storage, is_login_method=False)
 
     resp = client.delete(
-        "/fake/connect/fake-account", headers={"Authorization": "Bearer test"}
+        "/fake/social-accounts/fake-account", headers={"Authorization": "Bearer test"}
     )
 
     assert resp.status_code == 200
@@ -257,7 +263,8 @@ def test_disconnect_runs_hooks(auth: CrossAuth, accounts_storage):
 
     with TestClient(app) as client:
         resp = client.delete(
-            "/fake/connect/hook-account", headers={"Authorization": "Bearer test"}
+            "/fake/social-accounts/hook-account",
+            headers={"Authorization": "Bearer test"},
         )
 
     assert resp.status_code == 200
@@ -286,7 +293,8 @@ def test_disconnect_before_hook_can_block(auth: CrossAuth, accounts_storage):
 
     with TestClient(app) as client:
         resp = client.delete(
-            "/fake/connect/blocked-account", headers={"Authorization": "Bearer test"}
+            "/fake/social-accounts/blocked-account",
+            headers={"Authorization": "Bearer test"},
         )
 
     assert resp.status_code == 400

--- a/website/content/docs/hooks.md
+++ b/website/content/docs/hooks.md
@@ -304,13 +304,13 @@ async def audit_link_complete(event: AfterOAuthFinalizeLinkEvent) -> None:
 
 ### `oauth.disconnect`
 
-Runs around `DELETE /{provider}/connect` and
-`DELETE /{provider}/connect/{social_account_id}`, after Cross-Auth has found the
-selected provider account, verified it belongs to the current user, and computed
-whether the user has a usable password or another login-enabled social account.
-Use the before hook to block app-specific cases, then perform cleanup after the
-account record has been deleted. This before hook is policy-only and must return
-`None`.
+Runs around `DELETE /{provider}/social-accounts` and
+`DELETE /{provider}/social-accounts/{social_account_id}`, after Cross-Auth has
+found the selected provider account, verified it belongs to the current user,
+and computed whether the user has a usable password or another login-enabled
+social account. Use the before hook to block app-specific cases, then perform
+cleanup after the account record has been deleted. This before hook is
+policy-only and must return `None`.
 
 ```python
 from cross_auth.hooks import (

--- a/website/content/docs/social-providers.md
+++ b/website/content/docs/social-providers.md
@@ -28,10 +28,10 @@ linked to the same user record via the `SocialAccount` model.
 The `POST /{provider}/link` endpoint handles account linking for authenticated
 users.
 
-The `DELETE /{provider}/connect` endpoint disconnects the current user's
+The `DELETE /{provider}/social-accounts` endpoint disconnects the current user's
 provider account when only one account for that provider is connected. If a user
 has multiple accounts for the same provider, use
-`DELETE /{provider}/connect/{social_account_id}` to choose the account
+`DELETE /{provider}/social-accounts/{social_account_id}` to choose the account
 explicitly. Cross-Auth verifies the selected social account belongs to the
 current user and provider, and blocks disconnecting it when it is the user's
 only login method. Use the `oauth.disconnect` hooks to add provider-specific


### PR DESCRIPTION
## Summary by Sourcery

Document and expose the new OAuth provider disconnection endpoints and align tests and docs with the updated route paths.

New Features:
- Expose DELETE /{provider}/social-accounts and DELETE /{provider}/social-accounts/{social_account_id} endpoints for disconnecting linked OAuth provider accounts.

Documentation:
- Update social provider and hook documentation to describe the new /social-accounts disconnection endpoints and their behavior.
- Add a release note describing the new disconnection flow, safeguards, and storage backend requirements.

Tests:
- Update disconnect flow tests to target the new /social-accounts endpoints instead of the legacy /connect paths.