### PR TITLE
Fix OpenAPI params for disconnect

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,10 @@
+---
+release type: patch
+---
+
+This release fixes the OpenAPI schema for disconnecting a specific linked OAuth
+account.
+
+The `DELETE /{provider}/social-accounts/{social_account_id}` route now documents
+its required `social_account_id` path parameter, so generated clients and API
+docs correctly show the account-specific disconnect endpoint.

--- a/src/cross_auth/_route.py
+++ b/src/cross_auth/_route.py
@@ -1,5 +1,5 @@
 from collections.abc import Awaitable, Callable
-from typing import Annotated, Any, get_args
+from typing import Annotated, Any, Literal, TypedDict, get_args
 
 from cross_web import AsyncHTTPRequest, Response
 from pydantic import BaseModel
@@ -9,6 +9,17 @@ from ._context import Context
 
 class Form:
     pass
+
+
+PathParameter = TypedDict(
+    "PathParameter",
+    {
+        "name": str,
+        "in": Literal["path"],
+        "required": Literal[True],
+        "schema": dict[str, Any],
+    },
+)
 
 
 def _get_fastapi_request_type(route: "Route") -> Any:
@@ -40,6 +51,7 @@ class Route:
         summary: str | None = None,
         openapi: dict[str, Any] | None = None,
         openapi_schemas: dict[str, Any] | None = None,
+        path_parameters: list[PathParameter] | None = None,
     ):
         self.path = path
         self.methods = methods
@@ -50,6 +62,7 @@ class Route:
         self.summary = summary
         self.openapi = openapi
         self.openapi_schemas = openapi_schemas
+        self.path_parameters = list(path_parameters or [])
 
     def to_fastapi_endpoint(self, context: Context) -> Callable[..., Any]:
         from fastapi import Request as FastAPIRequest
@@ -63,3 +76,21 @@ class Route:
             return route_response.to_fastapi()
 
         return wrapper
+
+    def get_openapi_extra(self) -> dict[str, Any] | None:
+        if not self.path_parameters:
+            return self.openapi
+
+        openapi = dict(self.openapi or {})
+        path_parameter_keys = {
+            (parameter["name"], parameter["in"]) for parameter in self.path_parameters
+        }
+        existing_parameters = [
+            parameter
+            for parameter in openapi.get("parameters", [])
+            if (parameter.get("name"), parameter.get("in")) not in path_parameter_keys
+        ]
+
+        openapi["parameters"] = [*existing_parameters, *self.path_parameters]
+
+        return openapi

--- a/src/cross_auth/router.py
+++ b/src/cross_auth/router.py
@@ -61,6 +61,14 @@ def _provider_routes(provider: OAuth2Provider) -> list[Route]:
             methods=["DELETE"],
             function=bound(disconnect_provider),
             operation_id=f"{provider.id}_disconnect_account",
+            path_parameters=[
+                {
+                    "name": "social_account_id",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string", "title": "Social Account Id"},
+                }
+            ],
         ),
         Route(
             path=f"{prefix}/authorize",
@@ -137,7 +145,7 @@ class AuthRouter(APIRouter):
                 methods=route.methods,
                 response_model=route.response_model,
                 operation_id=route.operation_id,
-                openapi_extra=route.openapi,
+                openapi_extra=route.get_openapi_extra(),
                 summary=route.summary,
             )
 

--- a/tests/router/test_disconnect_flow.py
+++ b/tests/router/test_disconnect_flow.py
@@ -44,6 +44,24 @@ def test_disconnect_requires_authentication(client: TestClient):
     }
 
 
+def test_disconnect_account_route_documents_path_parameter(auth: CrossAuth):
+    app = FastAPI()
+    app.include_router(auth.router)
+
+    operation = app.openapi()["paths"]["/fake/social-accounts/{social_account_id}"][
+        "delete"
+    ]
+
+    assert operation["parameters"] == [
+        {
+            "name": "social_account_id",
+            "in": "path",
+            "required": True,
+            "schema": {"type": "string", "title": "Social Account Id"},
+        }
+    ]
+
+
 def test_disconnect_requires_connected_account(client: TestClient):
     resp = client.delete(
         "/fake/social-accounts", headers={"Authorization": "Bearer test"}

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -1,0 +1,63 @@
+from cross_auth._route import PathParameter, Route
+
+
+async def _handler(request, context): ...
+
+
+ITEM_ID_PARAMETER: PathParameter = {
+    "name": "item_id",
+    "in": "path",
+    "required": True,
+    "schema": {"type": "string", "title": "Item Id"},
+}
+
+OTHER_ID_PARAMETER: PathParameter = {
+    "name": "other_id",
+    "in": "path",
+    "required": True,
+    "schema": {"type": "string", "title": "Other Id"},
+}
+
+
+def test_route_copies_path_parameters():
+    parameters = [ITEM_ID_PARAMETER]
+
+    route = Route("/items/{item_id}", ["GET"], _handler, path_parameters=parameters)
+    parameters.append(OTHER_ID_PARAMETER)
+
+    assert route.path_parameters == [ITEM_ID_PARAMETER]
+
+
+def test_route_path_parameters_override_matching_openapi_parameters():
+    route = Route(
+        "/items/{item_id}",
+        ["GET"],
+        _handler,
+        openapi={
+            "parameters": [
+                {
+                    "name": "include_deleted",
+                    "in": "query",
+                    "schema": {"type": "boolean"},
+                },
+                {
+                    "name": "item_id",
+                    "in": "path",
+                    "required": False,
+                    "schema": {"type": "integer"},
+                },
+            ]
+        },
+        path_parameters=[ITEM_ID_PARAMETER],
+    )
+
+    assert route.get_openapi_extra() == {
+        "parameters": [
+            {
+                "name": "include_deleted",
+                "in": "query",
+                "schema": {"type": "boolean"},
+            },
+            ITEM_ID_PARAMETER,
+        ]
+    }


### PR DESCRIPTION
## Summary by Sourcery

Document path parameter metadata for the social account disconnect endpoint and expose it in generated OpenAPI schemas.

Bug Fixes:
- Ensure the DELETE /{provider}/social-accounts/{social_account_id} route documents its required social_account_id path parameter in OpenAPI.

Enhancements:
- Add route-level support for specifying path parameters and merging them into OpenAPI metadata via a helper method.

Documentation:
- Add a release note describing the OpenAPI schema fix for the account-specific disconnect endpoint.

Tests:
- Add a test to verify the disconnect account route documents the social_account_id path parameter in the generated OpenAPI schema.