### PR TITLE
✨ Add support for Google

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+---
+release type: minor
+---
+
+Add a new OAuth provider for Google, with local ID token validation against
+Google's JWKS endpoint.
+
+This release also includes a few related improvements to the OAuth2 / OIDC base
+classes:
+
+- `OAuth2Provider` now accepts an `extra_authorization_params` keyword argument
+  for appending custom query parameters to the authorization URL (e.g. Google's
+  `access_type=offline`, `prompt=consent`, `hd`, `include_granted_scopes`).
+  Provider-controlled parameters such as `state`, `client_id`, and
+  `redirect_uri` cannot be overridden.
+- `OIDCProvider.issuer` now accepts either a single string or a list of strings
+  to support providers (like Google) that emit ID tokens with multiple valid
+  issuer forms.
+- OIDC JWKS caching now honors the `Cache-Control: max-age` header from the
+  provider's JWKS response (clamped between 5 minutes and 24 hours) instead of
+  using a fixed 24-hour TTL, so caches no longer outlive the provider's key
+  rotation window.

--- a/src/cross_auth/social_providers/google.py
+++ b/src/cross_auth/social_providers/google.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .oauth import UserInfo
+from .oidc import OIDCProvider
+
+
+class GoogleProvider(OIDCProvider):
+    id = "google"
+
+    authorization_endpoint = "https://accounts.google.com/o/oauth2/v2/auth"
+    token_endpoint = "https://oauth2.googleapis.com/token"
+    jwks_uri = "https://www.googleapis.com/oauth2/v3/certs"
+    # Google emits id_tokens with either form of iss; both must validate.
+    # https://developers.google.com/identity/gsi/web/guides/verify-google-id-token
+    issuer = ["https://accounts.google.com", "accounts.google.com"]
+    jwks_cache_key = "google:jwks"
+
+    scopes = ["openid", "email", "profile"]
+    supports_pkce = True
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        trust_email: bool = False,
+        *,
+        extra_authorization_params: dict[str, str] | None = None,
+        authorization_endpoint: str | None = None,
+        token_endpoint: str | None = None,
+        jwks_uri: str | None = None,
+    ):
+        """
+        Initialize the Google OAuth2 / OIDC provider.
+
+        Args:
+            client_id: OAuth2 client ID.
+            client_secret: OAuth2 client secret.
+            trust_email: If True, emails from this provider are trusted for account
+                linking even without explicit email_verified=True. Defaults to False
+                because Google provides an email_verified claim.
+            extra_authorization_params: Additional query parameters for the
+                authorization URL. Common Google-specific values:
+                ``{"access_type": "offline", "prompt": "consent"}`` to receive a
+                refresh token, ``{"hd": "example.com"}`` to hint a Workspace
+                domain, ``{"include_granted_scopes": "true"}`` for incremental
+                authorization.
+            authorization_endpoint: Custom authorization URL (for browser redirects).
+            token_endpoint: Custom token exchange URL (for server-to-server calls).
+            jwks_uri: Custom JWKS URL (for server-to-server ID token validation).
+        """
+        super().__init__(
+            client_id,
+            client_secret,
+            trust_email,
+            extra_authorization_params=extra_authorization_params,
+        )
+
+        if authorization_endpoint is not None:
+            self.authorization_endpoint = authorization_endpoint
+        if token_endpoint is not None:
+            self.token_endpoint = token_endpoint
+        if jwks_uri is not None:
+            self.jwks_uri = jwks_uri
+
+    def extract_user_info_from_claims(
+        self,
+        claims: dict[str, Any],
+        extra: dict[str, Any] | None = None,
+    ) -> UserInfo:
+        info: UserInfo = {
+            "id": claims["sub"],
+            "email": claims.get("email"),
+            "email_verified": claims.get("email_verified"),
+        }
+        if name := claims.get("name"):
+            info["name"] = name
+        return info

--- a/src/cross_auth/social_providers/oauth.py
+++ b/src/cross_auth/social_providers/oauth.py
@@ -68,6 +68,8 @@ class OAuth2Provider:
         client_id: str,
         client_secret: str | None = None,
         trust_email: bool = True,
+        *,
+        extra_authorization_params: dict[str, str] | None = None,
     ):
         """
         Initialize the OAuth2 provider.
@@ -79,10 +81,15 @@ class OAuth2Provider:
             trust_email: If True, emails from this provider are trusted for account
                 linking even without explicit email_verified=True. Set to False for
                 providers that don't verify email ownership.
+            extra_authorization_params: Additional query parameters to append to
+                the authorization URL (e.g., Google's ``access_type=offline``,
+                ``prompt=consent``, ``hd``, ``include_granted_scopes``). Keys that
+                conflict with provider-controlled params are ignored.
         """
         self.client_id = client_id
         self.client_secret = client_secret
         self.trust_email = trust_email
+        self.extra_authorization_params = extra_authorization_params
 
     def can_auto_link(self, context: Context, email_verified: bool | None) -> bool:
         """Check if auto-linking by email is allowed.
@@ -174,6 +181,13 @@ class OAuth2Provider:
             code_challenge_method=code_challenge_method,
             login_hint=login_hint,
         )
+
+        # Merge extras without overriding provider-controlled keys. setdefault
+        # protects state, client_id, redirect_uri, code_challenge, etc.
+        if self.extra_authorization_params:
+            for k, v in self.extra_authorization_params.items():
+                params.setdefault(k, v)
+
         return f"{self.authorization_endpoint}?{urlencode(params)}"
 
     async def intercept_callback(

--- a/src/cross_auth/social_providers/oidc.py
+++ b/src/cross_auth/social_providers/oidc.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 import time
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
@@ -36,20 +37,42 @@ class OIDCProvider(OAuth2Provider):
     """
 
     jwks_uri: ClassVar[str]
-    issuer: ClassVar[str]
+    issuer: ClassVar[str | list[str]]
     jwks_cache_key: ClassVar[str]
 
     # OIDC providers typically don't need a userinfo endpoint
     user_info_endpoint: ClassVar[str | None] = None
 
     _JWKS_REFETCH_COOLDOWN: ClassVar[int] = 60  # seconds
+    _JWKS_TTL_FLOOR: ClassVar[int] = 300  # 5 minutes
+    _JWKS_TTL_CEILING: ClassVar[int] = 86400  # 24 hours
+    _JWKS_TTL_FALLBACK: ClassVar[int] = 3600  # 1 hour when no Cache-Control
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._jwks_last_fetch_time: float = 0.0
 
+    @classmethod
+    def _ttl_from_cache_control(cls, header: str | None) -> int:
+        """Extract max-age from a Cache-Control header, clamped to floor/ceiling.
+
+        Returns the fallback TTL if the header is missing or has no max-age.
+        """
+        if not header:
+            return cls._JWKS_TTL_FALLBACK
+
+        match = re.search(r"max-age\s*=\s*(\d+)", header, re.IGNORECASE)
+        if not match:
+            return cls._JWKS_TTL_FALLBACK
+
+        return max(cls._JWKS_TTL_FLOOR, min(int(match.group(1)), cls._JWKS_TTL_CEILING))
+
     def _fetch_jwks(self, secondary_storage: "SecondaryStorage") -> dict[str, Any]:
-        """Fetch provider's JWKS, using secondary_storage as cache."""
+        """Fetch provider's JWKS, using secondary_storage as cache.
+
+        TTL honors the JWKS response's Cache-Control max-age (clamped) so cache
+        doesn't outlive the provider's key rotation window.
+        """
         if cached := secondary_storage.get(self.jwks_cache_key):
             return json.loads(cached)
 
@@ -57,8 +80,9 @@ class OIDCProvider(OAuth2Provider):
         response.raise_for_status()
 
         jwks = response.json()
+        ttl = self._ttl_from_cache_control(response.headers.get("cache-control"))
 
-        secondary_storage.set(self.jwks_cache_key, json.dumps(jwks), ttl=86400)
+        secondary_storage.set(self.jwks_cache_key, json.dumps(jwks), ttl=ttl)
         self._jwks_last_fetch_time = time.monotonic()
         return jwks
 

--- a/tests/providers/google/test_provider.py
+++ b/tests/providers/google/test_provider.py
@@ -1,0 +1,283 @@
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+from unittest.mock import MagicMock
+
+import jwt
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.algorithms import RSAAlgorithm
+
+from cross_auth.models.oauth_token_response import TokenResponse
+from cross_auth.social_providers.google import GoogleProvider
+
+
+def test_google_provider_defaults() -> None:
+    provider = GoogleProvider(
+        client_id="google-client-id",
+        client_secret="google-client-secret",
+    )
+
+    assert provider.id == "google"
+    assert provider.authorization_endpoint == (
+        "https://accounts.google.com/o/oauth2/v2/auth"
+    )
+    assert provider.token_endpoint == "https://oauth2.googleapis.com/token"
+    assert provider.jwks_uri == "https://www.googleapis.com/oauth2/v3/certs"
+    assert provider.issuer == ["https://accounts.google.com", "accounts.google.com"]
+    assert provider.jwks_cache_key == "google:jwks"
+    assert provider.scopes == ["openid", "email", "profile"]
+    assert provider.supports_pkce is True
+    assert provider.trust_email is False
+
+
+def test_google_provider_endpoint_overrides() -> None:
+    provider = GoogleProvider(
+        client_id="google-client-id",
+        client_secret="google-client-secret",
+        authorization_endpoint="https://mock.example/o/oauth2/v2/auth",
+        token_endpoint="https://mock.example/token",
+        jwks_uri="https://mock.example/oauth2/v3/certs",
+    )
+
+    assert provider.authorization_endpoint == "https://mock.example/o/oauth2/v2/auth"
+    assert provider.token_endpoint == "https://mock.example/token"
+    assert provider.jwks_uri == "https://mock.example/oauth2/v3/certs"
+
+
+def test_google_authorization_url() -> None:
+    provider = GoogleProvider(
+        client_id="google-client-id",
+        client_secret="google-client-secret",
+    )
+
+    auth_url = provider.build_authorization_url(
+        state="state-123",
+        redirect_uri="https://app.example/auth/google/callback",
+        code_challenge="challenge",
+        code_challenge_method="S256",
+        login_hint="user@example.com",
+    )
+    parsed = urlparse(auth_url)
+    query = parse_qs(parsed.query)
+
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "accounts.google.com"
+    assert parsed.path == "/o/oauth2/v2/auth"
+    assert query == {
+        "client_id": ["google-client-id"],
+        "scope": ["openid email profile"],
+        "redirect_uri": ["https://app.example/auth/google/callback"],
+        "response_type": ["code"],
+        "state": ["state-123"],
+        "code_challenge": ["challenge"],
+        "code_challenge_method": ["S256"],
+        "login_hint": ["user@example.com"],
+    }
+
+
+def test_extra_authorization_params_are_appended() -> None:
+    provider = GoogleProvider(
+        client_id="google-client-id",
+        client_secret="google-client-secret",
+        extra_authorization_params={
+            "access_type": "offline",
+            "prompt": "consent",
+            "hd": "example.com",
+            "include_granted_scopes": "true",
+        },
+    )
+
+    url = provider.build_authorization_url(
+        state="state-123",
+        redirect_uri="https://app.example/auth/google/callback",
+        code_challenge="challenge",
+        code_challenge_method="S256",
+    )
+    query = parse_qs(urlparse(url).query)
+
+    assert query["access_type"] == ["offline"]
+    assert query["prompt"] == ["consent"]
+    assert query["hd"] == ["example.com"]
+    assert query["include_granted_scopes"] == ["true"]
+
+
+def test_extra_authorization_params_cannot_override_required() -> None:
+    provider = GoogleProvider(
+        client_id="google-client-id",
+        client_secret="google-client-secret",
+        extra_authorization_params={
+            "client_id": "hijacked",
+            "state": "hijacked",
+            "redirect_uri": "https://evil.example/cb",
+        },
+    )
+
+    url = provider.build_authorization_url(
+        state="state-123",
+        redirect_uri="https://app.example/auth/google/callback",
+        code_challenge="challenge",
+        code_challenge_method="S256",
+    )
+    query = parse_qs(urlparse(url).query)
+
+    assert query["client_id"] == ["google-client-id"]
+    assert query["state"] == ["state-123"]
+    assert query["redirect_uri"] == ["https://app.example/auth/google/callback"]
+
+
+def test_extract_user_info_from_claims() -> None:
+    provider = GoogleProvider(
+        client_id="google-client-id",
+        client_secret="google-client-secret",
+    )
+
+    user_info = provider.extract_user_info_from_claims(
+        {
+            "sub": "google-user-123",
+            "email": "user@example.com",
+            "email_verified": True,
+            "name": "Test User",
+            "picture": "https://example.com/avatar.png",
+        }
+    )
+
+    assert user_info == {
+        "id": "google-user-123",
+        "email": "user@example.com",
+        "email_verified": True,
+        "name": "Test User",
+    }
+
+
+def test_fetch_user_info_validates_rs256_id_token() -> None:
+    provider = GoogleProvider(
+        client_id="google-client-id",
+        client_secret="google-client-secret",
+    )
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_jwk = json.loads(RSAAlgorithm.to_jwk(private_key.public_key()))
+    public_jwk["kid"] = "google-key-1"
+    public_jwk["alg"] = "RS256"
+
+    id_token = jwt.encode(
+        {
+            "iss": "https://accounts.google.com",
+            "aud": "google-client-id",
+            "sub": "google-user-123",
+            "email": "user@example.com",
+            "email_verified": True,
+            "name": "Test User",
+            "exp": datetime.now(tz=UTC) + timedelta(minutes=5),
+            "iat": datetime.now(tz=UTC),
+        },
+        private_key,
+        algorithm="RS256",
+        headers={"kid": "google-key-1"},
+    )
+
+    secondary_storage = MagicMock()
+    secondary_storage.get.return_value = json.dumps({"keys": [public_jwk]})
+    context = MagicMock()
+    context.secondary_storage = secondary_storage
+
+    user_info = provider.fetch_user_info(
+        TokenResponse(
+            token_type="Bearer",
+            access_token="google-access-token",
+            id_token=id_token,
+        ),
+        context,
+    )
+
+    assert user_info["id"] == "google-user-123"
+    assert user_info["email"] == "user@example.com"
+    assert user_info["email_verified"] is True
+
+
+def test_jwks_ttl_from_cache_control() -> None:
+    parse = GoogleProvider._ttl_from_cache_control
+
+    # Honors max-age within bounds
+    assert parse("public, max-age=3600, must-revalidate") == 3600
+    assert parse("MAX-AGE=120, public") == 300  # clamped to floor
+    assert parse("max-age=200000") == 86400  # clamped to ceiling
+
+    # Fallback when header missing or no max-age
+    assert parse(None) == 3600
+    assert parse("no-cache") == 3600
+    assert parse("") == 3600
+
+
+def test_fetch_jwks_uses_response_cache_control(monkeypatch) -> None:
+    provider = GoogleProvider(
+        client_id="google-client-id",
+        client_secret="google-client-secret",
+    )
+
+    captured_ttl: dict[str, int] = {}
+
+    def fake_get(url: str) -> Any:
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"keys": []}
+        response.headers = {"cache-control": "public, max-age=7200"}
+        return response
+
+    secondary_storage = MagicMock()
+    secondary_storage.get.return_value = None
+
+    def fake_set(key: str, value: str, ttl: int) -> None:
+        captured_ttl["ttl"] = ttl
+
+    secondary_storage.set.side_effect = fake_set
+
+    monkeypatch.setattr("cross_auth.social_providers.oidc.httpx.get", fake_get)
+
+    provider._fetch_jwks(secondary_storage)
+
+    assert captured_ttl["ttl"] == 7200
+
+
+def test_fetch_user_info_accepts_schemeless_issuer() -> None:
+    # Google docs require validators to accept iss="accounts.google.com" as
+    # well as the canonical "https://accounts.google.com".
+    provider = GoogleProvider(
+        client_id="google-client-id",
+        client_secret="google-client-secret",
+    )
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_jwk = json.loads(RSAAlgorithm.to_jwk(private_key.public_key()))
+    public_jwk["kid"] = "google-key-1"
+    public_jwk["alg"] = "RS256"
+
+    id_token = jwt.encode(
+        {
+            "iss": "accounts.google.com",
+            "aud": "google-client-id",
+            "sub": "google-user-123",
+            "email": "user@example.com",
+            "email_verified": True,
+            "exp": datetime.now(tz=UTC) + timedelta(minutes=5),
+            "iat": datetime.now(tz=UTC),
+        },
+        private_key,
+        algorithm="RS256",
+        headers={"kid": "google-key-1"},
+    )
+
+    secondary_storage = MagicMock()
+    secondary_storage.get.return_value = json.dumps({"keys": [public_jwk]})
+    context = MagicMock()
+    context.secondary_storage = secondary_storage
+
+    user_info = provider.fetch_user_info(
+        TokenResponse(
+            token_type="Bearer",
+            access_token="google-access-token",
+            id_token=id_token,
+        ),
+        context,
+    )
+
+    assert user_info["id"] == "google-user-123"

--- a/website/content/docs/providers/discord.md
+++ b/website/content/docs/providers/discord.md
@@ -2,7 +2,7 @@
 title: Discord
 description: Configure Discord OAuth for authentication
 section: Providers
-order: 4
+order: 5
 ---
 
 # Discord

--- a/website/content/docs/providers/github.md
+++ b/website/content/docs/providers/github.md
@@ -2,7 +2,7 @@
 title: GitHub
 description: Configure GitHub OAuth for authentication
 section: Providers
-order: 3
+order: 4
 ---
 
 # GitHub

--- a/website/content/docs/providers/google.md
+++ b/website/content/docs/providers/google.md
@@ -1,0 +1,159 @@
+---
+title: Google
+description: Configure Google OAuth for authentication
+section: Providers
+order: 3
+---
+
+# Google
+
+Google uses OAuth 2.0 with OpenID Connect. Cross Auth validates Google's
+`id_token` locally using Google's JWKS endpoint.
+
+## Configuration
+
+```python
+from cross_auth.social_providers.google import GoogleProvider
+
+google = GoogleProvider(
+    client_id="your-google-client-id",
+    client_secret="your-google-client-secret",
+)
+```
+
+### Account linking and `trust_email`
+
+Unlike other providers, `GoogleProvider` defaults `trust_email=False`. Google
+always returns an `email_verified` claim in the ID token, so auto-linking uses
+that claim instead of blanket-trusting the email. If account linking is enabled
+and a user's `email_verified` is `False` (rare, but possible for federated
+Google accounts), linking will be skipped. Pass `trust_email=True` explicitly
+only if you want to override this.
+
+### Requesting a refresh token
+
+Google only issues a `refresh_token` when the authorization request includes
+`access_type=offline`, and only re-issues one on subsequent sign-ins if you also
+pass `prompt=consent`:
+
+```python
+google = GoogleProvider(
+    client_id="your-google-client-id",
+    client_secret="your-google-client-secret",
+    extra_authorization_params={
+        "access_type": "offline",
+        "prompt": "consent",
+    },
+)
+```
+
+### Restricting to a Google Workspace domain
+
+`extra_authorization_params` can also pass `hd` (Workspace domain hint) and
+`include_granted_scopes` (incremental authorization):
+
+```python
+google = GoogleProvider(
+    client_id="...",
+    client_secret="...",
+    extra_authorization_params={"hd": "example.com"},
+)
+```
+
+> The `hd` request parameter is a UX hint only — it is not a security boundary.
+> To actually restrict sign-in to a Workspace domain, subclass `GoogleProvider`
+> and validate the `hd` claim from the verified ID token in
+> `extract_user_info_from_claims`.
+
+## Google Setup
+
+### Create an OAuth Client
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Select your project
+3. Navigate to **APIs & Services** → **Credentials**
+4. Click **Create Credentials** → **OAuth client ID**
+5. Select **Web application**
+6. Add your authorized redirect URI:
+   - `https://your-app.com/auth/google/callback`
+7. Copy the **Client ID** and **Client secret**
+
+## Scopes
+
+The Google provider requests these scopes by default:
+
+| Scope     | Description               |
+| --------- | ------------------------- |
+| `openid`  | Enables OpenID Connect    |
+| `email`   | Access user's email       |
+| `profile` | Access basic profile data |
+
+## User Info
+
+Google returns the following user information in the ID token:
+
+| Field            | Type    | Description               |
+| ---------------- | ------- | ------------------------- |
+| `sub`            | string  | Stable Google user ID     |
+| `email`          | string  | User's email address      |
+| `email_verified` | boolean | Whether email is verified |
+| `name`           | string  | Display name              |
+| `picture`        | string  | Profile picture URL       |
+
+Cross Auth maps `sub` to the standard user info `id` field.
+
+## Example
+
+```python
+from fastapi import FastAPI
+from cross_auth.router import AuthRouter
+from cross_auth.social_providers.google import GoogleProvider
+
+google = GoogleProvider(
+    client_id="123.apps.googleusercontent.com",
+    client_secret="secret123",
+)
+
+auth_router = AuthRouter(
+    providers=[google],
+    # ... other config
+)
+
+app = FastAPI()
+app.include_router(auth_router, prefix="/auth")
+```
+
+Users can then authenticate via:
+
+- `GET /auth/google/authorize` - Start OAuth flow
+- `GET /auth/google/callback` - OAuth callback (handled automatically)
+
+## Testing With a Mock Provider
+
+For local or CI tests, you can override endpoints:
+
+```python
+google = GoogleProvider(
+    client_id="test-google-client-id",
+    client_secret="test-google-client-secret",
+    authorization_endpoint="https://google-oauth-mock.example.com/o/oauth2/v2/auth",
+    token_endpoint="https://google-oauth-mock.example.com/token",
+    jwks_uri="https://google-oauth-mock.example.com/oauth2/v3/certs",
+)
+```
+
+## Troubleshooting
+
+### "id_token audience mismatch"
+
+- Ensure the `client_id` matches the OAuth client configured in Google Cloud
+
+### "id_token issuer mismatch"
+
+- The token's `iss` claim must be either `https://accounts.google.com` or
+  `accounts.google.com` — both forms are valid per Google's docs
+
+### "Key not found in provider's JWKS"
+
+- Ensure `jwks_uri` points to a JWKS endpoint that contains the key ID from the
+  token header

--- a/website/content/docs/providers/index.md
+++ b/website/content/docs/providers/index.md
@@ -15,6 +15,7 @@ including OIDC providers and standard OAuth2 providers.
 | Provider                           | Type   | PKCE | Notes                            |
 | ---------------------------------- | ------ | ---- | -------------------------------- |
 | [Apple](/docs/providers/apple)     | OIDC   | Yes  | JWT client secret, POST callback |
+| [Google](/docs/providers/google)   | OIDC   | Yes  | ID token validation with JWKS    |
 | [GitHub](/docs/providers/github)   | OAuth2 | Yes  | Userinfo endpoint                |
 | [Discord](/docs/providers/discord) | OAuth2 | Yes  | Userinfo endpoint                |
 
@@ -35,9 +36,10 @@ You can use multiple providers simultaneously:
 from cross_auth.router import AuthRouter
 from cross_auth.social_providers.apple import AppleProvider
 from cross_auth.social_providers.github import GitHubProvider
+from cross_auth.social_providers.google import GoogleProvider
 
 auth_router = AuthRouter(
-    providers=[apple, github, discord],
+    providers=[apple, google, github, discord],
     # ... other config
 )
 ```


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack

- **#37** (`add-support-for-google`) <-- this PR
<!-- shortcake:end -->

## Summary by Sourcery

Add a Google OIDC provider and supporting infrastructure for configurable authorization parameters and JWKS caching behavior.

New Features:
- Introduce a GoogleProvider implementing Google OAuth2/OIDC with ID token validation via JWKS and configurable endpoints.
- Allow OAuth2 providers to accept extra authorization URL parameters without overriding required fields.

Enhancements:
- Adjust OIDC JWKS caching to derive TTL from the provider response's Cache-Control header with bounded limits.
- Support multiple acceptable issuer values in OIDC providers to align with provider-specific requirements.

Documentation:
- Add Google provider documentation covering configuration, scopes, user info mapping, testing, and troubleshooting, and include Google in the provider index.

Tests:
- Add comprehensive tests for the Google provider, including authorization URL building, ID token/JWKS validation, issuer handling, and JWKS caching TTL behavior.

Chores:
- Record a minor release note describing the addition of the Google OAuth provider.