### PR TITLE
♻️ Make endpoints sync

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,10 @@
+---
+release type: minor
+---
+
+This release makes auth routes and hooks synchronous, allowing applications that
+use synchronous dependencies such as database clients to run auth logic without
+blocking the event loop.
+
+It also updates Cross Auth to use `cross-web`'s synchronous `HTTPRequest`
+wrapper.

--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Annotated, Any, cast
 
 import jwt
-from cross_web import AsyncHTTPRequest
+from cross_web import HTTPRequest
 from fastapi import Depends, FastAPI, Form, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse
@@ -367,7 +367,7 @@ def resolve_bearer_user(request: Request) -> DemoUser:
     return resolve_bearer_token(token)
 
 
-def resolve_auth_user(request: AsyncHTTPRequest) -> DemoUser | None:
+def resolve_auth_user(request: HTTPRequest) -> DemoUser | None:
     authorization = request.headers.get("Authorization")
     if authorization and authorization.startswith("Bearer "):
         token = authorization.split(" ", 1)[1]
@@ -448,7 +448,7 @@ def audit_session_logout(event: AfterLogoutEvent) -> None:
 
 
 @auth.before("oauth.callback")
-async def require_verified_provider_email(event: BeforeOAuthCallbackEvent) -> None:
+def require_verified_provider_email(event: BeforeOAuthCallbackEvent) -> None:
     if event.validated_user_info.email_verified is not True:
         raise CrossAuthException(
             "email_not_verified",
@@ -457,7 +457,7 @@ async def require_verified_provider_email(event: BeforeOAuthCallbackEvent) -> No
 
 
 @auth.after("oauth.callback")
-async def audit_oauth_callback(event: AfterOAuthCallbackEvent) -> None:
+def audit_oauth_callback(event: AfterOAuthCallbackEvent) -> None:
     record_hook_event(
         "after:oauth.callback",
         flow=event.auth_request.flow,
@@ -468,7 +468,7 @@ async def audit_oauth_callback(event: AfterOAuthCallbackEvent) -> None:
 
 
 @auth.after("token.authorization_code")
-async def audit_token_exchange(event: AfterTokenAuthorizationCodeEvent) -> None:
+def audit_token_exchange(event: AfterTokenAuthorizationCodeEvent) -> None:
     record_hook_event(
         "after:token.authorization_code",
         client_id=event.authorization_data.client_id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [{ name = "Patrick Arminio", email = "patrick.arminio@gmail.com" }]
 requires-python = ">=3.11"
 dependencies = [
-    "cross-web>=0.4.0",
+    "cross-web>=0.7.0",
     "passlib[bcrypt]>=1.7.4",
     "pydantic[email]>=2.11.3",
     "bcrypt>=4.0.0,<5.0.0",

--- a/src/cross_auth/_auth_flow.py
+++ b/src/cross_auth/_auth_flow.py
@@ -6,7 +6,7 @@ import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Any, Literal, NamedTuple, cast
 
-from cross_web import AsyncHTTPRequest
+from cross_web import HTTPRequest
 from pydantic import BaseModel, HttpUrl, TypeAdapter, ValidationError
 
 from ._context import Context
@@ -151,7 +151,7 @@ def _generate_provider_pkce(
     return verifier, calculate_s256_challenge(verifier), "S256"
 
 
-def _proxy_redirect_uri(request: AsyncHTTPRequest, context: Context) -> str:
+def _proxy_redirect_uri(request: HTTPRequest, context: Context) -> str:
     return construct_relative_url(str(request.url), "callback", context.base_url)
 
 
@@ -189,9 +189,9 @@ def _same_id(left: Any, right: Any) -> bool:
     return str(left) == str(right)
 
 
-async def disconnect_provider(
+def disconnect_provider(
     provider: OAuth2Provider,
-    request: AsyncHTTPRequest,
+    request: HTTPRequest,
     context: Context,
 ) -> Response:
     """DELETE /{provider}/social-accounts[/{social_account_id}] — detach account."""
@@ -237,7 +237,7 @@ async def disconnect_provider(
         )
 
     try:
-        await context.hooks.run_before_async(
+        context.hooks.run_before(
             "oauth.disconnect",
             BeforeOAuthDisconnectEvent(
                 provider=provider,
@@ -267,7 +267,7 @@ async def disconnect_provider(
 
     context.accounts_storage.delete_social_account(social_account.id)
 
-    await context.hooks.run_after_async(
+    context.hooks.run_after(
         "oauth.disconnect",
         AfterOAuthDisconnectEvent(
             provider=provider,
@@ -286,9 +286,9 @@ async def disconnect_provider(
     )
 
 
-async def start_session_flow(
+def start_session_flow(
     provider: OAuth2Provider,
-    request: AsyncHTTPRequest,
+    request: HTTPRequest,
     context: Context,
 ) -> Response:
     """GET /{provider}/login — start a session (cookie) login flow.
@@ -326,9 +326,9 @@ async def start_session_flow(
     return Response.redirect(authorization_url)
 
 
-async def start_connect_flow(
+def start_connect_flow(
     provider: OAuth2Provider,
-    request: AsyncHTTPRequest,
+    request: HTTPRequest,
     context: Context,
 ) -> Response:
     """GET /{provider}/connect — logged-in user attaches a social account.
@@ -376,9 +376,9 @@ async def start_connect_flow(
     return Response.redirect(authorization_url)
 
 
-async def start_token_flow(
+def start_token_flow(
     provider: OAuth2Provider,
-    request: AsyncHTTPRequest,
+    request: HTTPRequest,
     context: Context,
 ) -> Response:
     """GET /{provider}/authorize — start an OAuth authorization-code flow for a client app."""
@@ -466,7 +466,7 @@ async def start_token_flow(
     )
 
     try:
-        authorize_event = await context.hooks.run_before_async(
+        authorize_event = context.hooks.run_before(
             "oauth.authorize",
             authorize_event,
         )
@@ -505,7 +505,7 @@ async def start_token_flow(
         login_hint=authorize_event.login_hint,
     )
 
-    await context.hooks.run_after_async(
+    context.hooks.run_after(
         "oauth.authorize",
         AfterOAuthAuthorizeEvent(
             provider=provider,
@@ -524,9 +524,9 @@ async def start_token_flow(
     return Response.redirect(authorization_url)
 
 
-async def handle_callback(
+def handle_callback(
     provider: OAuth2Provider,
-    request: AsyncHTTPRequest,
+    request: HTTPRequest,
     context: Context,
 ) -> Response:
     """GET/POST /{provider}/callback — provider redirects back here.
@@ -540,20 +540,20 @@ async def handle_callback(
     callback variants) and post-process the final redirect via
     `finalize_redirect`.
     """
-    if intercepted := await provider.intercept_callback(request, context):
+    if intercepted := provider.intercept_callback(request, context):
         return intercepted
 
-    response = await _handle_oauth_callback(provider, request, context)
-    return await provider.finalize_redirect(request, response)
+    response = _handle_oauth_callback(provider, request, context)
+    return provider.finalize_redirect(request, response)
 
 
-async def _handle_oauth_callback(
+def _handle_oauth_callback(
     provider: OAuth2Provider,
-    request: AsyncHTTPRequest,
+    request: HTTPRequest,
     context: Context,
 ) -> Response:
     """Handle the standard OAuth callback path after provider interception."""
-    callback_data = await provider.extract_callback_params(request)
+    callback_data = provider.extract_callback_params(request)
     state = callback_data.state
     auth_request = _load_auth_request(context, state) if state else None
 
@@ -639,7 +639,7 @@ async def _handle_oauth_callback(
             validated_user_info=validated,
         )
         try:
-            callback_event = await context.hooks.run_before_async(
+            callback_event = context.hooks.run_before(
                 "oauth.callback",
                 callback_event,
             )
@@ -693,7 +693,7 @@ async def _handle_oauth_callback(
                 status_code=e.status_code,
             )
 
-        await context.hooks.run_after_async(
+        context.hooks.run_after(
             "oauth.callback",
             AfterOAuthCallbackEvent(
                 provider=provider,
@@ -721,7 +721,7 @@ async def _handle_oauth_callback(
     if auth_request.flow == "token":
         code, response = _complete_token(auth_request, resolved_user.user, context)
         assert auth_request.client_redirect_uri is not None
-        await context.hooks.run_after_async(
+        context.hooks.run_after(
             "oauth.callback",
             AfterOAuthCallbackEvent(
                 provider=provider,
@@ -1059,9 +1059,9 @@ def _complete_link(
     )
 
 
-async def start_link_flow(
+def start_link_flow(
     provider: OAuth2Provider,
-    request: AsyncHTTPRequest,
+    request: HTTPRequest,
     context: Context,
 ) -> Response:
     """POST /{provider}/link — logged-in user starts an account-linking flow.
@@ -1084,7 +1084,7 @@ async def start_link_flow(
         )
 
     try:
-        link_request = InitiateLinkRequest.model_validate_json(await request.get_body())
+        link_request = InitiateLinkRequest.model_validate_json(request.body)
     except (json.JSONDecodeError, ValidationError) as e:
         logger.error("Invalid request body: %s", e)
         return Response.error(
@@ -1100,7 +1100,7 @@ async def start_link_flow(
         return Response.error("invalid_client", error_description="Invalid client_id")
 
     try:
-        await context.hooks.run_before_async(
+        context.hooks.run_before(
             "oauth.link",
             BeforeOAuthLinkEvent(
                 provider=provider,
@@ -1142,7 +1142,7 @@ async def start_link_flow(
         code_challenge_method=challenge_method,
     )
 
-    await context.hooks.run_after_async(
+    context.hooks.run_after(
         "oauth.link",
         AfterOAuthLinkEvent(
             provider=provider,
@@ -1163,9 +1163,9 @@ async def start_link_flow(
     )
 
 
-async def finalize_link(
+def finalize_link(
     provider: OAuth2Provider,
-    request: AsyncHTTPRequest,
+    request: HTTPRequest,
     context: Context,
 ) -> Response:
     """POST /{provider}/finalize-link — client redeems a link_code."""
@@ -1176,7 +1176,7 @@ async def finalize_link(
         )
 
     try:
-        request_data = json.loads(await request.get_body())
+        request_data = json.loads(request.body)
     except json.JSONDecodeError as e:
         logger.error("Invalid request body: %s", e)
         return Response.error(
@@ -1255,7 +1255,7 @@ async def finalize_link(
         validated_user_info=validated,
     )
     try:
-        finalize_event = await context.hooks.run_before_async(
+        finalize_event = context.hooks.run_before(
             "oauth.finalize_link",
             finalize_event,
         )
@@ -1329,7 +1329,7 @@ async def finalize_link(
         )
         created_social_account = social_account
 
-    await context.hooks.run_after_async(
+    context.hooks.run_after(
         "oauth.finalize_link",
         AfterOAuthFinalizeLinkEvent(
             provider=provider,

--- a/src/cross_auth/_context.py
+++ b/src/cross_auth/_context.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from urllib.parse import urlparse
 
-from cross_web import AsyncHTTPRequest, Cookie
+from cross_web import HTTPRequest, Cookie
 
 from ._config import Config
 from ._session import SessionConfig, create_session, make_session_cookie, resolve_config
@@ -18,7 +18,7 @@ class Context:
         create_token: Callable[[str], tuple[str, int]],
         # TODO: this doesn't allow to use the library as an Identity Provider
         trusted_origins: list[str],
-        get_user_from_request: Callable[[AsyncHTTPRequest], User | None],
+        get_user_from_request: Callable[[HTTPRequest], User | None],
         base_url: str | None = None,
         config: Config | None = None,
         session_enabled: bool = False,

--- a/src/cross_auth/_issuer.py
+++ b/src/cross_auth/_issuer.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Annotated, Literal
 
-from cross_web import AsyncHTTPRequest, Response
+from cross_web import HTTPRequest, Response
 from pydantic import AwareDatetime, BaseModel, Discriminator, Field, ValidationError
 from pydantic.type_adapter import TypeAdapter
 
@@ -142,11 +142,15 @@ class Issuer:
 
         return self._error_response(error_type, message)
 
-    async def token(self, request: AsyncHTTPRequest, context: Context) -> Response:
-        form_data = await request.get_form_data()
+    def token(
+        self,
+        request: HTTPRequest,
+        context: Context,
+    ) -> Response:
+        input_data = dict(request.post_data)
 
         try:
-            token_request = TokenRequestAdapter.validate_python(form_data.form)
+            token_request = TokenRequestAdapter.validate_python(input_data)
         except ValidationError as e:
             return self._format_validation_error(e)
 
@@ -154,11 +158,11 @@ class Issuer:
         # TODO: support confidential clients (client_secret)
 
         if isinstance(token_request, AuthorizationCodeGrantRequest):
-            return await self._authorization_code_grant(token_request, context)
+            return self._authorization_code_grant(token_request, context)
         elif isinstance(token_request, PasswordGrantRequest):
-            return await self._password_grant(token_request, context)
+            return self._password_grant(token_request, context)
 
-    async def _authorization_code_grant(
+    def _authorization_code_grant(
         self, request: AuthorizationCodeGrantRequest, context: Context
     ) -> Response:
         code = request.code
@@ -218,7 +222,7 @@ class Issuer:
             )
 
         try:
-            await context.hooks.run_before_async(
+            context.hooks.run_before(
                 "token.authorization_code",
                 BeforeTokenAuthorizationCodeEvent(
                     client_id=authorization_data.client_id,
@@ -241,7 +245,7 @@ class Issuer:
             scope="",
         )
 
-        await context.hooks.run_after_async(
+        context.hooks.run_after(
             "token.authorization_code",
             AfterTokenAuthorizationCodeEvent(
                 request=request,
@@ -264,13 +268,13 @@ class Issuer:
             cookies=[],
         )
 
-    async def _password_grant(
+    def _password_grant(
         self, request: PasswordGrantRequest, context: Context
     ) -> Response:
         user = context.accounts_storage.find_user_by_email(request.username)
 
         try:
-            await context.hooks.run_before_async(
+            context.hooks.run_before(
                 "token.password",
                 BeforeTokenPasswordEvent(
                     client_id=request.client_id,
@@ -307,7 +311,7 @@ class Issuer:
             scope="",
         )
 
-        await context.hooks.run_after_async(
+        context.hooks.run_after(
             "token.password",
             AfterTokenPasswordEvent(
                 request=request,
@@ -341,6 +345,7 @@ class Issuer:
                 response_model=TokenResponse,
                 operation_id="token",
                 request_type=TokenRequest,
+                read_form_data=True,
                 summary="OAuth 2.0 token endpoint",
                 openapi={
                     "requestBody": {

--- a/src/cross_auth/_request.py
+++ b/src/cross_auth/_request.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from cross_web import (
+    AsyncHTTPRequest,
+    FormData,
+    HTTPRequest,
+    SyncHTTPRequestAdapter,
+)
+from cross_web.request._base import HTTPMethod, PathParams, QueryParams
+
+
+# FastAPI/Starlette expose body and form parsing as async operations. Routes preload
+# those values in async dependencies, then this adapter presents the remaining
+# request data through cross-web's sync HTTPRequest API for handlers and hooks.
+class HTTPRequestAdapter(SyncHTTPRequestAdapter):
+    def __init__(
+        self,
+        request: AsyncHTTPRequest,
+        *,
+        body: str | bytes = b"",
+        form_data: FormData | None = None,
+    ) -> None:
+        self._request = request
+        self._body = body
+        self._form_data = form_data or FormData(files={}, form={})
+
+    @property
+    def method(self) -> HTTPMethod:
+        return self._request.method
+
+    @property
+    def query_params(self) -> QueryParams:
+        return self._request.query_params
+
+    @property
+    def path_params(self) -> PathParams:
+        return self._request.path_params
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        return self._request.headers
+
+    @property
+    def content_type(self) -> str | None:
+        return self._request.content_type
+
+    @property
+    def body(self) -> str | bytes:
+        return self._body
+
+    @property
+    def post_data(self) -> Mapping[str, str | bytes]:
+        return self._form_data.form
+
+    @property
+    def files(self) -> Mapping[str, Any]:
+        return self._form_data.files
+
+    def get_form_data(self) -> FormData:
+        return self._form_data
+
+    @property
+    def url(self) -> str:
+        return self._request.url
+
+    @property
+    def cookies(self) -> Mapping[str, str]:
+        return self._request.cookies
+
+
+def make_http_request(
+    request: AsyncHTTPRequest,
+    *,
+    body: str | bytes = b"",
+    form_data: FormData | None = None,
+) -> HTTPRequest:
+    return HTTPRequest(HTTPRequestAdapter(request, body=body, form_data=form_data))

--- a/src/cross_auth/_route.py
+++ b/src/cross_auth/_route.py
@@ -74,6 +74,20 @@ def _body_to_form_data(body: Any) -> FormData:
     return FormData(files={}, form={})
 
 
+def _form_data_request_body_openapi() -> dict[str, Any]:
+    return {
+        "content": {
+            "application/x-www-form-urlencoded": {
+                "schema": {
+                    "additionalProperties": True,
+                    "type": "object",
+                    "title": "Form Data",
+                }
+            }
+        }
+    }
+
+
 class Route:
     def __init__(
         self,
@@ -152,10 +166,14 @@ class Route:
         return wrapper
 
     def get_openapi_extra(self) -> dict[str, Any] | None:
-        if not self.path_parameters:
-            return self.openapi
-
         openapi = dict(self.openapi or {})
+
+        if self.read_form_data and "requestBody" not in openapi:
+            openapi["requestBody"] = _form_data_request_body_openapi()
+
+        if not self.path_parameters:
+            return openapi or None
+
         path_parameter_keys = {
             (parameter["name"], parameter["in"]) for parameter in self.path_parameters
         }

--- a/src/cross_auth/_route.py
+++ b/src/cross_auth/_route.py
@@ -1,10 +1,13 @@
-from collections.abc import Awaitable, Callable
+import json
+from collections.abc import Callable
 from typing import Annotated, Any, Literal, TypedDict, get_args
+from urllib.parse import parse_qsl
 
-from cross_web import AsyncHTTPRequest, Response
+from cross_web import AsyncHTTPRequest, FormData, Response
 from pydantic import BaseModel
 
 from ._context import Context
+from ._request import make_http_request
 
 
 class Form:
@@ -39,15 +42,49 @@ def _get_fastapi_request_type(route: "Route") -> Any:
     return RequestType
 
 
+def _body_to_bytes(body: Any) -> bytes:
+    if body is None:
+        return b""
+
+    if isinstance(body, bytes):
+        return body
+
+    if isinstance(body, str):
+        return body.encode()
+
+    return json.dumps(body).encode()
+
+
+def _body_to_form_data(body: Any) -> FormData:
+    if body is None:
+        return FormData(files={}, form={})
+
+    if isinstance(body, bytes):
+        return FormData(
+            files={},
+            form=dict(parse_qsl(body.decode(), keep_blank_values=True)),
+        )
+
+    if isinstance(body, str):
+        return FormData(files={}, form=dict(parse_qsl(body, keep_blank_values=True)))
+
+    if isinstance(body, dict):
+        return FormData(files={}, form=body)
+
+    return FormData(files={}, form={})
+
+
 class Route:
     def __init__(
         self,
         path: str,
         methods: list[str],
-        function: Callable[[AsyncHTTPRequest, Context], Awaitable[Response]],
+        function: Callable[..., Response],
         response_model: type[BaseModel] | None = None,
         operation_id: str | None = None,
         request_type: Any | None = None,
+        read_body: bool = False,
+        read_form_data: bool = False,
         summary: str | None = None,
         openapi: dict[str, Any] | None = None,
         openapi_schemas: dict[str, Any] | None = None,
@@ -59,21 +96,58 @@ class Route:
         self.response_model = response_model
         self.operation_id = operation_id
         self.request_type = request_type
+        self.read_body = read_body
+        self.read_form_data = read_form_data
         self.summary = summary
         self.openapi = openapi
         self.openapi_schemas = openapi_schemas
         self.path_parameters = list(path_parameters or [])
 
     def to_fastapi_endpoint(self, context: Context) -> Callable[..., Any]:
+        from fastapi import Body
         from fastapi import Request as FastAPIRequest
         from fastapi import Response as FastAPIResponse
 
-        async def wrapper(request: FastAPIRequest) -> FastAPIResponse:
-            route_request = AsyncHTTPRequest.from_fastapi(request)
-
-            route_response = await self.function(route_request, context)
+        def run_handler(
+            request: FastAPIRequest,
+            *,
+            body: str | bytes = b"",
+            form_data: FormData | None = None,
+        ) -> FastAPIResponse:
+            async_request = AsyncHTTPRequest.from_fastapi(request)
+            route_request = make_http_request(
+                async_request, body=body, form_data=form_data
+            )
+            route_response = self.function(route_request, context)
 
             return route_response.to_fastapi()
+
+        if self.read_body or self.read_form_data:
+            body_metadata = Body(
+                media_type=(
+                    "application/x-www-form-urlencoded"
+                    if self.read_form_data
+                    else "application/json"
+                )
+            )
+
+            def wrapper(
+                request: FastAPIRequest,
+                body: Annotated[Any, body_metadata] = None,
+            ) -> FastAPIResponse:
+                form_data = (
+                    _body_to_form_data(body)
+                    if self.read_form_data and request.method == "POST"
+                    else None
+                )
+                request_body = _body_to_bytes(body) if self.read_body else b""
+
+                return run_handler(request, body=request_body, form_data=form_data)
+
+            return wrapper
+
+        def wrapper(request: FastAPIRequest) -> FastAPIResponse:
+            return run_handler(request)
 
         return wrapper
 

--- a/src/cross_auth/_session.py
+++ b/src/cross_auth/_session.py
@@ -4,7 +4,7 @@ import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Literal, TypedDict
 
-from cross_web import AsyncHTTPRequest, Cookie
+from cross_web import HTTPRequest, Cookie
 from pydantic import AwareDatetime, BaseModel
 
 from ._storage import AccountsStorage, SecondaryStorage, User
@@ -120,7 +120,7 @@ def make_clear_cookie(
 
 
 def get_current_user(
-    request: AsyncHTTPRequest,
+    request: HTTPRequest,
     storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
     config: SessionConfig | None = None,

--- a/src/cross_auth/fastapi.py
+++ b/src/cross_auth/fastapi.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Literal, overload
 
-from cross_web import AsyncHTTPRequest, Cookie
+from cross_web import AsyncHTTPRequest, Cookie, HTTPRequest
 from cross_web import Response as CrossWebResponse
 from fastapi import HTTPException
 from fastapi import Request as FastAPIRequest
@@ -12,6 +12,7 @@ from fastapi import Response as FastAPIResponse
 from ._config import Config
 from ._context import AccountsStorage, SecondaryStorage, User
 from ._password import authenticate
+from ._request import make_http_request
 from ._session import (
     SessionConfig,
     create_session,
@@ -53,7 +54,6 @@ from .hooks._types import (
     BeforeTokenPasswordHandler,
     HookEventName,
 )
-from .hooks.registry import _event_allows_async
 from .router import AuthRouter
 from .social_providers.oauth import OAuth2Provider
 
@@ -71,7 +71,7 @@ class CrossAuth:
         create_token: Callable[[str], tuple[str, int]],
         trusted_origins: list[str],
         session_config: SessionConfig | None = None,
-        get_user_from_request: Callable[[AsyncHTTPRequest], User | None] | None = None,
+        get_user_from_request: Callable[[HTTPRequest], User | None] | None = None,
         base_url: str | None = None,
         config: Config | None = None,
         default_next_url: str = "/",
@@ -104,7 +104,7 @@ class CrossAuth:
     def router(self) -> AuthRouter:
         return self._router
 
-    def _default_get_user_from_request(self, request: AsyncHTTPRequest) -> User | None:
+    def _default_get_user_from_request(self, request: HTTPRequest) -> User | None:
         return get_current_user(
             request,
             self._storage,
@@ -114,7 +114,7 @@ class CrossAuth:
 
     def _resolve_user(self, request: FastAPIRequest) -> User | None:
         async_request = AsyncHTTPRequest.from_fastapi(request)
-        return self._get_user_from_request(async_request)
+        return self._get_user_from_request(make_http_request(async_request))
 
     def get_current_user(self, request: FastAPIRequest) -> User | None:
         return self._resolve_user(request)
@@ -195,10 +195,8 @@ class CrossAuth:
     def before(
         self, event: HookEventName
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
-        allow_async = _event_allows_async(event)
-
         def decorator(handler: Callable[..., object]) -> Callable[..., object]:
-            self._hooks.register_before(event, handler, allow_async=allow_async)
+            self._hooks.register_before(event, handler)
             return handler
 
         return decorator
@@ -258,10 +256,8 @@ class CrossAuth:
     def after(
         self, event: HookEventName
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
-        allow_async = _event_allows_async(event)
-
         def decorator(handler: Callable[..., object]) -> Callable[..., object]:
-            self._hooks.register_after(event, handler, allow_async=allow_async)
+            self._hooks.register_after(event, handler)
             return handler
 
         return decorator
@@ -340,7 +336,7 @@ class CrossAuth:
     def logout(self, request: FastAPIRequest, *, response: FastAPIResponse) -> None:
         resolved = resolve_config(self._session_config)
         cookie_name = resolved["cookie_name"]
-        hook_request = AsyncHTTPRequest.from_fastapi(request)
+        hook_request = make_http_request(AsyncHTTPRequest.from_fastapi(request))
         hook_response = self._make_hook_response(response)
         event = self._hooks.run_before(
             "logout",

--- a/src/cross_auth/hooks/_types.py
+++ b/src/cross_auth/hooks/_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from typing import Literal, TypeAlias
 
 from .events import (
@@ -39,7 +39,6 @@ HookEventName: TypeAlias = Literal[
     "token.authorization_code",
 ]
 
-_SYNC_EVENT_NAMES: frozenset[str] = frozenset({"authenticate", "login", "logout"})
 _ALL_EVENT_NAMES: frozenset[str] = frozenset(
     {
         "authenticate",
@@ -78,54 +77,34 @@ AfterLogoutHandler: TypeAlias = Callable[[AfterLogoutEvent], None]
 
 BeforeOAuthAuthorizeHandler: TypeAlias = Callable[
     [BeforeOAuthAuthorizeEvent],
-    BeforeOAuthAuthorizeEvent | Awaitable[BeforeOAuthAuthorizeEvent | None] | None,
+    BeforeOAuthAuthorizeEvent | None,
 ]
-AfterOAuthAuthorizeHandler: TypeAlias = Callable[
-    [AfterOAuthAuthorizeEvent], Awaitable[None] | None
-]
+AfterOAuthAuthorizeHandler: TypeAlias = Callable[[AfterOAuthAuthorizeEvent], None]
 
 BeforeOAuthCallbackHandler: TypeAlias = Callable[
     [BeforeOAuthCallbackEvent],
-    BeforeOAuthCallbackEvent | Awaitable[BeforeOAuthCallbackEvent | None] | None,
+    BeforeOAuthCallbackEvent | None,
 ]
-AfterOAuthCallbackHandler: TypeAlias = Callable[
-    [AfterOAuthCallbackEvent], Awaitable[None] | None
-]
+AfterOAuthCallbackHandler: TypeAlias = Callable[[AfterOAuthCallbackEvent], None]
 
-BeforeOAuthLinkHandler: TypeAlias = Callable[
-    [BeforeOAuthLinkEvent], Awaitable[None] | None
-]
-AfterOAuthLinkHandler: TypeAlias = Callable[
-    [AfterOAuthLinkEvent], Awaitable[None] | None
-]
+BeforeOAuthLinkHandler: TypeAlias = Callable[[BeforeOAuthLinkEvent], None]
+AfterOAuthLinkHandler: TypeAlias = Callable[[AfterOAuthLinkEvent], None]
 
 BeforeOAuthFinalizeLinkHandler: TypeAlias = Callable[
     [BeforeOAuthFinalizeLinkEvent],
-    BeforeOAuthFinalizeLinkEvent
-    | Awaitable[BeforeOAuthFinalizeLinkEvent | None]
-    | None,
+    BeforeOAuthFinalizeLinkEvent | None,
 ]
-AfterOAuthFinalizeLinkHandler: TypeAlias = Callable[
-    [AfterOAuthFinalizeLinkEvent], Awaitable[None] | None
-]
+AfterOAuthFinalizeLinkHandler: TypeAlias = Callable[[AfterOAuthFinalizeLinkEvent], None]
 
-BeforeOAuthDisconnectHandler: TypeAlias = Callable[
-    [BeforeOAuthDisconnectEvent], Awaitable[None] | None
-]
-AfterOAuthDisconnectHandler: TypeAlias = Callable[
-    [AfterOAuthDisconnectEvent], Awaitable[None] | None
-]
+BeforeOAuthDisconnectHandler: TypeAlias = Callable[[BeforeOAuthDisconnectEvent], None]
+AfterOAuthDisconnectHandler: TypeAlias = Callable[[AfterOAuthDisconnectEvent], None]
 
-BeforeTokenPasswordHandler: TypeAlias = Callable[
-    [BeforeTokenPasswordEvent], Awaitable[None] | None
-]
-AfterTokenPasswordHandler: TypeAlias = Callable[
-    [AfterTokenPasswordEvent], Awaitable[None] | None
-]
+BeforeTokenPasswordHandler: TypeAlias = Callable[[BeforeTokenPasswordEvent], None]
+AfterTokenPasswordHandler: TypeAlias = Callable[[AfterTokenPasswordEvent], None]
 
 BeforeTokenAuthorizationCodeHandler: TypeAlias = Callable[
-    [BeforeTokenAuthorizationCodeEvent], Awaitable[None] | None
+    [BeforeTokenAuthorizationCodeEvent], None
 ]
 AfterTokenAuthorizationCodeHandler: TypeAlias = Callable[
-    [AfterTokenAuthorizationCodeEvent], Awaitable[None] | None
+    [AfterTokenAuthorizationCodeEvent], None
 ]

--- a/src/cross_auth/hooks/events.py
+++ b/src/cross_auth/hooks/events.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
-    from cross_web import AsyncHTTPRequest, Cookie, Response
+    from cross_web import HTTPRequest, Cookie, Response
 
     from .._auth_flow import AuthRequest, InitiateLinkRequest, LinkCodeData
     from .._issuer import (
@@ -52,14 +52,14 @@ class AfterLoginEvent:
 
 @dataclass(frozen=True, slots=True)
 class BeforeLogoutEvent:
-    request: AsyncHTTPRequest
+    request: HTTPRequest
     response: Response
     session_id: str | None
 
 
 @dataclass(frozen=True, slots=True)
 class AfterLogoutEvent:
-    request: AsyncHTTPRequest
+    request: HTTPRequest
     response: Response
     session_id: str | None
 
@@ -67,14 +67,14 @@ class AfterLogoutEvent:
 @dataclass(frozen=True, slots=True)
 class BeforeOAuthAuthorizeEvent:
     provider: OAuth2Provider
-    request: AsyncHTTPRequest
+    request: HTTPRequest
     login_hint: str | None
 
 
 @dataclass(frozen=True, slots=True)
 class AfterOAuthAuthorizeEvent:
     provider: OAuth2Provider
-    request: AsyncHTTPRequest
+    request: HTTPRequest
     redirect_uri: str
     client_id: str
     client_state: str | None
@@ -88,7 +88,7 @@ class AfterOAuthAuthorizeEvent:
 @dataclass(frozen=True, slots=True)
 class BeforeOAuthCallbackEvent:
     provider: OAuth2Provider
-    request: AsyncHTTPRequest
+    request: HTTPRequest
     user_info: UserInfo
     validated_user_info: ValidatedUserInfo
 
@@ -96,7 +96,7 @@ class BeforeOAuthCallbackEvent:
 @dataclass(frozen=True, slots=True)
 class AfterOAuthCallbackEvent:
     provider: OAuth2Provider
-    request: AsyncHTTPRequest
+    request: HTTPRequest
     auth_request: AuthRequest
     callback_data: CallbackData
     token_response: TokenResponse
@@ -114,14 +114,14 @@ class AfterOAuthCallbackEvent:
 @dataclass(frozen=True, slots=True)
 class BeforeOAuthLinkEvent:
     provider: OAuth2Provider
-    request: AsyncHTTPRequest
+    request: HTTPRequest
     user: User
 
 
 @dataclass(frozen=True, slots=True)
 class AfterOAuthLinkEvent:
     provider: OAuth2Provider
-    request: AsyncHTTPRequest
+    request: HTTPRequest
     user: User
     link_request: InitiateLinkRequest
     state: str
@@ -131,7 +131,7 @@ class AfterOAuthLinkEvent:
 @dataclass(frozen=True, slots=True)
 class BeforeOAuthFinalizeLinkEvent:
     provider: OAuth2Provider
-    request: AsyncHTTPRequest
+    request: HTTPRequest
     user: User
     allow_login: bool
     user_info: UserInfo
@@ -141,7 +141,7 @@ class BeforeOAuthFinalizeLinkEvent:
 @dataclass(frozen=True, slots=True)
 class AfterOAuthFinalizeLinkEvent:
     provider: OAuth2Provider
-    request: AsyncHTTPRequest
+    request: HTTPRequest
     user: User
     link_data: LinkCodeData
     allow_login: bool
@@ -155,7 +155,7 @@ class AfterOAuthFinalizeLinkEvent:
 @dataclass(frozen=True, slots=True)
 class BeforeOAuthDisconnectEvent:
     provider: OAuth2Provider
-    request: AsyncHTTPRequest
+    request: HTTPRequest
     user: User
     social_account: SocialAccount
 
@@ -163,7 +163,7 @@ class BeforeOAuthDisconnectEvent:
 @dataclass(frozen=True, slots=True)
 class AfterOAuthDisconnectEvent:
     provider: OAuth2Provider
-    request: AsyncHTTPRequest
+    request: HTTPRequest
     user: User
     social_account: SocialAccount
 

--- a/src/cross_auth/hooks/registry.py
+++ b/src/cross_auth/hooks/registry.py
@@ -3,23 +3,20 @@ from __future__ import annotations
 import inspect
 import logging
 from collections import defaultdict
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from typing import TypeAlias, TypeVar, cast
 
 from ..exceptions import CrossAuthException
 from ._types import (
     _ALL_EVENT_NAMES,
     _RETURNABLE_BEFORE_EVENT_NAMES,
-    _SYNC_EVENT_NAMES,
     HookEventName,
 )
 
 logger = logging.getLogger(__name__)
 
-_BeforeRuntimeHandler: TypeAlias = Callable[
-    [object], object | Awaitable[object | None] | None
-]
-_AfterRuntimeHandler: TypeAlias = Callable[[object], Awaitable[None] | None]
+_BeforeRuntimeHandler: TypeAlias = Callable[[object], object | None]
+_AfterRuntimeHandler: TypeAlias = Callable[[object], None]
 _EventT = TypeVar("_EventT")
 
 
@@ -32,22 +29,18 @@ class HookRegistry:
         self,
         event: HookEventName,
         handler: Callable[..., object],
-        *,
-        allow_async: bool,
     ) -> None:
         self._validate_event_name(event)
-        self._validate_sync_registration(event, handler, allow_async=allow_async)
+        self._validate_sync_registration(event, handler)
         self._before[event].append(cast(_BeforeRuntimeHandler, handler))
 
     def register_after(
         self,
         event: HookEventName,
         handler: Callable[..., object],
-        *,
-        allow_async: bool,
     ) -> None:
         self._validate_event_name(event)
-        self._validate_sync_registration(event, handler, allow_async=allow_async)
+        self._validate_sync_registration(event, handler)
         self._after[event].append(cast(_AfterRuntimeHandler, handler))
 
     def run_before(self, event: HookEventName, payload: _EventT) -> _EventT:
@@ -57,17 +50,6 @@ class HookRegistry:
             result = handler(current)
             if inspect.isawaitable(result):
                 raise TypeError(f"{event} hooks for sync events must be synchronous")
-            current = self._resolve_before_result(event, current, result)
-
-        return current
-
-    async def run_before_async(self, event: HookEventName, payload: _EventT) -> _EventT:
-        current = payload
-
-        for handler in self._before[event]:
-            result = handler(current)
-            if inspect.isawaitable(result):
-                result = await result
             current = self._resolve_before_result(event, current, result)
 
         return current
@@ -89,30 +71,11 @@ class HookRegistry:
                     exc_info=True,
                 )
 
-    async def run_after_async(self, event: HookEventName, payload: _EventT) -> None:
-        for handler in self._after[event]:
-            try:
-                result = handler(payload)
-                if inspect.isawaitable(result):
-                    result = await result
-                if result is not None:
-                    raise TypeError(f"{event} after hooks must return None")
-            except CrossAuthException:
-                logger.warning(
-                    "Ignoring CrossAuthException raised by after hook for %s",
-                    event,
-                    exc_info=True,
-                )
-
     @staticmethod
     def _validate_sync_registration(
         event: HookEventName,
         handler: Callable[..., object],
-        *,
-        allow_async: bool,
     ) -> None:
-        if allow_async:
-            return
         if inspect.iscoroutinefunction(handler):
             raise TypeError(f"{event} hooks for sync events must be synchronous")
 
@@ -139,10 +102,6 @@ class HookRegistry:
             )
 
         return cast(_EventT, result)
-
-
-def _event_allows_async(event: HookEventName) -> bool:
-    return event not in _SYNC_EVENT_NAMES
 
 
 __all__ = ["HookRegistry"]

--- a/src/cross_auth/router.py
+++ b/src/cross_auth/router.py
@@ -1,9 +1,9 @@
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from functools import partial
 from typing import Any
 
-from cross_web import AsyncHTTPRequest, Response
+from cross_web import HTTPRequest, Response
 from fastapi import APIRouter
 
 from ._auth_flow import (
@@ -26,7 +26,7 @@ from .social_providers.oauth import OAuth2Provider
 logger = logging.getLogger(__name__)
 
 
-FlowHandler = Callable[[OAuth2Provider, AsyncHTTPRequest, Context], Awaitable[Response]]
+FlowHandler = Callable[..., Response]
 
 
 def _provider_routes(provider: OAuth2Provider) -> list[Route]:
@@ -34,7 +34,7 @@ def _provider_routes(provider: OAuth2Provider) -> list[Route]:
 
     def bound(
         handler: FlowHandler,
-    ) -> Callable[[AsyncHTTPRequest, Context], Awaitable[Response]]:
+    ) -> Callable[..., Response]:
         return partial(handler, provider)
 
     return [
@@ -81,18 +81,21 @@ def _provider_routes(provider: OAuth2Provider) -> list[Route]:
             methods=["GET", "POST"],  # POST for Apple (response_mode=form_post)
             function=bound(handle_callback),
             operation_id=f"{provider.id}_callback",
+            read_form_data=True,
         ),
         Route(
             path=f"{prefix}/link",
             methods=["POST"],
             function=bound(start_link_flow),
             operation_id=f"{provider.id}_link",
+            read_body=True,
         ),
         Route(
             path=f"{prefix}/finalize-link",
             methods=["POST"],
             function=bound(finalize_link),
             operation_id=f"{provider.id}_finalize_link",
+            read_body=True,
         ),
     ]
 
@@ -105,7 +108,7 @@ class AuthRouter(APIRouter):
         providers: list[OAuth2Provider],
         secondary_storage: SecondaryStorage,
         accounts_storage: AccountsStorage,
-        get_user_from_request: Callable[[AsyncHTTPRequest], User | None],
+        get_user_from_request: Callable[[HTTPRequest], User | None],
         create_token: Callable[[str], tuple[str, int]],
         trusted_origins: list[str],
         base_url: str | None = None,

--- a/src/cross_auth/social_providers/apple.py
+++ b/src/cross_auth/social_providers/apple.py
@@ -4,7 +4,7 @@ import time
 from typing import Annotated, Any, Literal
 
 import jwt
-from cross_web import AsyncHTTPRequest
+from cross_web import HTTPRequest
 from pydantic import BaseModel, BeforeValidator, EmailStr
 
 from .oauth import (
@@ -150,7 +150,7 @@ class AppleProvider(OIDCProvider):
         state: str,
         redirect_uri: str,
         *,
-        request: AsyncHTTPRequest | None = None,
+        request: HTTPRequest | None = None,
         code_challenge: str | None = None,
         code_challenge_method: str | None = None,
         login_hint: str | None = None,
@@ -219,7 +219,10 @@ class AppleProvider(OIDCProvider):
 
         return info
 
-    async def extract_callback_params(self, request: AsyncHTTPRequest) -> CallbackData:
+    def extract_callback_params(
+        self,
+        request: HTTPRequest,
+    ) -> CallbackData:
         """Extract callback data from Apple's POST form data.
 
         Apple uses response_mode=form_post, so callback data comes via POST.
@@ -230,18 +233,26 @@ class AppleProvider(OIDCProvider):
                 error_description="Apple callback must be POST (response_mode=form_post)",
             )
 
-        form_data = await request.get_form_data()
+        form_data = request.post_data
+
+        def get_form_value(key: str) -> str | None:
+            value = form_data.get(key)
+
+            if isinstance(value, bytes):
+                return value.decode()
+
+            return value
 
         extra: dict[str, Any] = {}
-        if user_json := form_data.form.get("user"):
+        if user_json := get_form_value("user"):
             try:
                 extra["user"] = json.loads(user_json)
             except json.JSONDecodeError:
                 logger.warning("Failed to parse Apple user JSON: %s", user_json)
 
         return CallbackData(
-            code=form_data.form.get("code"),
-            state=form_data.form.get("state"),
-            error=form_data.form.get("error"),
+            code=get_form_value("code"),
+            state=get_form_value("state"),
+            error=get_form_value("error"),
             extra=extra if extra else None,
         )

--- a/src/cross_auth/social_providers/oauth.py
+++ b/src/cross_auth/social_providers/oauth.py
@@ -4,7 +4,7 @@ from typing import Any, ClassVar, NotRequired, TypedDict
 from urllib.parse import urlencode
 
 import httpx
-from cross_web import AsyncHTTPRequest
+from cross_web import HTTPRequest
 from pydantic import BaseModel, ValidationError
 
 from cross_auth.utils._response import Response
@@ -128,7 +128,7 @@ class OAuth2Provider:
         state: str,
         redirect_uri: str,
         *,
-        request: AsyncHTTPRequest | None = None,
+        request: HTTPRequest | None = None,
         code_challenge: str | None = None,
         code_challenge_method: str | None = None,
         login_hint: str | None = None,
@@ -163,7 +163,7 @@ class OAuth2Provider:
         state: str,
         redirect_uri: str,
         *,
-        request: AsyncHTTPRequest | None = None,
+        request: HTTPRequest | None = None,
         code_challenge: str | None = None,
         code_challenge_method: str | None = None,
         login_hint: str | None = None,
@@ -190,9 +190,9 @@ class OAuth2Provider:
 
         return f"{self.authorization_endpoint}?{urlencode(params)}"
 
-    async def intercept_callback(
+    def intercept_callback(
         self,
-        request: AsyncHTTPRequest,
+        request: HTTPRequest,
         context: Context,
     ) -> Response | None:
         """Inspect an incoming callback before the normal OAuth flow runs.
@@ -203,9 +203,9 @@ class OAuth2Provider:
         """
         return None
 
-    async def finalize_redirect(
+    def finalize_redirect(
         self,
-        request: AsyncHTTPRequest,
+        request: HTTPRequest,
         response: Response,
     ) -> Response:
         """Post-process the Response a flow handler is about to return.
@@ -216,7 +216,10 @@ class OAuth2Provider:
         """
         return response
 
-    async def extract_callback_params(self, request: AsyncHTTPRequest) -> CallbackData:
+    def extract_callback_params(
+        self,
+        request: HTTPRequest,
+    ) -> CallbackData:
         """Extract code, state, and error from callback request.
 
         Override for providers that use POST (e.g., Apple with response_mode=form_post).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
 import pytest
-from cross_web import AsyncHTTPRequest
+from cross_web import HTTPRequest
 from passlib.context import CryptContext
 
 from cross_auth._context import Context
@@ -268,7 +268,7 @@ def context(
     accounts_storage: AccountsStorage,
     logged_in_user: User,
 ) -> Context:
-    def _get_user_from_request(request: AsyncHTTPRequest) -> UserProtocol | None:
+    def _get_user_from_request(request: HTTPRequest) -> UserProtocol | None:
         if request.headers.get("Authorization") == "Bearer test":
             return cast(UserProtocol, logged_in_user)
 

--- a/tests/fastapi/test_hooks.py
+++ b/tests/fastapi/test_hooks.py
@@ -6,7 +6,7 @@ from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
-from cross_web import AsyncHTTPRequest, Response as CrossWebResponse
+from cross_web import HTTPRequest, Response as CrossWebResponse
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
@@ -143,13 +143,13 @@ def test_logout_hooks(
 
     @auth.before("logout")
     def capture_before(event: BeforeLogoutEvent) -> None:
-        assert isinstance(event.request, AsyncHTTPRequest)
+        assert isinstance(event.request, HTTPRequest)
         assert isinstance(event.response, CrossWebResponse)
         seen["before"] = event.session_id
 
     @auth.after("logout")
     def capture_after(event: AfterLogoutEvent) -> None:
-        assert isinstance(event.request, AsyncHTTPRequest)
+        assert isinstance(event.request, HTTPRequest)
         assert isinstance(event.response, CrossWebResponse)
         seen["after"] = event.session_id
 
@@ -226,8 +226,7 @@ def test_sync_events_reject_async_hooks(
         auth.before("login")(cast(Any, invalid_hook))
 
 
-@pytest.mark.asyncio
-async def test_policy_only_before_hooks_reject_replacement():
+def test_policy_only_before_hooks_reject_replacement():
     hooks = HookRegistry()
     event = BeforeTokenPasswordEvent(
         client_id="client",
@@ -236,7 +235,7 @@ async def test_policy_only_before_hooks_reject_replacement():
         scope=None,
     )
 
-    async def replace_event(
+    def replace_event(
         event: BeforeTokenPasswordEvent,
     ) -> BeforeTokenPasswordEvent:
         return event
@@ -244,15 +243,13 @@ async def test_policy_only_before_hooks_reject_replacement():
     hooks.register_before(
         "token.password",
         cast(Any, replace_event),
-        allow_async=True,
     )
 
     with pytest.raises(TypeError, match="token.password before hooks must return None"):
-        await hooks.run_before_async("token.password", event)
+        hooks.run_before("token.password", event)
 
 
-@pytest.mark.asyncio
-async def test_oauth_authorize_hooks(
+def test_oauth_authorize_hooks(
     secondary_storage,
     accounts_storage,
     oauth_provider,
@@ -265,13 +262,13 @@ async def test_oauth_authorize_hooks(
     seen: dict[str, str] = {}
 
     @auth.before("oauth.authorize")
-    async def apply_login_hint(
+    def apply_login_hint(
         event: BeforeOAuthAuthorizeEvent,
     ) -> BeforeOAuthAuthorizeEvent:
         return replace(event, login_hint="hooked@example.com")
 
     @auth.after("oauth.authorize")
-    async def capture_authorization_url(event: AfterOAuthAuthorizeEvent) -> None:
+    def capture_authorization_url(event: AfterOAuthAuthorizeEvent) -> None:
         seen["authorization_url"] = event.authorization_url
         seen["state"] = event.state
 
@@ -302,8 +299,7 @@ async def test_oauth_authorize_hooks(
     assert json.loads(stored)["client_id"] == "original-client"
 
 
-@pytest.mark.asyncio
-async def test_oauth_callback_hooks(
+def test_oauth_callback_hooks(
     secondary_storage,
     accounts_storage,
     oauth_provider,
@@ -332,7 +328,7 @@ async def test_oauth_callback_hooks(
     )
 
     @auth.before("oauth.callback")
-    async def rewrite_email(
+    def rewrite_email(
         event: BeforeOAuthCallbackEvent,
     ) -> BeforeOAuthCallbackEvent:
         user_info = {
@@ -347,7 +343,7 @@ async def test_oauth_callback_hooks(
         return replace(event, user_info=user_info, validated_user_info=validated)
 
     @auth.after("oauth.callback")
-    async def capture_created_user(event: AfterOAuthCallbackEvent) -> None:
+    def capture_created_user(event: AfterOAuthCallbackEvent) -> None:
         if event.created_user is not None:
             seen["email"] = event.created_user.email
 
@@ -387,8 +383,7 @@ async def test_oauth_callback_hooks(
     assert accounts_storage.find_user_by_email("hooked@example.com") is not None
 
 
-@pytest.mark.asyncio
-async def test_oauth_callback_hooks_run_for_session_flow(
+def test_oauth_callback_hooks_run_for_session_flow(
     secondary_storage,
     accounts_storage,
     oauth_provider,
@@ -402,7 +397,7 @@ async def test_oauth_callback_hooks_run_for_session_flow(
     seen: dict[str, str] = {}
 
     @auth.before("oauth.callback")
-    async def rewrite_session_email(
+    def rewrite_session_email(
         event: BeforeOAuthCallbackEvent,
     ) -> BeforeOAuthCallbackEvent:
         user_info = {
@@ -417,7 +412,7 @@ async def test_oauth_callback_hooks_run_for_session_flow(
         return replace(event, user_info=user_info, validated_user_info=validated)
 
     @auth.after("oauth.callback")
-    async def capture_session_callback(event: AfterOAuthCallbackEvent) -> None:
+    def capture_session_callback(event: AfterOAuthCallbackEvent) -> None:
         assert event.authorization_code is None
         assert event.redirect_uri is None
         if event.created_user is not None:
@@ -467,8 +462,7 @@ async def test_oauth_callback_hooks_run_for_session_flow(
     assert session.user_id == "session-provider-user-id"
 
 
-@pytest.mark.asyncio
-async def test_login_hooks_run_for_oauth_session_flow(
+def test_login_hooks_run_for_oauth_session_flow(
     secondary_storage,
     accounts_storage,
     oauth_provider,
@@ -540,8 +534,7 @@ async def test_login_hooks_run_for_oauth_session_flow(
     assert session.user_id == "oauth-session-user-id"
 
 
-@pytest.mark.asyncio
-async def test_oauth_link_hooks(
+def test_oauth_link_hooks(
     secondary_storage,
     accounts_storage,
     logged_in_user,
@@ -561,7 +554,7 @@ async def test_oauth_link_hooks(
     seen: dict[str, str] = {}
 
     @auth.after("oauth.link")
-    async def capture_state(event: AfterOAuthLinkEvent) -> None:
+    def capture_state(event: AfterOAuthLinkEvent) -> None:
         seen["state"] = event.state
         seen["authorization_url"] = event.authorization_url
 
@@ -588,8 +581,7 @@ async def test_oauth_link_hooks(
     )
 
 
-@pytest.mark.asyncio
-async def test_oauth_finalize_link_hooks(
+def test_oauth_finalize_link_hooks(
     secondary_storage,
     accounts_storage,
     logged_in_user,
@@ -623,13 +615,13 @@ async def test_oauth_finalize_link_hooks(
     )
 
     @auth.before("oauth.finalize_link")
-    async def disable_login_method(
+    def disable_login_method(
         event: BeforeOAuthFinalizeLinkEvent,
     ) -> BeforeOAuthFinalizeLinkEvent:
         return replace(event, allow_login=False)
 
     @auth.after("oauth.finalize_link")
-    async def capture_login_mode(event: AfterOAuthFinalizeLinkEvent) -> None:
+    def capture_login_mode(event: AfterOAuthFinalizeLinkEvent) -> None:
         seen["is_login_method"] = event.social_account.is_login_method
 
     respx_mock.post(oauth_provider.token_endpoint).mock(
@@ -667,8 +659,7 @@ async def test_oauth_finalize_link_hooks(
     assert seen == {"is_login_method": False}
 
 
-@pytest.mark.asyncio
-async def test_token_hooks(
+def test_token_hooks(
     secondary_storage,
     accounts_storage,
 ):
@@ -677,7 +668,7 @@ async def test_token_hooks(
     seen: dict[str, str] = {}
 
     @auth.before("token.password")
-    async def block_legacy_password_grant(event: BeforeTokenPasswordEvent) -> None:
+    def block_legacy_password_grant(event: BeforeTokenPasswordEvent) -> None:
         nonlocal blocked
         blocked = True
         if event.client_id == "legacy-spa":
@@ -687,7 +678,7 @@ async def test_token_hooks(
             )
 
     @auth.after("token.authorization_code")
-    async def capture_auth_code_token(event: AfterTokenAuthorizationCodeEvent) -> None:
+    def capture_auth_code_token(event: AfterTokenAuthorizationCodeEvent) -> None:
         seen["access_token"] = event.token_response.access_token
         raise CrossAuthException("invalid_grant", "ignored after hook failure")
 

--- a/tests/fastapi/test_router.py
+++ b/tests/fastapi/test_router.py
@@ -48,6 +48,16 @@ def test_router(test_app: FastAPI):
                                     }
                                 },
                             },
+                            "422": {
+                                "description": "Validation Error",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/HTTPValidationError"
+                                        }
+                                    }
+                                },
+                            },
                             "400": {
                                 "description": "Bad request - invalid parameters or grant",
                                 "content": {
@@ -127,6 +137,24 @@ def test_router(test_app: FastAPI):
                         },
                         "type": "object",
                         "title": "HTTPValidationError",
+                    },
+                    "ValidationError": {
+                        "properties": {
+                            "loc": {
+                                "items": {
+                                    "anyOf": [{"type": "string"}, {"type": "integer"}]
+                                },
+                                "type": "array",
+                                "title": "Location",
+                            },
+                            "msg": {"type": "string", "title": "Message"},
+                            "type": {"type": "string", "title": "Error Type"},
+                            "input": {"title": "Input"},
+                            "ctx": {"type": "object", "title": "Context"},
+                        },
+                        "type": "object",
+                        "required": ["loc", "msg", "type"],
+                        "title": "ValidationError",
                     },
                     "PasswordGrantRequest": {
                         "properties": {

--- a/tests/providers/test_oauth_authorize.py
+++ b/tests/providers/test_oauth_authorize.py
@@ -1,12 +1,10 @@
 import pytest
-from cross_web import AsyncHTTPRequest, TestingRequestAdapter
+from cross_web import HTTPRequest, TestingHTTPRequestAdapter
 
 from cross_auth._auth_flow import AuthRequest, start_token_flow
 from cross_auth._context import Context
 from cross_auth._storage import SecondaryStorage
 from cross_auth.social_providers.oauth import OAuth2Provider
-
-pytestmark = pytest.mark.asyncio
 
 
 @pytest.mark.parametrize(
@@ -16,11 +14,11 @@ pytestmark = pytest.mark.asyncio
         {"response_type": "invalid"},
     ],
 )
-async def test_invalid_request_when_response_type_is_missing_or_invalid(
+def test_invalid_request_when_response_type_is_missing_or_invalid(
     oauth_provider: OAuth2Provider, context: Context, query_params: dict
 ):
-    request = AsyncHTTPRequest(
-        TestingRequestAdapter(
+    request = HTTPRequest(
+        TestingHTTPRequestAdapter(
             method="GET",
             url="http://localhost:8000/test/authorize",
             query_params={
@@ -31,7 +29,7 @@ async def test_invalid_request_when_response_type_is_missing_or_invalid(
         )
     )
 
-    response = await start_token_flow(oauth_provider, request, context)
+    response = start_token_flow(oauth_provider, request, context)
 
     assert response.status_code == 302
     assert response.headers is not None
@@ -39,13 +37,13 @@ async def test_invalid_request_when_response_type_is_missing_or_invalid(
     assert "error=invalid_request" in response.headers["Location"]
 
 
-async def test_authorize_redirects_to_provider(
+def test_authorize_redirects_to_provider(
     oauth_provider: OAuth2Provider,
     context: Context,
     secondary_storage: SecondaryStorage,
 ):
-    request = AsyncHTTPRequest(
-        TestingRequestAdapter(
+    request = HTTPRequest(
+        TestingHTTPRequestAdapter(
             method="GET",
             url="http://localhost:8000/test/authorize",
             query_params={
@@ -59,7 +57,7 @@ async def test_authorize_redirects_to_provider(
         )
     )
 
-    response = await start_token_flow(oauth_provider, request, context)
+    response = start_token_flow(oauth_provider, request, context)
 
     assert response.status_code == 302
     assert response.headers is not None
@@ -96,26 +94,24 @@ async def test_authorize_redirects_to_provider(
     assert authorization_request_data.client_code_challenge_method == "S256"
 
 
-async def test_authorize_requires_redirect_uri(
+def test_authorize_requires_redirect_uri(
     oauth_provider: OAuth2Provider, context: Context
 ):
-    request = AsyncHTTPRequest(
-        TestingRequestAdapter(
+    request = HTTPRequest(
+        TestingHTTPRequestAdapter(
             method="GET", url="http://localhost:8000/test/authorize", query_params={}
         )
     )
 
-    response = await start_token_flow(oauth_provider, request, context)
+    response = start_token_flow(oauth_provider, request, context)
 
     assert response.status_code == 400
     assert response.json() == {"error": "invalid_request"}
 
 
-async def test_invalid_redirect_uri_error(
-    oauth_provider: OAuth2Provider, context: Context
-):
-    request = AsyncHTTPRequest(
-        TestingRequestAdapter(
+def test_invalid_redirect_uri_error(oauth_provider: OAuth2Provider, context: Context):
+    request = HTTPRequest(
+        TestingHTTPRequestAdapter(
             method="GET",
             url="http://localhost:8000/test/authorize",
             query_params={
@@ -126,21 +122,21 @@ async def test_invalid_redirect_uri_error(
         )
     )
 
-    response = await start_token_flow(oauth_provider, request, context)
+    response = start_token_flow(oauth_provider, request, context)
 
     assert response.status_code == 400
     assert response.json() == {"error": "invalid_redirect_uri"}
 
 
-async def test_link_code_response_type_not_supported(
+def test_link_code_response_type_not_supported(
     oauth_provider: OAuth2Provider, context: Context
 ):
     """
     The authorize endpoint no longer supports response_type=link_code.
     Use POST /{provider}/link instead.
     """
-    request = AsyncHTTPRequest(
-        TestingRequestAdapter(
+    request = HTTPRequest(
+        TestingHTTPRequestAdapter(
             method="GET",
             url="http://localhost:8000/test/authorize",
             query_params={
@@ -155,7 +151,7 @@ async def test_link_code_response_type_not_supported(
         )
     )
 
-    response = await start_token_flow(oauth_provider, request, context)
+    response = start_token_flow(oauth_provider, request, context)
 
     assert response.status_code == 302
     assert response.headers is not None
@@ -164,7 +160,7 @@ async def test_link_code_response_type_not_supported(
     assert "state=client_state_123" in location
 
 
-async def test_authorize_rejects_invalid_client_id(
+def test_authorize_rejects_invalid_client_id(
     oauth_provider: OAuth2Provider,
     secondary_storage: SecondaryStorage,
     accounts_storage,
@@ -175,15 +171,15 @@ async def test_authorize_rejects_invalid_client_id(
         secondary_storage=secondary_storage,
         accounts_storage=accounts_storage,
         create_token=lambda id: (f"token-{id}", 0),
-        get_user_from_request=lambda r: logged_in_user
-        if r.headers.get("Authorization") == "Bearer test"
-        else None,
+        get_user_from_request=lambda r: (
+            logged_in_user if r.headers.get("Authorization") == "Bearer test" else None
+        ),
         trusted_origins=["valid-frontend.com"],
         config={"allowed_client_ids": ["allowed_client"]},
     )
 
-    request = AsyncHTTPRequest(
-        TestingRequestAdapter(
+    request = HTTPRequest(
+        TestingHTTPRequestAdapter(
             method="GET",
             url="http://localhost:8000/test/authorize",
             query_params={
@@ -197,9 +193,7 @@ async def test_authorize_rejects_invalid_client_id(
         )
     )
 
-    response = await start_token_flow(
-        oauth_provider, request, context_with_client_validation
-    )
+    response = start_token_flow(oauth_provider, request, context_with_client_validation)
 
     assert response.status_code == 302
     assert response.headers is not None
@@ -208,7 +202,7 @@ async def test_authorize_rejects_invalid_client_id(
     assert "error_description=Invalid+client_id" in location
 
 
-async def test_authorize_accepts_valid_client_id(
+def test_authorize_accepts_valid_client_id(
     oauth_provider: OAuth2Provider,
     secondary_storage: SecondaryStorage,
     accounts_storage,
@@ -219,15 +213,15 @@ async def test_authorize_accepts_valid_client_id(
         secondary_storage=secondary_storage,
         accounts_storage=accounts_storage,
         create_token=lambda id: (f"token-{id}", 0),
-        get_user_from_request=lambda r: logged_in_user
-        if r.headers.get("Authorization") == "Bearer test"
-        else None,
+        get_user_from_request=lambda r: (
+            logged_in_user if r.headers.get("Authorization") == "Bearer test" else None
+        ),
         trusted_origins=["valid-frontend.com"],
         config={"allowed_client_ids": ["allowed_client"]},
     )
 
-    request = AsyncHTTPRequest(
-        TestingRequestAdapter(
+    request = HTTPRequest(
+        TestingHTTPRequestAdapter(
             method="GET",
             url="http://localhost:8000/test/authorize",
             query_params={
@@ -241,9 +235,7 @@ async def test_authorize_accepts_valid_client_id(
         )
     )
 
-    response = await start_token_flow(
-        oauth_provider, request, context_with_client_validation
-    )
+    response = start_token_flow(oauth_provider, request, context_with_client_validation)
 
     assert response.status_code == 302
     assert response.headers is not None

--- a/tests/providers/test_provider.py
+++ b/tests/providers/test_provider.py
@@ -3,7 +3,7 @@ import json
 import httpx
 import pytest
 import respx
-from cross_web import AsyncHTTPRequest, TestingRequestAdapter
+from cross_web import HTTPRequest, TestingHTTPRequestAdapter
 
 from cross_auth._auth_flow import handle_callback, start_token_flow
 from cross_auth._context import Context
@@ -77,13 +77,12 @@ def example_provider_with_pkce() -> ExampleProviderWithPKCE:
 
 
 @respx.mock
-@pytest.mark.asyncio
-async def test_pkce_flow_includes_code_verifier(
+def test_pkce_flow_includes_code_verifier(
     example_provider_with_pkce: ExampleProviderWithPKCE,
     context: Context,
 ) -> None:
-    authorize_request = AsyncHTTPRequest(
-        TestingRequestAdapter(
+    authorize_request = HTTPRequest(
+        TestingHTTPRequestAdapter(
             method="GET",
             url="http://localhost:8000/example_pkce/authorize",
             query_params={
@@ -96,7 +95,7 @@ async def test_pkce_flow_includes_code_verifier(
         )
     )
 
-    authorize_response = await start_token_flow(
+    authorize_response = start_token_flow(
         example_provider_with_pkce, authorize_request, context
     )
 
@@ -113,8 +112,8 @@ async def test_pkce_flow_includes_code_verifier(
     assert stored_json["provider_code_verifier"] is not None
     stored_verifier = stored_json["provider_code_verifier"]
 
-    callback_request = AsyncHTTPRequest(
-        TestingRequestAdapter(
+    callback_request = HTTPRequest(
+        TestingHTTPRequestAdapter(
             method="GET",
             url="http://localhost:8000/example_pkce/callback",
             query_params={
@@ -141,7 +140,7 @@ async def test_pkce_flow_includes_code_verifier(
         )
     )
 
-    await handle_callback(example_provider_with_pkce, callback_request, context)
+    handle_callback(example_provider_with_pkce, callback_request, context)
 
     request_data = token_route.calls[0].request.content.decode()
 

--- a/tests/router/conftest.py
+++ b/tests/router/conftest.py
@@ -6,7 +6,7 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 import pytest
 import respx
-from cross_web import AsyncHTTPRequest
+from cross_web import HTTPRequest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -42,7 +42,7 @@ def _bearer_user_resolver(
     the seeded test user in `tests/conftest.py`.
     """
 
-    def resolve(request: AsyncHTTPRequest) -> User | None:
+    def resolve(request: HTTPRequest) -> User | None:
         auth_header = request.headers.get("Authorization") or request.headers.get(
             "authorization"
         )

--- a/tests/router/test_disconnect_flow.py
+++ b/tests/router/test_disconnect_flow.py
@@ -267,12 +267,12 @@ def test_disconnect_runs_hooks(auth: CrossAuth, accounts_storage):
     seen: dict[str, str] = {}
 
     @auth.before("oauth.disconnect")
-    async def capture_before(event: BeforeOAuthDisconnectEvent) -> None:
+    def capture_before(event: BeforeOAuthDisconnectEvent) -> None:
         seen["before_provider"] = event.provider.id
         seen["before_account"] = str(event.social_account.id)
 
     @auth.after("oauth.disconnect")
-    async def capture_after(event: AfterOAuthDisconnectEvent) -> None:
+    def capture_after(event: AfterOAuthDisconnectEvent) -> None:
         seen["after_provider"] = event.provider.id
         seen["after_account"] = str(event.social_account.id)
 
@@ -299,11 +299,11 @@ def test_disconnect_before_hook_can_block(auth: CrossAuth, accounts_storage):
     seen = {"after": False}
 
     @auth.before("oauth.disconnect")
-    async def block_disconnect(event: BeforeOAuthDisconnectEvent) -> None:
+    def block_disconnect(event: BeforeOAuthDisconnectEvent) -> None:
         raise CrossAuthException("disconnect_disabled", "Disconnect disabled")
 
     @auth.after("oauth.disconnect")
-    async def capture_after(event: AfterOAuthDisconnectEvent) -> None:
+    def capture_after(event: AfterOAuthDisconnectEvent) -> None:
         seen["after"] = True
 
     app = FastAPI()

--- a/tests/router/test_provider_hooks.py
+++ b/tests/router/test_provider_hooks.py
@@ -10,7 +10,7 @@ import respx
 from cross_auth._context import Context
 from cross_auth._storage import AccountsStorage, SecondaryStorage
 from cross_auth.utils._response import Response
-from cross_web import AsyncHTTPRequest
+from cross_web import HTTPRequest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -36,7 +36,7 @@ class HookedFakeProvider(FakeProvider):
         state: str,
         redirect_uri: str,
         *,
-        request: AsyncHTTPRequest | None = None,
+        request: HTTPRequest | None = None,
         code_challenge: str | None = None,
         code_challenge_method: str | None = None,
         login_hint: str | None = None,
@@ -53,9 +53,9 @@ class HookedFakeProvider(FakeProvider):
             return url
         return _append_query(url, {"audience": audience})
 
-    async def intercept_callback(
+    def intercept_callback(
         self,
-        request: AsyncHTTPRequest,
+        request: HTTPRequest,
         context: Context,
     ) -> Response | None:
         if request.query_params.get("provider_status") == "pending":
@@ -65,9 +65,9 @@ class HookedFakeProvider(FakeProvider):
             )
         return None
 
-    async def finalize_redirect(
+    def finalize_redirect(
         self,
-        request: AsyncHTTPRequest,
+        request: HTTPRequest,
         response: Response,
     ) -> Response:
         if (

--- a/tests/test_issuer.py
+++ b/tests/test_issuer.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta, timezone
 
-import pytest
-from cross_web import AsyncHTTPRequest
+from cross_web import HTTPRequest
 from inline_snapshot import snapshot
 
 from cross_auth._context import Context
@@ -10,10 +9,8 @@ from cross_auth._storage import SecondaryStorage
 from cross_auth.exceptions import CrossAuthException
 from cross_auth.hooks import BeforeTokenPasswordEvent
 
-pytestmark = pytest.mark.asyncio
 
-
-async def test_issuer(issuer: Issuer):
+def test_issuer(issuer: Issuer):
     (token_route,) = issuer.routes
 
     assert token_route.path == "/token"
@@ -21,11 +18,11 @@ async def test_issuer(issuer: Issuer):
     assert token_route.function == issuer.token
 
 
-async def test_returns_error_response_if_client_id_is_missing(
+def test_returns_error_response_if_client_id_is_missing(
     issuer: Issuer, context: Context
 ):
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(data={"grant_type": "authorization_code"}),
+    response = issuer.token(
+        HTTPRequest.from_form_data(data={"grant_type": "authorization_code"}),
         context,
     )
     assert response.status_code == 400
@@ -34,11 +31,11 @@ async def test_returns_error_response_if_client_id_is_missing(
     )
 
 
-async def test_returns_error_response_if_grant_type_is_missing(
+def test_returns_error_response_if_grant_type_is_missing(
     issuer: Issuer, context: Context
 ):
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(data={"client_id": "test"}), context
+    response = issuer.token(
+        HTTPRequest.from_form_data(data={"client_id": "test"}), context
     )
     assert response.status_code == 400
     assert response.json() == snapshot(
@@ -49,11 +46,9 @@ async def test_returns_error_response_if_grant_type_is_missing(
     )
 
 
-async def test_returns_error_for_unsupported_grant_type(
-    issuer: Issuer, context: Context
-):
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+def test_returns_error_for_unsupported_grant_type(issuer: Issuer, context: Context):
+    response = issuer.token(
+        HTTPRequest.from_form_data(
             data={"grant_type": "client_credentials", "client_id": "test"}
         ),
         context,
@@ -68,11 +63,9 @@ async def test_returns_error_for_unsupported_grant_type(
     )
 
 
-async def test_returns_error_response_if_code_is_missing(
-    issuer: Issuer, context: Context
-):
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+def test_returns_error_response_if_code_is_missing(issuer: Issuer, context: Context):
+    response = issuer.token(
+        HTTPRequest.from_form_data(
             data={"grant_type": "authorization_code", "client_id": "test"}
         ),
         context,
@@ -83,11 +76,11 @@ async def test_returns_error_response_if_code_is_missing(
     )
 
 
-async def test_returns_error_response_if_redirect_uri_is_missing(
+def test_returns_error_response_if_redirect_uri_is_missing(
     issuer: Issuer, context: Context
 ):
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+    response = issuer.token(
+        HTTPRequest.from_form_data(
             data={
                 "grant_type": "authorization_code",
                 "client_id": "test",
@@ -102,11 +95,9 @@ async def test_returns_error_response_if_redirect_uri_is_missing(
     )
 
 
-async def test_returns_error_response_if_code_is_invalid(
-    issuer: Issuer, context: Context
-):
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+def test_returns_error_response_if_code_is_invalid(issuer: Issuer, context: Context):
+    response = issuer.token(
+        HTTPRequest.from_form_data(
             data={
                 "grant_type": "authorization_code",
                 "client_id": "test",
@@ -124,11 +115,11 @@ async def test_returns_error_response_if_code_is_invalid(
     )
 
 
-async def test_returns_error_response_if_code_has_expired(
+def test_returns_error_response_if_code_has_expired(
     issuer: Issuer, context: Context, expired_code: str
 ):
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+    response = issuer.token(
+        HTTPRequest.from_form_data(
             data={
                 "grant_type": "authorization_code",
                 "client_id": "test",
@@ -149,11 +140,11 @@ async def test_returns_error_response_if_code_has_expired(
     )
 
 
-async def test_returns_error_response_if_redirect_uri_does_not_match(
+def test_returns_error_response_if_redirect_uri_does_not_match(
     issuer: Issuer, context: Context, valid_code: str
 ):
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+    response = issuer.token(
+        HTTPRequest.from_form_data(
             data={
                 "grant_type": "authorization_code",
                 "client_id": "test",
@@ -171,11 +162,11 @@ async def test_returns_error_response_if_redirect_uri_does_not_match(
     )
 
 
-async def test_returns_error_response_if_code_verifier_is_missing(
+def test_returns_error_response_if_code_verifier_is_missing(
     issuer: Issuer, context: Context, valid_code: str
 ):
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+    response = issuer.token(
+        HTTPRequest.from_form_data(
             data={
                 "grant_type": "authorization_code",
                 "client_id": "test",
@@ -192,7 +183,7 @@ async def test_returns_error_response_if_code_verifier_is_missing(
     )
 
 
-async def test_returns_error_response_if_client_id_does_not_match(
+def test_returns_error_response_if_client_id_does_not_match(
     issuer: Issuer, context: Context, secondary_storage: SecondaryStorage
 ):
     """
@@ -215,8 +206,8 @@ async def test_returns_error_response_if_client_id_does_not_match(
     )
 
     # Attempt to exchange with different client_id
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+    response = issuer.token(
+        HTTPRequest.from_form_data(
             data={
                 "grant_type": "authorization_code",
                 "client_id": "attacker-client",  # Different client!
@@ -234,11 +225,11 @@ async def test_returns_error_response_if_client_id_does_not_match(
     )
 
 
-async def test_returns_token_if_code_is_valid(
+def test_returns_token_if_code_is_valid(
     issuer: Issuer, context: Context, valid_code: str
 ):
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+    response = issuer.token(
+        HTTPRequest.from_form_data(
             data={
                 "grant_type": "authorization_code",
                 "client_id": "test",
@@ -264,7 +255,7 @@ async def test_returns_token_if_code_is_valid(
     )
 
 
-async def test_authorization_code_can_only_be_used_once(
+def test_authorization_code_can_only_be_used_once(
     issuer: Issuer, context: Context, valid_code: str
 ):
     """
@@ -273,8 +264,8 @@ async def test_authorization_code_can_only_be_used_once(
     reuse an intercepted authorization code.
     """
     # First exchange should succeed
-    response1 = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+    response1 = issuer.token(
+        HTTPRequest.from_form_data(
             data={
                 "grant_type": "authorization_code",
                 "client_id": "test",
@@ -289,8 +280,8 @@ async def test_authorization_code_can_only_be_used_once(
     assert response1.status_code == 200
 
     # Second attempt with same code should fail
-    response2 = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+    response2 = issuer.token(
+        HTTPRequest.from_form_data(
             data={
                 "grant_type": "authorization_code",
                 "client_id": "test",
@@ -308,9 +299,9 @@ async def test_authorization_code_can_only_be_used_once(
     )
 
 
-async def test_password_grant_missing_username(issuer: Issuer, context: Context):
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+def test_password_grant_missing_username(issuer: Issuer, context: Context):
+    response = issuer.token(
+        HTTPRequest.from_form_data(
             data={
                 "grant_type": "password",
                 "client_id": "test",
@@ -325,9 +316,9 @@ async def test_password_grant_missing_username(issuer: Issuer, context: Context)
     )
 
 
-async def test_password_grant_missing_password(issuer: Issuer, context: Context):
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+def test_password_grant_missing_password(issuer: Issuer, context: Context):
+    response = issuer.token(
+        HTTPRequest.from_form_data(
             data={
                 "grant_type": "password",
                 "client_id": "test",
@@ -342,9 +333,9 @@ async def test_password_grant_missing_password(issuer: Issuer, context: Context)
     )
 
 
-async def test_password_grant_invalid_credentials(issuer: Issuer, context: Context):
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+def test_password_grant_invalid_credentials(issuer: Issuer, context: Context):
+    response = issuer.token(
+        HTTPRequest.from_form_data(
             data={
                 "grant_type": "password",
                 "client_id": "test",
@@ -360,9 +351,9 @@ async def test_password_grant_invalid_credentials(issuer: Issuer, context: Conte
     )
 
 
-async def test_password_grant_invalid_username(issuer: Issuer, context: Context):
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+def test_password_grant_invalid_username(issuer: Issuer, context: Context):
+    response = issuer.token(
+        HTTPRequest.from_form_data(
             data={
                 "grant_type": "password",
                 "client_id": "test",
@@ -378,21 +369,20 @@ async def test_password_grant_invalid_username(issuer: Issuer, context: Context)
     )
 
 
-async def test_password_grant_preserves_unknown_hook_error_type(
+def test_password_grant_preserves_unknown_hook_error_type(
     issuer: Issuer,
     context: Context,
 ):
-    async def reject_request(event: BeforeTokenPasswordEvent) -> None:
+    def reject_request(event: BeforeTokenPasswordEvent) -> None:
         raise CrossAuthException("forbidden", "Password grant is forbidden")
 
     context.hooks.register_before(
         "token.password",
         reject_request,
-        allow_async=True,
     )
 
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+    response = issuer.token(
+        HTTPRequest.from_form_data(
             data={
                 "grant_type": "password",
                 "client_id": "test",
@@ -412,9 +402,9 @@ async def test_password_grant_preserves_unknown_hook_error_type(
     )
 
 
-async def test_password_grant_success(issuer: Issuer, context: Context):
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+def test_password_grant_success(issuer: Issuer, context: Context):
+    response = issuer.token(
+        HTTPRequest.from_form_data(
             data={
                 "grant_type": "password",
                 "client_id": "test",
@@ -438,9 +428,9 @@ async def test_password_grant_success(issuer: Issuer, context: Context):
     )
 
 
-async def test_password_grant_with_scope(issuer: Issuer, context: Context):
-    response = await issuer.token(
-        AsyncHTTPRequest.from_form_data(
+def test_password_grant_with_scope(issuer: Issuer, context: Context):
+    response = issuer.token(
+        HTTPRequest.from_form_data(
             data={
                 "grant_type": "password",
                 "client_id": "test",
@@ -465,7 +455,7 @@ async def test_password_grant_with_scope(issuer: Issuer, context: Context):
     )
 
 
-async def test_password_grant_has_consistent_timing(issuer: Issuer, context: Context):
+def test_password_grant_has_consistent_timing(issuer: Issuer, context: Context):
     """
     Test that password grant has consistent timing for existing and non-existing users.
     This prevents timing attacks that could be used to enumerate valid user accounts.
@@ -479,8 +469,8 @@ async def test_password_grant_has_consistent_timing(issuer: Issuer, context: Con
     nonexistent_times = []
     for _ in range(3):
         start = time.perf_counter()
-        await issuer.token(
-            AsyncHTTPRequest.from_form_data(
+        issuer.token(
+            HTTPRequest.from_form_data(
                 data={
                     "grant_type": "password",
                     "client_id": "test",
@@ -497,8 +487,8 @@ async def test_password_grant_has_consistent_timing(issuer: Issuer, context: Con
     existing_times = []
     for _ in range(3):
         start = time.perf_counter()
-        await issuer.token(
-            AsyncHTTPRequest.from_form_data(
+        issuer.token(
+            HTTPRequest.from_form_data(
                 data={
                     "grant_type": "password",
                     "client_id": "test",
@@ -518,7 +508,7 @@ async def test_password_grant_has_consistent_timing(issuer: Issuer, context: Con
     # The timing difference should be minimal (<50ms)
     # If it's larger, it indicates a timing attack vulnerability
     assert difference < 0.05, (
-        f"Timing difference too large: {difference*1000:.2f}ms. "
-        f"Non-existent: {avg_nonexistent*1000:.2f}ms, "
-        f"Existing: {avg_existing*1000:.2f}ms"
+        f"Timing difference too large: {difference * 1000:.2f}ms. "
+        f"Non-existent: {avg_nonexistent * 1000:.2f}ms, "
+        f"Existing: {avg_existing * 1000:.2f}ms"
     )

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -1,7 +1,17 @@
+import inspect
+import json
+from typing import get_args
+
+from cross_web import Response
+from fastapi import FastAPI
+from fastapi.params import Body as FastAPIBody
+from fastapi.testclient import TestClient
+
 from cross_auth._route import PathParameter, Route
 
 
-async def _handler(request, context): ...
+def _handler(request, context):
+    return Response(status_code=204)
 
 
 ITEM_ID_PARAMETER: PathParameter = {
@@ -17,6 +27,14 @@ OTHER_ID_PARAMETER: PathParameter = {
     "required": True,
     "schema": {"type": "string", "title": "Other Id"},
 }
+
+
+def _has_fastapi_body_parameter(endpoint) -> bool:
+    return any(
+        isinstance(metadata, FastAPIBody)
+        for parameter in inspect.signature(endpoint).parameters.values()
+        for metadata in get_args(parameter.annotation)
+    )
 
 
 def test_route_copies_path_parameters():
@@ -61,3 +79,56 @@ def test_route_path_parameters_override_matching_openapi_parameters():
             ITEM_ID_PARAMETER,
         ]
     }
+
+
+def test_fastapi_endpoint_without_preload_is_sync(context):
+    route = Route("/items", ["GET"], _handler)
+
+    endpoint = route.to_fastapi_endpoint(context=context)
+
+    assert not inspect.iscoroutinefunction(endpoint)
+
+
+def test_fastapi_endpoint_with_body_preload_uses_fastapi_body(context):
+    seen = {}
+
+    def handler(request, context):
+        seen["body"] = json.loads(request.body)
+        return Response(status_code=204)
+
+    route = Route("/items", ["POST"], handler, read_body=True)
+    endpoint = route.to_fastapi_endpoint(context=context)
+
+    assert not inspect.iscoroutinefunction(endpoint)
+    assert _has_fastapi_body_parameter(endpoint)
+
+    app = FastAPI()
+    app.add_api_route(route.path, endpoint, methods=route.methods)
+    client = TestClient(app)
+
+    response = client.post("/items", json={"name": "patrick"})
+
+    assert response.status_code == 204
+    assert seen == {"body": {"name": "patrick"}}
+
+
+def test_fastapi_endpoint_with_form_preload_uses_dependency(context):
+    seen = {}
+
+    def handler(request, context):
+        seen["form_data"] = dict(request.post_data)
+        return Response(status_code=204)
+
+    route = Route("/items", ["POST"], handler, read_form_data=True)
+    endpoint = route.to_fastapi_endpoint(context=context)
+
+    assert not inspect.iscoroutinefunction(endpoint)
+
+    app = FastAPI()
+    app.add_api_route(route.path, endpoint, methods=route.methods)
+    client = TestClient(app)
+
+    response = client.post("/items", data={"name": "patrick"})
+
+    assert response.status_code == 204
+    assert seen == {"form_data": {"name": "patrick"}}

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -132,3 +132,29 @@ def test_fastapi_endpoint_with_form_preload_uses_dependency(context):
 
     assert response.status_code == 204
     assert seen == {"form_data": {"name": "patrick"}}
+
+
+def test_fastapi_endpoint_with_form_preload_has_object_request_body(context):
+    route = Route("/items", ["POST"], _handler, read_form_data=True)
+
+    app = FastAPI()
+    app.add_api_route(
+        route.path,
+        route.to_fastapi_endpoint(context=context),
+        methods=route.methods,
+        openapi_extra=route.get_openapi_extra(),
+    )
+
+    operation = app.openapi()["paths"]["/items"]["post"]
+
+    assert operation["requestBody"] == {
+        "content": {
+            "application/x-www-form-urlencoded": {
+                "schema": {
+                    "additionalProperties": True,
+                    "type": "object",
+                    "title": "Form Data",
+                }
+            }
+        }
+    }

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from unittest.mock import patch
 
-from cross_web import AsyncHTTPRequest, TestingRequestAdapter
+from cross_web import HTTPRequest, TestingHTTPRequestAdapter
 
 from cross_auth import AccountsStorage, SecondaryStorage
 from cross_auth._password import authenticate
@@ -136,8 +136,8 @@ def test_make_clear_cookie():
     assert cookie.domain == "example.com"
 
 
-def _make_request(cookies: dict[str, str] | None = None) -> AsyncHTTPRequest:
-    return AsyncHTTPRequest(TestingRequestAdapter(cookies=cookies))
+def _make_request(cookies: dict[str, str] | None = None) -> HTTPRequest:
+    return HTTPRequest(TestingHTTPRequestAdapter(cookies=cookies))
 
 
 def test_get_current_user(

--- a/uv.lock
+++ b/uv.lock
@@ -369,7 +369,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bcrypt", specifier = ">=4.0.0,<5.0.0" },
-    { name = "cross-web", specifier = ">=0.4.0" },
+    { name = "cross-web", specifier = ">=0.7.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.11.3" },
@@ -473,14 +473,14 @@ wheels = [
 
 [[package]]
 name = "cross-web"
-version = "0.6.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/83/b5ef04565acc065387dda3a4fbf0c4cfb6bab805c81b66b2bc5b5ac9a282/cross_web-0.6.0.tar.gz", hash = "sha256:ae90570802615365ca1a781117b43bfd0d6cd3bf611649d24c3a206a82a693c9", size = 331315, upload-time = "2026-04-13T14:29:12.718Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/a0/bdb8370215987cc5bde497cb8b976b17ab14841566ecef2aab6ae3e6c7b0/cross_web-0.7.0.tar.gz", hash = "sha256:15fbc8b9a824a055db8127fd6e43e0773074f620fdecb6b2b587d3d0a2bdd459", size = 332407, upload-time = "2026-05-19T14:18:48.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/a2/dab06d9b80cb76c700883186a9a2e6fd103342c9b4def4d88f5787796e17/cross_web-0.6.0-py3-none-any.whl", hash = "sha256:bdebf0c08d02f3a48cf67b6904d3a6d8fd8cab2cd905592ab96ab00b259cd582", size = 24820, upload-time = "2026-04-13T14:29:11.198Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4a/78b52ec2edcbd9b123638f4e0421fd8699ebe653ebf63ac5f82abd2665bc/cross_web-0.7.0-py3-none-any.whl", hash = "sha256:ddea9be3c68b48eaf16561847a5831a559786949c544b3701432e00a4e8d19d9", size = 25207, upload-time = "2026-05-19T14:18:47.614Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack

- **#38** (`make-endpoints-sync`) <-- this PR
<!-- shortcake:end -->

## Summary by Sourcery

Make auth endpoints, OAuth flows, and hooks synchronous and adapt FastAPI routing to use cross-web’s sync HTTPRequest wrapper.

Enhancements:
- Add a sync HTTPRequest adapter and FastAPI integration that preload body and form data while keeping route handlers synchronous.
- Expose Route options to preload JSON bodies or form-encoded data and reflect this in generated OpenAPI schemas, including validation error responses.
- Refactor hook registration and execution to be fully synchronous and simplify hook type signatures to disallow async handlers.
- Update OAuth flow handlers, issuer token endpoint logic, and social providers to operate on synchronous HTTPRequest objects instead of AsyncHTTPRequest.
- Adjust session/user resolution, router wiring, and examples to work with the new synchronous request model and hook lifecycle.

Build:
- Bump cross-web dependency to a version that provides the synchronous HTTPRequest API.

Documentation:
- Add a release note describing the move to synchronous auth routes/hooks and the adoption of cross-web’s synchronous HTTPRequest wrapper.

Tests:
- Convert async tests to sync, add coverage for new route preloading behavior, and update provider/router tests to work with synchronous flows and hooks.