### PR TITLE
Add support for durable sessions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+---
+release type: minor
+---
+
+This release adds durable session storage support, session management APIs, and
+a FastAPI example dashboard for listing and revoking sessions. The built-in
+`/token` endpoint now issues revocable opaque session tokens when
+`session_storage` is configured. The old `create_token` callback has been
+removed; supply a `token_issuer` instead to mint custom tokens (e.g. JWTs).

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -7,7 +7,7 @@ Playwright tests written in TypeScript.
 
 ## What It Tests
 
-- auth-code + token login from the separate SPA
+- auth-code + opaque bearer-token login from the separate SPA
 - bearer-authenticated API access from the SPA
 - GitHub account linking for a session-authenticated backend user
 - GitHub account linking for a bearer-authenticated client

--- a/e2e/tests/session-management.spec.ts
+++ b/e2e/tests/session-management.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test"
+
+test("session dashboard lists and revokes first-party bearer sessions", async ({
+  page,
+}) => {
+  await page.goto("http://127.0.0.1:8000/")
+
+  await page.getByLabel("Email").fill("demo@example.com")
+  await page.getByLabel("Password").fill("password123")
+  await page.getByRole("button", { name: "Sign in with password" }).click()
+
+  await expect(page).toHaveURL(/127\.0\.0\.1:8000\/profile/)
+
+  const tokenResponse = await page.request.post(
+    "http://127.0.0.1:8000/auth/token",
+    {
+      form: {
+        grant_type: "password",
+        client_id: "session-management-e2e",
+        username: "demo@example.com",
+        password: "password123",
+      },
+    },
+  )
+  expect(tokenResponse.ok()).toBeTruthy()
+  const tokenBody = await tokenResponse.json()
+  expect(tokenBody.access_token).toBeTruthy()
+
+  const bearerMe = await page.request.get("http://127.0.0.1:8000/api/me", {
+    headers: { Authorization: `Bearer ${tokenBody.access_token}` },
+  })
+  expect(bearerMe.ok()).toBeTruthy()
+  expect(await bearerMe.json()).toMatchObject({
+    email: "demo@example.com",
+  })
+
+  await page
+    .locator(".header-nav")
+    .getByRole("link", { name: "Sessions", exact: true })
+    .click()
+  await expect(page).toHaveURL(/127\.0\.0\.1:8000\/sessions/)
+  await expect(
+    page.getByRole("heading", { name: "Active sessions for demo@example.com" }),
+  ).toBeVisible()
+  await expect(page.getByTestId("sessions-table")).toBeVisible()
+  await expect(page.getByText("Browser (").first()).toBeVisible()
+  await expect(
+    page.getByText("Authorized Application (session-management-e2e)"),
+  ).toBeVisible()
+
+  const apiSessions = await page.request.get(
+    "http://127.0.0.1:8000/api/sessions",
+  )
+  expect(apiSessions.ok()).toBeTruthy()
+  const sessionsBody = await apiSessions.json()
+  expect(sessionsBody.sessions).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        access_label: "Authorized Application (session-management-e2e)",
+        status: "active",
+      }),
+      expect.objectContaining({
+        current: true,
+        status: "active",
+      }),
+    ]),
+  )
+
+  const bearerRow = page.locator("tr", {
+    hasText: "Authorized Application (session-management-e2e)",
+  })
+  await bearerRow.getByRole("button", { name: "Revoke" }).click()
+
+  await expect(page).toHaveURL(/127\.0\.0\.1:8000\/sessions/)
+  await expect(bearerRow.getByText("revoked")).toBeVisible()
+  await expect(bearerRow.getByText("retained")).toBeVisible()
+})

--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field, replace
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated, Any, cast
+from urllib.parse import urlencode
 
-import jwt
 from cross_web import HTTPRequest
-from fastapi import Depends, FastAPI, Form, HTTPException, Request
+from fastapi import Depends, FastAPI, Form, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
@@ -18,6 +18,10 @@ from cross_auth import (
     AccountsStorage,
     SecondaryStorage,
     SessionConfig,
+    SessionListOrder,
+    SessionListResult,
+    SessionStatus,
+    SessionStorage,
 )
 from cross_auth import User as UserProtocol
 from cross_auth._session import get_current_user as get_session_user
@@ -47,10 +51,9 @@ BACKEND_TRUSTED_REDIRECT_HOSTS = [
     "localhost:8000",
     "127.0.0.1:8000",
 ]
-TOKEN_ISSUER = "cross-auth-fastapi-example"
-TOKEN_SECRET = "cross-auth-fastapi-example-secret"  # noqa: S105
-TOKEN_EXPIRES_IN = 3600
 MAX_HOOK_EVENTS = 20
+# Small page size so the demo's handful of sessions paginate visibly.
+SESSIONS_PAGE_SIZE = 5
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 SPA_CORS_ORIGINS = [
@@ -113,6 +116,169 @@ class MemorySecondaryStorage(SecondaryStorage):
 
     def pop(self, key: str) -> str | None:
         return self.data.pop(key, None)
+
+
+@dataclass
+class DemoSessionRecord:
+    id: str
+    token_hash: str
+    user_id: str
+    created_at: datetime
+    updated_at: datetime
+    expires_at: datetime
+    last_active_at: datetime | None = None
+    revoked_at: datetime | None = None
+    client_id: str | None = None
+    client_name: str | None = None
+    user_agent: str | None = None
+    ip: str | None = None
+
+    @property
+    def status(self) -> SessionStatus:
+        return session_status(self, now=datetime.now(tz=UTC))
+
+
+@dataclass
+class DemoSessionListResult:
+    records: list[DemoSessionRecord]
+    next_cursor: str | None = None
+
+
+class MemorySessionStorage(SessionStorage):
+    def __init__(self) -> None:
+        self.sessions_by_id: dict[str, DemoSessionRecord] = {}
+
+    def create(
+        self,
+        *,
+        token_hash: str,
+        user_id: Any,
+        created_at: datetime,
+        updated_at: datetime,
+        expires_at: datetime,
+        client_id: str | None = None,
+        client_name: str | None = None,
+        user_agent: str | None = None,
+        ip: str | None = None,
+        last_active_at: datetime | None = None,
+    ) -> DemoSessionRecord:
+        record = DemoSessionRecord(
+            id=str(uuid.uuid4()),
+            token_hash=token_hash,
+            user_id=str(user_id),
+            created_at=created_at,
+            updated_at=updated_at,
+            expires_at=expires_at,
+            client_id=client_id,
+            client_name=client_name,
+            user_agent=user_agent,
+            ip=ip,
+            last_active_at=last_active_at,
+        )
+        self.sessions_by_id[record.id] = record
+        return record
+
+    def get(self, *, token_hash: str, now: datetime) -> DemoSessionRecord | None:
+        record = next(
+            (
+                record
+                for record in self.sessions_by_id.values()
+                if record.token_hash == token_hash
+            ),
+            None,
+        )
+        if record is None:
+            return None
+        if record.revoked_at is not None or now > record.expires_at:
+            return None
+        return record
+
+    def get_any(self, session_id: Any) -> DemoSessionRecord | None:
+        return self.sessions_by_id.get(str(session_id))
+
+    def list_for_user(
+        self,
+        user_id: Any,
+        *,
+        now: datetime,
+        status: SessionStatus | None = None,
+        order_by: SessionListOrder = "updated_at_desc",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> SessionListResult:
+        records = [
+            record
+            for record in self.sessions_by_id.values()
+            if record.user_id == str(user_id)
+        ]
+        if status is not None:
+            records = [
+                record
+                for record in records
+                if session_status(record, now=now) == status
+            ]
+
+        field, direction = order_by.rsplit("_", 1)
+        # Tie-break on id so the order is total and the cursor is stable.
+        records.sort(
+            key=lambda record: (getattr(record, field), record.id),
+            reverse=direction == "desc",
+        )
+
+        # The cursor is the id of the last record from the previous page. A real
+        # store would encode the (sort key, id) pair so it can resume with an
+        # indexed range query instead of scanning; for the demo we slice.
+        if cursor is not None:
+            ids = [record.id for record in records]
+            if cursor in ids:
+                records = records[ids.index(cursor) + 1 :]
+
+        page = records[:limit]
+        has_more = len(records) > limit
+        next_cursor = page[-1].id if has_more and page else None
+        return cast(
+            SessionListResult,
+            DemoSessionListResult(records=page, next_cursor=next_cursor),
+        )
+
+    def refresh(
+        self,
+        session_id: Any,
+        *,
+        updated_at: datetime,
+        expires_at: datetime,
+        last_active_at: datetime | None = None,
+    ) -> DemoSessionRecord | None:
+        record = self.get_any(session_id)
+        if record is None:
+            return None
+        record.updated_at = updated_at
+        record.expires_at = expires_at
+        record.last_active_at = last_active_at
+        return record
+
+    def revoke(self, session_id: Any, *, revoked_at: datetime) -> None:
+        record = self.get_any(session_id)
+        if record is not None:
+            record.revoked_at = revoked_at
+
+    def revoke_all_for_user(
+        self,
+        user_id: Any,
+        *,
+        revoked_at: datetime,
+        except_session_id: Any | None = None,
+    ) -> int:
+        count = 0
+        for record in self.sessions_by_id.values():
+            if record.user_id != str(user_id):
+                continue
+            if except_session_id is not None and record.id == str(except_session_id):
+                continue
+            if record.revoked_at is None:
+                record.revoked_at = revoked_at
+                count += 1
+        return count
 
 
 class MemoryAccountsStorage(AccountsStorage):
@@ -294,6 +460,55 @@ def serialize_user(user: DemoUser) -> dict[str, Any]:
     }
 
 
+def session_status(record: DemoSessionRecord, *, now: datetime) -> SessionStatus:
+    if record.revoked_at is not None:
+        return "revoked"
+    if now > record.expires_at:
+        return "expired"
+    return "active"
+
+
+def session_access_label(record: DemoSessionRecord) -> str:
+    if record.client_id:
+        return f"Authorized Application ({record.client_name or record.client_id})"
+    if record.user_agent:
+        if "Chrome" in record.user_agent:
+            browser = "Chrome"
+        elif "Firefox" in record.user_agent:
+            browser = "Firefox"
+        elif "Safari" in record.user_agent:
+            browser = "Safari"
+        else:
+            browser = "Browser"
+        return f"Browser ({browser})"
+    return "Browser"
+
+
+def serialize_session(
+    record: DemoSessionRecord,
+    *,
+    current_session_id: str | None,
+) -> dict[str, Any]:
+    return {
+        "id": record.id,
+        "user_id": record.user_id,
+        "status": record.status,
+        "access_label": session_access_label(record),
+        "created_at": record.created_at.isoformat(),
+        "updated_at": record.updated_at.isoformat(),
+        "expires_at": record.expires_at.isoformat(),
+        "last_active_at": (
+            record.last_active_at.isoformat() if record.last_active_at else None
+        ),
+        "revoked_at": record.revoked_at.isoformat() if record.revoked_at else None,
+        "client_id": record.client_id,
+        "client_name": record.client_name,
+        "user_agent": record.user_agent,
+        "ip": record.ip,
+        "current": record.id == current_session_id,
+    }
+
+
 def get_error_message(error: str | None) -> str | None:
     if error == "invalid_credentials":
         return "The demo credentials were invalid."
@@ -308,17 +523,6 @@ def get_error_message(error: str | None) -> str | None:
     if error == "email_not_verified":
         return "The provider reported an unverified email address."
     return None
-
-
-def create_demo_token(user_id: str) -> tuple[str, int]:
-    now = datetime.now(tz=UTC)
-    payload = {
-        "sub": user_id,
-        "iss": TOKEN_ISSUER,
-        "iat": now,
-        "exp": now + timedelta(seconds=TOKEN_EXPIRES_IN),
-    }
-    return jwt.encode(payload, TOKEN_SECRET, algorithm="HS256"), TOKEN_EXPIRES_IN
 
 
 hook_events: list[dict[str, str]] = []
@@ -336,55 +540,17 @@ def record_hook_event(name: str, **fields: str) -> None:
     del hook_events[MAX_HOOK_EVENTS:]
 
 
-def resolve_bearer_token(token: str) -> DemoUser:
-    try:
-        payload = jwt.decode(
-            token,
-            TOKEN_SECRET,
-            algorithms=["HS256"],
-            issuer=TOKEN_ISSUER,
-        )
-    except jwt.PyJWTError as e:
-        raise HTTPException(status_code=401, detail="Invalid bearer token") from e
-
-    user_id = payload.get("sub")
-    if not isinstance(user_id, str):
-        raise HTTPException(status_code=401, detail="Invalid bearer token")
-
-    user = accounts_storage.find_user_by_id(user_id)
-    if user is None:
-        raise HTTPException(status_code=401, detail="User not found")
-
-    return user
-
-
-def resolve_bearer_user(request: Request) -> DemoUser:
-    authorization = request.headers.get("Authorization")
-    if not authorization or not authorization.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing bearer token")
-
-    token = authorization.split(" ", 1)[1]
-    return resolve_bearer_token(token)
-
-
 def resolve_auth_user(request: HTTPRequest) -> DemoUser | None:
-    authorization = request.headers.get("Authorization")
-    if authorization and authorization.startswith("Bearer "):
-        token = authorization.split(" ", 1)[1]
-        try:
-            return resolve_bearer_token(token)
-        except HTTPException:
-            return None
-
-    return cast(
-        DemoUser | None,
-        get_session_user(
-            request,
-            secondary_storage,
-            accounts_storage,
-            {"cookie_name": SESSION_COOKIE_NAME, "secure": False},
-        ),
+    session_user = get_session_user(
+        request,
+        session_storage,
+        accounts_storage,
+        SESSION_CONFIG,
     )
+    if session_user is not None:
+        return cast(DemoUser, session_user)
+
+    return None
 
 
 github = GitHubProvider(
@@ -396,24 +562,29 @@ github = GitHubProvider(
 )
 
 secondary_storage = MemorySecondaryStorage()
+session_storage = MemorySessionStorage()
 accounts_storage = MemoryAccountsStorage()
 SESSION_CONFIG: SessionConfig = {
-    "cookie_name": SESSION_COOKIE_NAME,
-    "secure": False,
+    "update_age": 60,
+    "cookies": {
+        "auth": True,
+        "name": SESSION_COOKIE_NAME,
+        "secure": False,
+    },
 }
 
 auth = CrossAuth(
     providers=[github],
     storage=secondary_storage,
     accounts_storage=accounts_storage,
-    create_token=create_demo_token,
+    session_storage=session_storage,
     trusted_origins=[*SPA_TRUSTED_REDIRECT_HOSTS, *BACKEND_TRUSTED_REDIRECT_HOSTS],
-    session_config=SESSION_CONFIG,
     get_user_from_request=resolve_auth_user,
     default_next_url="/profile",
     config={
         "account_linking": {"enabled": True},
         "allowed_client_ids": [SPA_CLIENT_ID],
+        "session": SESSION_CONFIG,
     },
 )
 
@@ -444,7 +615,10 @@ def audit_session_login(event: AfterLoginEvent) -> None:
 
 @auth.after("logout")
 def audit_session_logout(event: AfterLogoutEvent) -> None:
-    record_hook_event("after:logout", session_id=event.session_id or "")
+    record_hook_event(
+        "after:logout",
+        session_id="" if event.session_record is None else str(event.session_record.id),
+    )
 
 
 @auth.before("oauth.callback")
@@ -512,6 +686,7 @@ def home(
 
 @app.post("/login")
 def login(
+    request: Request,
     email: Annotated[str, Form()],
     password: Annotated[str, Form()],
 ) -> RedirectResponse:
@@ -520,7 +695,11 @@ def login(
         return RedirectResponse(url="/?error=invalid_credentials", status_code=303)
 
     response = RedirectResponse(url="/profile", status_code=303)
-    auth.login(str(user.id), response=response)
+    auth.login(
+        str(user.id),
+        response=response,
+        metadata={"user_agent": request.headers.get("User-Agent")},
+    )
     return response
 
 
@@ -546,6 +725,78 @@ def profile(
     )
 
 
+@app.get("/sessions")
+def sessions_page(
+    request: Request,
+    response: Response,
+    user: Annotated[UserProtocol | None, Depends(auth.get_current_user)],
+    status: SessionStatus | None = None,
+    cursor: str | None = None,
+):
+    if user is None:
+        return RedirectResponse(url="/", status_code=303)
+
+    current_session = auth.get_current_session(request, response)
+    result = auth.list_sessions(
+        str(user.id),
+        status=status,
+        limit=SESSIONS_PAGE_SIZE,
+        cursor=cursor,
+    )
+    sessions = [
+        serialize_session(
+            cast(DemoSessionRecord, record),
+            current_session_id=(
+                str(current_session.id) if current_session is not None else None
+            ),
+        )
+        for record in result.records
+    ]
+
+    next_query = None
+    if result.next_cursor is not None:
+        params = {"cursor": result.next_cursor}
+        if status is not None:
+            params["status"] = status
+        next_query = urlencode(params)
+
+    return templates.TemplateResponse(
+        request,
+        "sessions.html",
+        {
+            "current_status": status,
+            "hook_events": hook_events[:5],
+            "sessions": sessions,
+            "user": user,
+            "next_query": next_query,
+        },
+    )
+
+
+@app.post("/sessions/{session_id}/revoke")
+def revoke_session_form(
+    session_id: str,
+    user: Annotated[UserProtocol, Depends(auth.require_current_user)],
+) -> RedirectResponse:
+    auth.revoke_session(session_id, user_id=str(user.id))
+    return RedirectResponse(url="/sessions", status_code=303)
+
+
+@app.post("/sessions/revoke-other")
+def revoke_other_sessions_form(
+    request: Request,
+    user: Annotated[UserProtocol, Depends(auth.require_current_user)],
+    response: Response,
+) -> RedirectResponse:
+    current_session = auth.get_current_session(request, response)
+    if current_session is not None:
+        auth.revoke_other_sessions(
+            user_id=str(user.id),
+            keep_session_id=current_session.id,
+        )
+    return RedirectResponse(url="/sessions", status_code=303)
+
+
 @app.get("/hooks")
 def hooks_page(request: Request):
     return templates.TemplateResponse(
@@ -569,3 +820,59 @@ def api_me_session(
     user: Annotated[UserProtocol, Depends(auth.require_current_user)],
 ) -> JSONResponse:
     return JSONResponse(serialize_user(cast(DemoUser, user)))
+
+
+@app.get("/api/sessions")
+def api_sessions(
+    request: Request,
+    response: Response,
+    user: Annotated[UserProtocol, Depends(auth.require_current_user)],
+    status: SessionStatus | None = None,
+    cursor: str | None = None,
+) -> JSONResponse:
+    current_session = auth.get_current_session(request, response)
+    result = auth.list_sessions(
+        str(user.id),
+        status=status,
+        limit=SESSIONS_PAGE_SIZE,
+        cursor=cursor,
+    )
+    return JSONResponse(
+        {
+            "sessions": [
+                serialize_session(
+                    cast(DemoSessionRecord, record),
+                    current_session_id=(
+                        str(current_session.id) if current_session is not None else None
+                    ),
+                )
+                for record in result.records
+            ],
+            "next_cursor": result.next_cursor,
+        }
+    )
+
+
+@app.post("/api/sessions/{session_id}/revoke")
+def api_revoke_session(
+    session_id: str,
+    user: Annotated[UserProtocol, Depends(auth.require_current_user)],
+) -> JSONResponse:
+    auth.revoke_session(session_id, user_id=str(user.id))
+    return JSONResponse({"ok": True})
+
+
+@app.post("/api/sessions/revoke-other")
+def api_revoke_other_sessions(
+    request: Request,
+    user: Annotated[UserProtocol, Depends(auth.require_current_user)],
+    response: Response,
+) -> JSONResponse:
+    current_session = auth.get_current_session(request, response)
+    revoked = 0
+    if current_session is not None:
+        revoked = auth.revoke_other_sessions(
+            user_id=str(user.id),
+            keep_session_id=current_session.id,
+        )
+    return JSONResponse({"ok": True, "revoked": revoked})

--- a/examples/fastapi/templates/base.html
+++ b/examples/fastapi/templates/base.html
@@ -211,6 +211,77 @@
         font-size: 0.88rem;
       }
 
+      /* ── Session Dashboard ── */
+      .toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+      }
+      .tabs {
+        display: inline-flex;
+        overflow: hidden;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+      }
+      .tabs a {
+        padding: 6px 10px;
+        border-right: 1px solid var(--border);
+        color: var(--muted);
+        font-size: 0.82rem;
+        font-weight: 600;
+        text-decoration: none;
+        background: white;
+      }
+      .tabs a:last-child { border-right: none; }
+      .tabs a[aria-current="page"] {
+        color: white;
+        background: var(--text);
+      }
+      .table-wrap {
+        overflow-x: auto;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        background: white;
+      }
+      table {
+        width: 100%;
+        min-width: 720px;
+        border-collapse: collapse;
+        table-layout: fixed;
+      }
+      th, td {
+        padding: 10px 12px;
+        border-bottom: 1px solid var(--border);
+        text-align: left;
+        vertical-align: top;
+      }
+      th {
+        font-family: var(--mono);
+        font-size: 0.72rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--muted);
+        background: #f5f5f5;
+      }
+      th:first-child, td:first-child { width: 260px; }
+      th:nth-child(2), td:nth-child(2) { width: 86px; }
+      th:nth-child(3), td:nth-child(3),
+      th:nth-child(4), td:nth-child(4),
+      th:nth-child(5), td:nth-child(5) { width: 140px; }
+      th:last-child, td:last-child {
+        width: 110px;
+        text-align: right;
+        white-space: nowrap;
+      }
+      tr:last-child td { border-bottom: none; }
+      .cell-main { display: grid; gap: 3px; }
+      .cell-main .pill { justify-self: start; }
+      .muted-small { color: var(--muted); font-size: 0.82rem; }
+      td code { white-space: nowrap; }
+
       /* ── Footer ── */
       .footer {
         padding: 14px 24px;
@@ -235,6 +306,7 @@
         <nav class="header-nav">
           <a href="/">Home</a>
           <a href="/profile">Profile</a>
+          <a href="/sessions">Sessions</a>
           <a href="/hooks">Hooks</a>
           <a href="/api/me">/me</a>
         </nav>

--- a/examples/fastapi/templates/home.html
+++ b/examples/fastapi/templates/home.html
@@ -32,6 +32,7 @@
         </div>
         <div class="actions">
           <a class="button primary" href="/profile">Profile</a>
+          <a class="button" href="/sessions">Sessions</a>
           <a class="button" href="/api/me">/api/me</a>
           <form action="/logout" method="post">
             <button type="submit">Log out</button>

--- a/examples/fastapi/templates/profile.html
+++ b/examples/fastapi/templates/profile.html
@@ -50,6 +50,7 @@
       </div>
       <div class="actions">
         <a class="button" href="/">Home</a>
+        <a class="button" href="/sessions">Manage sessions</a>
         <a class="button" href="/api/me">/api/me</a>
         <a class="button" href="http://localhost:5173" target="_blank" rel="noreferrer">Open SPA demo</a>
         <button type="button" id="link-github-button">Link GitHub account</button>

--- a/examples/fastapi/templates/sessions.html
+++ b/examples/fastapi/templates/sessions.html
@@ -1,0 +1,103 @@
+{% extends "base.html" %}
+
+{% block title %}Sessions · Cross-Auth FastAPI Hybrid Example{% endblock %}
+
+{% block content %}
+  <div class="hero">
+    <div class="eyebrow">Session Dashboard</div>
+    <h1>Active sessions for {{ user.email }}</h1>
+    <p class="lead">
+      Cookie and first-party bearer sign-ins are stored in the same durable
+      session store. Revocation takes effect immediately for both transports.
+    </p>
+  </div>
+
+  <div class="grid cols-1">
+    <div class="stack">
+      <div class="toolbar">
+        <nav class="tabs" aria-label="Session filters">
+          <a href="/sessions" {% if current_status is none %}aria-current="page"{% endif %}>All</a>
+          <a href="/sessions?status=active" {% if current_status == "active" %}aria-current="page"{% endif %}>Active</a>
+          <a href="/sessions?status=expired" {% if current_status == "expired" %}aria-current="page"{% endif %}>Expired</a>
+          <a href="/sessions?status=revoked" {% if current_status == "revoked" %}aria-current="page"{% endif %}>Revoked</a>
+        </nav>
+        <form action="/sessions/revoke-other" method="post">
+          <button type="submit">Revoke other sessions</button>
+        </form>
+      </div>
+
+      {% if sessions %}
+        <div class="table-wrap">
+          <table data-testid="sessions-table">
+            <thead>
+              <tr>
+                <th>Access</th>
+                <th>Status</th>
+                <th>Created</th>
+                <th>Last active</th>
+                <th>Expires</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for session in sessions %}
+                <tr data-session-id="{{ session.id }}" data-current="{{ 'true' if session.current else 'false' }}">
+                  <td>
+                    <div class="cell-main">
+                      <strong>{{ session.access_label }}</strong>
+                      {% if session.current %}
+                        <span class="pill ok">current</span>
+                      {% endif %}
+                      {% if session.user_agent %}
+                        <span class="muted-small">{{ session.user_agent }}</span>
+                      {% endif %}
+                      {% if session.client_id %}
+                        <span class="muted-small">client_id={{ session.client_id }}</span>
+                      {% endif %}
+                    </div>
+                  </td>
+                  <td>
+                    {% if session.status == "active" %}
+                      <span class="pill ok">active</span>
+                    {% elif session.status == "revoked" %}
+                      <span class="pill warn">revoked</span>
+                    {% else %}
+                      <span class="pill">expired</span>
+                    {% endif %}
+                  </td>
+                  <td><code>{{ session.created_at[5:16]|replace("T", " ") }}</code></td>
+                  <td>
+                    {% if session.last_active_at %}
+                      <code>{{ session.last_active_at[5:16]|replace("T", " ") }}</code>
+                    {% else %}
+                      <span class="pill">unknown</span>
+                    {% endif %}
+                  </td>
+                  <td><code>{{ session.expires_at[5:16]|replace("T", " ") }}</code></td>
+                  <td>
+                    {% if session.status == "active" and not session.current %}
+                      <form action="/sessions/{{ session.id }}/revoke" method="post">
+                        <button type="submit">Revoke</button>
+                      </form>
+                    {% elif session.current %}
+                      <span class="pill">current</span>
+                    {% else %}
+                      <span class="pill">retained</span>
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        {% if next_query %}
+          <div class="toolbar">
+            <a href="/sessions?{{ next_query }}" data-testid="sessions-next">Next page →</a>
+          </div>
+        {% endif %}
+      {% else %}
+        <span class="pill">no sessions in this filter</span>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/examples/spa/README.md
+++ b/examples/spa/README.md
@@ -9,7 +9,7 @@ backend as if Cross-Auth were a standalone authentication server.
 - redirect to the backend generic provider authorize endpoint
 - callback handling in a separate frontend app
 - auth-code exchange at `/auth/token`
-- client-side bearer token storage
+- client-side storage of an opaque, revocable bearer token
 - authenticated API call to the backend with `Authorization: Bearer ...`
 
 ## Run It

--- a/src/cross_auth/__init__.py
+++ b/src/cross_auth/__init__.py
@@ -1,6 +1,16 @@
 from cross_auth._context import Context
-from cross_auth._session import SessionConfig, SessionData
-from cross_auth._storage import AccountsStorage, SecondaryStorage, User
+from cross_auth._session import SessionConfig, SessionCookieConfig
+from cross_auth._storage import (
+    AccountsStorage,
+    SecondaryStorage,
+    SessionListOrder,
+    SessionListResult,
+    SessionRecord,
+    SessionStatus,
+    SessionStorage,
+    User,
+)
+from cross_auth._tokens import TokenIssueRequest, TokenIssuer
 from cross_auth.hooks import (
     AfterAuthenticateEvent,
     AfterLoginEvent,
@@ -62,8 +72,15 @@ __all__ = [
     "OIDCProvider",
     "SecondaryStorage",
     "SessionConfig",
-    "SessionData",
+    "SessionCookieConfig",
+    "SessionListOrder",
+    "SessionListResult",
+    "SessionRecord",
+    "SessionStatus",
+    "SessionStorage",
     "TokenExchangeParams",
+    "TokenIssueRequest",
+    "TokenIssuer",
     "TokenResponse",
     "User",
     "UserInfo",

--- a/src/cross_auth/_auth_flow.py
+++ b/src/cross_auth/_auth_flow.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, HttpUrl, TypeAdapter, ValidationError
 
 from ._context import Context
 from ._issuer import AuthorizationCodeGrantData
-from ._session import create_session, make_session_cookie, resolve_config
+from ._session import _get_header, make_session_cookie
 from ._storage import SocialAccount, User
 from .exceptions import CrossAuthException
 from .hooks import (
@@ -684,7 +684,12 @@ def _handle_oauth_callback(
 
     if auth_request.flow == "session":
         try:
-            response = _complete_session(auth_request, resolved_user.user, context)
+            response = _complete_session(
+                auth_request,
+                resolved_user.user,
+                context,
+                request,
+            )
         except CrossAuthException as e:
             return _flow_error(
                 auth_request,
@@ -943,12 +948,18 @@ def _complete_connect(
 
 
 def _complete_session(
-    auth_request: AuthRequest, user: User, context: Context
+    auth_request: AuthRequest,
+    user: User,
+    context: Context,
+    request: HTTPRequest,
 ) -> Response:
-    if not context.is_session_enabled:
+    if not context.cookie_auth_enabled:
         return Response.error(
             "server_error",
-            error_description="Session flow not configured for this deployment",
+            error_description=(
+                "Cookie auth is not enabled for this deployment "
+                "(config['session']['cookies']['auth'])"
+            ),
         )
 
     next_url = auth_request.next_url or context.default_next_url
@@ -959,13 +970,11 @@ def _complete_session(
         BeforeLoginEvent(user_id=str(user.id), response=response),
     )
 
-    resolved = resolve_config(context.session_config)
-    session_id, session_data = create_session(
+    session_token, session_record = context.create_session(
         event.user_id,
-        context.secondary_storage,
-        max_age=resolved["max_age"],
+        {"user_agent": _get_header(request.headers, "user-agent")},
     )
-    cookie = make_session_cookie(session_id, context.session_config)
+    cookie = make_session_cookie(session_token, context.session_config)
 
     if event.response.cookies is None:
         event.response.cookies = []
@@ -976,8 +985,7 @@ def _complete_session(
         AfterLoginEvent(
             user_id=event.user_id,
             response=event.response,
-            session_id=session_id,
-            session_data=session_data,
+            session_record=session_record,
             cookie=cookie,
         ),
     )

--- a/src/cross_auth/_config.py
+++ b/src/cross_auth/_config.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TypedDict
 
+from ._session import SessionConfig
+
 
 class AccountLinkingConfig(TypedDict, total=False):
     """Account linking configuration."""
@@ -28,3 +30,8 @@ class Config(TypedDict, total=False):
     # is skipped (any client_id is accepted). When set, only these client_ids
     # are allowed to initiate OAuth flows.
     allowed_client_ids: list[str]
+
+    # Session cookie settings (cookie name, max_age, secure, etc.) plus the
+    # cookie_auth flag that enables the browser /{provider}/login flow. See
+    # SessionConfig. cookie_auth requires session_storage to be provided.
+    session: SessionConfig

--- a/src/cross_auth/_context.py
+++ b/src/cross_auth/_context.py
@@ -4,8 +4,23 @@ from urllib.parse import urlparse
 from cross_web import HTTPRequest, Cookie
 
 from ._config import Config
-from ._session import SessionConfig, create_session, make_session_cookie, resolve_config
-from ._storage import AccountsStorage, SecondaryStorage, User
+from ._session import (
+    SessionConfig,
+    SessionMetadata,
+    _get_header,
+    create_session,
+    make_session_cookie,
+    resolve_config,
+)
+from ._storage import (
+    AccountsStorage,
+    SecondaryStorage,
+    SessionRecord,
+    SessionStorage,
+    User,
+)
+from ._tokens import TokenIssueRequest, TokenIssuer
+from .exceptions import CrossAuthException
 from .hooks import HookRegistry
 from .utils._is_same_host import is_same_host
 
@@ -15,44 +30,84 @@ class Context:
         self,
         secondary_storage: SecondaryStorage,
         accounts_storage: AccountsStorage,
-        create_token: Callable[[str], tuple[str, int]],
         # TODO: this doesn't allow to use the library as an Identity Provider
         trusted_origins: list[str],
         get_user_from_request: Callable[[HTTPRequest], User | None],
+        session_storage: SessionStorage | None = None,
+        token_issuer: TokenIssuer | None = None,
         base_url: str | None = None,
         config: Config | None = None,
-        session_enabled: bool = False,
-        session_config: SessionConfig | None = None,
         default_next_url: str = "/",
         hooks: HookRegistry | None = None,
     ):
         self.secondary_storage = secondary_storage
         self.accounts_storage = accounts_storage
-        self.create_token = create_token
+        self.session_storage = session_storage
         self.trusted_origins = trusted_origins
         self.get_user_from_request = get_user_from_request
+        self.token_issuer = token_issuer
         self.base_url = base_url
         self.config: Config = config if config is not None else {}
-        self._session_enabled = session_enabled
-        self.session_config = session_config
+        self.session_config: SessionConfig | None = self.config.get("session")
         self.default_next_url = default_next_url
         self.hooks = hooks if hooks is not None else HookRegistry()
 
-    @property
-    def is_session_enabled(self) -> bool:
-        return self._session_enabled
+        if self.cookie_auth_enabled and session_storage is None:
+            raise ValueError(
+                "config['session']['cookies']['auth'] is enabled but no "
+                "session_storage was provided"
+            )
 
-    def create_session_cookie(self, user_id: str) -> Cookie:
-        if not self.is_session_enabled:
+    @property
+    def cookie_auth_enabled(self) -> bool:
+        cookies = (self.config.get("session") or {}).get("cookies") or {}
+        return cookies.get("auth", False)
+
+    def create_session(
+        self,
+        user_id: str,
+        metadata: SessionMetadata | None = None,
+    ) -> tuple[str, SessionRecord]:
+        session_storage = self.session_storage
+        if session_storage is None:
             raise RuntimeError("Session flow not configured for this deployment")
 
         resolved = resolve_config(self.session_config)
-        session_id, _ = create_session(
+        return create_session(
             user_id,
-            self.secondary_storage,
+            session_storage,
             max_age=resolved["max_age"],
+            metadata=metadata,
+            token_hasher=resolved["token_hasher"],
         )
-        return make_session_cookie(session_id, self.session_config)
+
+    def create_session_cookie(
+        self,
+        user_id: str,
+        metadata: SessionMetadata | None = None,
+    ) -> Cookie:
+        session_token, _ = self.create_session(user_id, metadata)
+        return make_session_cookie(session_token, self.session_config)
+
+    def issue_token(self, request: TokenIssueRequest) -> tuple[str, int]:
+        if self.token_issuer is not None:
+            return self.token_issuer(request)
+
+        if self.session_storage is None:
+            raise CrossAuthException(
+                "server_error",
+                "The token endpoint requires token_issuer or session_storage",
+            )
+
+        resolved = resolve_config(self.session_config)
+        session_token, _ = self.create_session(
+            request.user_id,
+            {
+                "client_id": request.client_id,
+                "user_agent": _get_header(request.http_request.headers, "user-agent"),
+            },
+        )
+        return session_token, resolved["max_age"]
 
     def is_valid_redirect_uri(self, redirect_uri: str) -> bool:
         host = urlparse(redirect_uri).netloc

--- a/src/cross_auth/_issuer.py
+++ b/src/cross_auth/_issuer.py
@@ -11,6 +11,7 @@ from cross_auth.utils._pkce import validate_pkce
 from ._context import Context
 from ._password import DUMMY_PASSWORD_HASH, pwd_context, validate_password
 from ._route import Form, Route
+from ._tokens import TokenIssueRequest
 from .exceptions import CrossAuthException
 from .hooks import (
     AfterTokenAuthorizationCodeEvent,
@@ -158,12 +159,15 @@ class Issuer:
         # TODO: support confidential clients (client_secret)
 
         if isinstance(token_request, AuthorizationCodeGrantRequest):
-            return self._authorization_code_grant(token_request, context)
+            return self._authorization_code_grant(token_request, context, request)
         elif isinstance(token_request, PasswordGrantRequest):
-            return self._password_grant(token_request, context)
+            return self._password_grant(token_request, context, request)
 
     def _authorization_code_grant(
-        self, request: AuthorizationCodeGrantRequest, context: Context
+        self,
+        request: AuthorizationCodeGrantRequest,
+        context: Context,
+        http_request: HTTPRequest,
     ) -> Response:
         code = request.code
 
@@ -233,7 +237,18 @@ class Issuer:
         except CrossAuthException as e:
             return self._error_response(e.error, e.error_description)
 
-        token, expires_in = context.create_token(authorization_data.user_id)
+        try:
+            token, expires_in = context.issue_token(
+                TokenIssueRequest(
+                    user_id=authorization_data.user_id,
+                    client_id=authorization_data.client_id,
+                    grant_type="authorization_code",
+                    scope=request.scope,
+                    http_request=http_request,
+                )
+            )
+        except CrossAuthException as e:
+            return self._error_response(e.error, e.error_description)
 
         token_data = TokenResponse(
             access_token=token,
@@ -269,7 +284,10 @@ class Issuer:
         )
 
     def _password_grant(
-        self, request: PasswordGrantRequest, context: Context
+        self,
+        request: PasswordGrantRequest,
+        context: Context,
+        http_request: HTTPRequest,
     ) -> Response:
         user = context.accounts_storage.find_user_by_email(request.username)
 
@@ -299,7 +317,19 @@ class Issuer:
         if not valid or user is None:
             return self._error_response("invalid_grant", "Invalid username or password")
 
-        token, expires_in = context.create_token(str(user.id))
+        try:
+            token, expires_in = context.issue_token(
+                TokenIssueRequest(
+                    user_id=str(user.id),
+                    client_id=request.client_id,
+                    scope=request.scope,
+                    username=request.username,
+                    http_request=http_request,
+                    grant_type="password",
+                )
+            )
+        except CrossAuthException as e:
+            return self._error_response(e.error, e.error_description)
 
         token_data = TokenResponse(
             access_token=token,

--- a/src/cross_auth/_session.py
+++ b/src/cross_auth/_session.py
@@ -1,27 +1,35 @@
 from __future__ import annotations
 
+import hashlib
 import secrets
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Literal, TypedDict
 
 from cross_web import HTTPRequest, Cookie
-from pydantic import AwareDatetime, BaseModel
 
-from ._storage import AccountsStorage, SecondaryStorage, User
+from ._storage import AccountsStorage, SessionRecord, SessionStorage, User
 
-_SESSION_KEY_PREFIX = "session:"
 _DEFAULT_MAX_AGE = 86400
 
-
-class SessionData(BaseModel):
-    user_id: str
-    created_at: AwareDatetime
-    expires_at: AwareDatetime
+SessionTokenHasher = Callable[[str], str]
 
 
-class SessionConfig(TypedDict, total=False):
-    cookie_name: str
-    max_age: int
+class SessionMetadata(TypedDict, total=False):
+    client_id: str | None
+    client_name: str | None
+    user_agent: str | None
+    ip: str | None
+
+
+class SessionCookieConfig(TypedDict, total=False):
+    # If True, register GET /{provider}/login and complete OAuth callbacks
+    # into a browser session cookie. Requires session_storage. When False
+    # (default), the login routes are not registered and only the token/PKCE
+    # flow (/authorize, /callback, /token) is exposed.
+    auth: bool
+    name: str
     secure: bool
     httponly: bool
     samesite: Literal["lax", "strict", "none"]
@@ -29,9 +37,16 @@ class SessionConfig(TypedDict, total=False):
     domain: str | None
 
 
-_SESSION_CONFIG_DEFAULTS: SessionConfig = {
-    "cookie_name": "session_id",
-    "max_age": _DEFAULT_MAX_AGE,
+class SessionConfig(TypedDict, total=False):
+    max_age: int
+    update_age: int | None
+    token_hasher: SessionTokenHasher
+    cookies: SessionCookieConfig
+
+
+_SESSION_COOKIE_DEFAULTS: SessionCookieConfig = {
+    "auth": False,
+    "name": "session_id",
     "secure": True,
     "httponly": True,
     "samesite": "lax",
@@ -39,53 +54,121 @@ _SESSION_CONFIG_DEFAULTS: SessionConfig = {
     "domain": None,
 }
 
+_SESSION_CONFIG_DEFAULTS: SessionConfig = {
+    "max_age": _DEFAULT_MAX_AGE,
+    "update_age": None,
+    "token_hasher": lambda session_token: hashlib.sha256(
+        session_token.encode("utf-8")
+    ).hexdigest(),
+    "cookies": _SESSION_COOKIE_DEFAULTS,
+}
+
 
 def resolve_config(config: SessionConfig | None) -> SessionConfig:
-    if config is None:
-        return _SESSION_CONFIG_DEFAULTS
-    return {**_SESSION_CONFIG_DEFAULTS, **config}
+    base: SessionConfig = config if config is not None else {}
+    # Shallow-merge top level, but deep-merge the nested cookie attributes so a
+    # partial `cookies` override doesn't drop the other cookie defaults.
+    return {
+        **_SESSION_CONFIG_DEFAULTS,
+        **base,
+        "cookies": {**_SESSION_COOKIE_DEFAULTS, **base.get("cookies", {})},
+    }
+
+
+def hash_session_token(
+    session_token: str,
+    token_hasher: SessionTokenHasher | None = None,
+) -> str:
+    hasher = token_hasher or _SESSION_CONFIG_DEFAULTS["token_hasher"]
+    return hasher(session_token)
 
 
 def create_session(
     user_id: str,
-    storage: SecondaryStorage,
+    storage: SessionStorage,
     max_age: int = _DEFAULT_MAX_AGE,
-) -> tuple[str, SessionData]:
-    session_id = secrets.token_urlsafe(32)
+    *,
+    metadata: SessionMetadata | None = None,
+    token_hasher: SessionTokenHasher | None = None,
+) -> tuple[str, SessionRecord]:
+    session_token = secrets.token_urlsafe(32)
     now = datetime.now(tz=timezone.utc)
-    session_data = SessionData(
+    expires_at = now + timedelta(seconds=max_age)
+    resolved_metadata = metadata or {}
+    session_record = storage.create(
+        token_hash=hash_session_token(session_token, token_hasher),
         user_id=user_id,
         created_at=now,
-        expires_at=now + timedelta(seconds=max_age),
+        updated_at=now,
+        expires_at=expires_at,
+        client_id=resolved_metadata.get("client_id"),
+        client_name=resolved_metadata.get("client_name"),
+        user_agent=resolved_metadata.get("user_agent"),
+        ip=resolved_metadata.get("ip"),
+        last_active_at=now,
     )
-    storage.set(f"{_SESSION_KEY_PREFIX}{session_id}", session_data.model_dump_json())
-    return session_id, session_data
+    return session_token, session_record
 
 
 def get_session(
-    session_id: str,
-    storage: SecondaryStorage,
-) -> SessionData | None:
-    raw = storage.get(f"{_SESSION_KEY_PREFIX}{session_id}")
-    if raw is None:
+    session_token: str,
+    storage: SessionStorage,
+    config: SessionConfig | None = None,
+) -> SessionRecord | None:
+    result = _get_session(session_token, storage, resolve_config(config))
+    return result[0] if result is not None else None
+
+
+def _get_session(
+    session_token: str,
+    storage: SessionStorage,
+    resolved: SessionConfig,
+) -> tuple[SessionRecord, bool] | None:
+    """Resolve a session by token, returning (record, refreshed).
+
+    ``refreshed`` is True when the ``update_age`` window elapsed and the record
+    was rolled forward (extending ``expires_at``); callers serving cookies use
+    it to decide whether to reissue Set-Cookie with a fresh Max-Age.
+    """
+    now = datetime.now(tz=timezone.utc)
+    session = storage.get(
+        token_hash=hash_session_token(session_token, resolved["token_hasher"]),
+        now=now,
+    )
+    if session is None:
         return None
-    session = SessionData.model_validate_json(raw)
-    if datetime.now(tz=timezone.utc) > session.expires_at:
-        storage.delete(f"{_SESSION_KEY_PREFIX}{session_id}")
+
+    update_age = resolved.get("update_age")
+    if update_age is None:
+        return session, False
+
+    if now - session.updated_at < timedelta(seconds=update_age):
+        return session, False
+
+    refreshed = storage.refresh(
+        session.id,
+        updated_at=now,
+        expires_at=now + timedelta(seconds=resolved["max_age"]),
+        last_active_at=now,
+    )
+    if refreshed is None:
         return None
-    return session
+    return refreshed, True
 
 
 def delete_session(
-    session_id: str,
-    storage: SecondaryStorage,
+    session_token: str,
+    storage: SessionStorage,
+    config: SessionConfig | None = None,
 ) -> None:
-    try:
-        storage.delete(f"{_SESSION_KEY_PREFIX}{session_id}")
-    except KeyError:
-        # MemoryStorage.delete raises KeyError for missing keys;
-        # silently ignore since the goal is to ensure the session is gone.
-        pass
+    resolved = resolve_config(config)
+    now = datetime.now(tz=timezone.utc)
+    session = storage.get(
+        token_hash=hash_session_token(session_token, resolved["token_hasher"]),
+        now=now,
+    )
+    if session is not None:
+        storage.revoke(session.id, revoked_at=now)
 
 
 def _build_cookie(
@@ -93,24 +176,25 @@ def _build_cookie(
     max_age: int,
     resolved: SessionConfig,
 ) -> Cookie:
+    cookies = resolved["cookies"]
     return Cookie(
-        name=resolved["cookie_name"],
+        name=cookies["name"],
         value=value,
-        secure=resolved["secure"],
-        path=resolved["path"],
-        domain=resolved["domain"],
+        secure=cookies["secure"],
+        path=cookies["path"],
+        domain=cookies["domain"],
         max_age=max_age,
-        httponly=resolved["httponly"],
-        samesite=resolved["samesite"],
+        httponly=cookies["httponly"],
+        samesite=cookies["samesite"],
     )
 
 
 def make_session_cookie(
-    session_id: str,
+    session_token: str,
     config: SessionConfig | None = None,
 ) -> Cookie:
     resolved = resolve_config(config)
-    return _build_cookie(session_id, resolved["max_age"], resolved)
+    return _build_cookie(session_token, resolved["max_age"], resolved)
 
 
 def make_clear_cookie(
@@ -121,15 +205,77 @@ def make_clear_cookie(
 
 def get_current_user(
     request: HTTPRequest,
-    storage: SecondaryStorage,
+    storage: SessionStorage,
     accounts_storage: AccountsStorage,
     config: SessionConfig | None = None,
 ) -> User | None:
-    resolved = resolve_config(config)
-    session_id = request.cookies.get(resolved["cookie_name"])
-    if session_id is None:
-        return None
-    session = get_session(session_id, storage)
+    session = get_current_session(request, storage, config)
     if session is None:
         return None
     return accounts_storage.find_user_by_id(session.user_id)
+
+
+@dataclass(frozen=True)
+class ResolvedSession:
+    record: SessionRecord
+    token: str
+    source: Literal["cookie", "bearer"]
+    refreshed: bool
+
+
+def resolve_current_session(
+    request: HTTPRequest,
+    storage: SessionStorage,
+    config: SessionConfig | None = None,
+) -> ResolvedSession | None:
+    """Resolve the request's session, preferring the cookie over a bearer token.
+
+    Unlike ``get_current_session`` this also reports the transport the token
+    arrived on and whether the record was just refreshed, so a response-aware
+    caller can roll the session cookie forward.
+    """
+    resolved = resolve_config(config)
+
+    cookie_token = request.cookies.get(resolved["cookies"]["name"])
+    if cookie_token is not None:
+        result = _get_session(cookie_token, storage, resolved)
+        if result is not None:
+            record, refreshed = result
+            return ResolvedSession(record, cookie_token, "cookie", refreshed)
+
+    bearer_token = _get_bearer_token(request)
+    if bearer_token is not None:
+        result = _get_session(bearer_token, storage, resolved)
+        if result is not None:
+            record, refreshed = result
+            return ResolvedSession(record, bearer_token, "bearer", refreshed)
+
+    return None
+
+
+def get_current_session(
+    request: HTTPRequest,
+    storage: SessionStorage,
+    config: SessionConfig | None = None,
+) -> SessionRecord | None:
+    resolution = resolve_current_session(request, storage, config)
+    return resolution.record if resolution is not None else None
+
+
+def _get_bearer_token(request: HTTPRequest) -> str | None:
+    authorization = _get_header(request.headers, "authorization")
+    if authorization is None:
+        return None
+
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        return None
+    return token.strip()
+
+
+def _get_header(headers: Mapping[str, str], name: str) -> str | None:
+    normalized = name.lower()
+    for key, value in headers.items():
+        if key.lower() == normalized:
+            return value
+    return None

--- a/src/cross_auth/_storage.py
+++ b/src/cross_auth/_storage.py
@@ -1,7 +1,19 @@
+from collections.abc import Iterable, Sequence
 from datetime import datetime
-from typing import Any, Iterable
+from typing import Any, Literal
 
+from pydantic import AwareDatetime
 from typing_extensions import Protocol
+
+SessionStatus = Literal["active", "expired", "revoked"]
+SessionListOrder = Literal[
+    "updated_at_desc",
+    "updated_at_asc",
+    "created_at_desc",
+    "created_at_asc",
+    "expires_at_desc",
+    "expires_at_asc",
+]
 
 
 class SocialAccount(Protocol):
@@ -38,6 +50,89 @@ class SecondaryStorage(Protocol):
     def pop(self, key: str) -> str | None:
         """Atomically get and delete a key. Returns None if key doesn't exist."""
         ...
+
+
+class SessionRecord(Protocol):
+    id: Any
+    user_id: Any
+    created_at: AwareDatetime
+    updated_at: AwareDatetime
+    expires_at: AwareDatetime
+    last_active_at: AwareDatetime | None
+    revoked_at: AwareDatetime | None
+    client_id: str | None
+    client_name: str | None
+    user_agent: str | None
+    ip: str | None
+
+    @property
+    def status(self) -> SessionStatus: ...
+
+
+class SessionListResult(Protocol):
+    records: Sequence[SessionRecord]
+    next_cursor: str | None
+
+
+class SessionStorage(Protocol):
+    def create(
+        self,
+        *,
+        token_hash: str,
+        user_id: Any,
+        created_at: AwareDatetime,
+        updated_at: AwareDatetime,
+        expires_at: AwareDatetime,
+        client_id: str | None = None,
+        client_name: str | None = None,
+        user_agent: str | None = None,
+        ip: str | None = None,
+        last_active_at: AwareDatetime | None = None,
+    ) -> SessionRecord: ...
+
+    def get(
+        self,
+        *,
+        token_hash: str,
+        now: AwareDatetime,
+    ) -> SessionRecord | None: ...
+
+    def get_any(self, session_id: Any) -> SessionRecord | None: ...
+
+    def list_for_user(
+        self,
+        user_id: Any,
+        *,
+        now: AwareDatetime,
+        status: SessionStatus | None = None,
+        order_by: SessionListOrder = "updated_at_desc",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> SessionListResult: ...
+
+    def refresh(
+        self,
+        session_id: Any,
+        *,
+        updated_at: AwareDatetime,
+        expires_at: AwareDatetime,
+        last_active_at: AwareDatetime | None = None,
+    ) -> SessionRecord | None: ...
+
+    def revoke(
+        self,
+        session_id: Any,
+        *,
+        revoked_at: AwareDatetime,
+    ) -> None: ...
+
+    def revoke_all_for_user(
+        self,
+        user_id: Any,
+        *,
+        revoked_at: AwareDatetime,
+        except_session_id: Any | None = None,
+    ) -> int: ...
 
 
 class AccountsStorage(Protocol):

--- a/src/cross_auth/_tokens.py
+++ b/src/cross_auth/_tokens.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from cross_web import HTTPRequest
+
+TokenGrantType = Literal["authorization_code", "password"]
+
+
+@dataclass(frozen=True, kw_only=True)
+class TokenIssueRequest:
+    user_id: str
+    client_id: str
+    grant_type: TokenGrantType
+    scope: str | None
+    http_request: HTTPRequest
+    username: str | None = None
+
+
+TokenIssuer = Callable[[TokenIssueRequest], tuple[str, int]]

--- a/src/cross_auth/fastapi.py
+++ b/src/cross_auth/fastapi.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Literal, overload
+from datetime import datetime, timezone
+from typing import Any, Literal, overload
 
 from cross_web import AsyncHTTPRequest, Cookie, HTTPRequest
 from cross_web import Response as CrossWebResponse
@@ -14,14 +15,27 @@ from ._context import AccountsStorage, SecondaryStorage, User
 from ._password import authenticate
 from ._request import make_http_request
 from ._session import (
+    ResolvedSession,
     SessionConfig,
+    SessionMetadata,
     create_session,
-    delete_session,
     get_current_user,
     make_clear_cookie,
     make_session_cookie,
     resolve_config,
+    resolve_current_session,
 )
+from ._session import (
+    get_session as get_session_by_token,
+)
+from ._storage import (
+    SessionListOrder,
+    SessionListResult,
+    SessionRecord,
+    SessionStatus,
+    SessionStorage,
+)
+from ._tokens import TokenIssuer
 from .hooks import (
     AfterAuthenticateEvent,
     AfterLoginEvent,
@@ -68,9 +82,9 @@ class CrossAuth:
         providers: list[OAuth2Provider],
         storage: SecondaryStorage,
         accounts_storage: AccountsStorage,
-        create_token: Callable[[str], tuple[str, int]],
         trusted_origins: list[str],
-        session_config: SessionConfig | None = None,
+        session_storage: SessionStorage | None = None,
+        token_issuer: TokenIssuer | None = None,
         get_user_from_request: Callable[[HTTPRequest], User | None] | None = None,
         base_url: str | None = None,
         config: Config | None = None,
@@ -78,7 +92,8 @@ class CrossAuth:
     ):
         self._storage = storage
         self._accounts_storage = accounts_storage
-        self._session_config = session_config
+        self._session_storage = session_storage
+        self._session_config: SessionConfig | None = (config or {}).get("session")
         self._hooks = HookRegistry()
 
         self._get_user_from_request = (
@@ -89,13 +104,12 @@ class CrossAuth:
             providers=providers,
             secondary_storage=storage,
             accounts_storage=accounts_storage,
+            session_storage=session_storage,
+            token_issuer=token_issuer,
             get_user_from_request=self._get_user_from_request,
-            create_token=create_token,
             trusted_origins=trusted_origins,
             base_url=base_url,
             config=config,
-            session_enabled=True,
-            session_config=self._session_config,
             default_next_url=default_next_url,
             hooks=self._hooks,
         )
@@ -104,10 +118,17 @@ class CrossAuth:
     def router(self) -> AuthRouter:
         return self._router
 
+    def _require_session_storage(self) -> SessionStorage:
+        if self._session_storage is None:
+            raise RuntimeError("session_storage is required for session operations")
+        return self._session_storage
+
     def _default_get_user_from_request(self, request: HTTPRequest) -> User | None:
+        if self._session_storage is None:
+            return None
         return get_current_user(
             request,
-            self._storage,
+            self._session_storage,
             self._accounts_storage,
             self._session_config,
         )
@@ -116,14 +137,113 @@ class CrossAuth:
         async_request = AsyncHTTPRequest.from_fastapi(request)
         return self._get_user_from_request(make_http_request(async_request))
 
-    def get_current_user(self, request: FastAPIRequest) -> User | None:
+    def get_current_user(
+        self, request: FastAPIRequest, response: FastAPIResponse
+    ) -> User | None:
+        # Roll the cookie before resolving the user so the refresh is captured
+        # here; the resolver then re-reads the (already refreshed) record.
+        self._roll_session_cookie(request, response)
         return self._resolve_user(request)
 
-    def require_current_user(self, request: FastAPIRequest) -> User:
+    def get_current_session(
+        self, request: FastAPIRequest, response: FastAPIResponse
+    ) -> SessionRecord | None:
+        session_storage = self._require_session_storage()
+        async_request = AsyncHTTPRequest.from_fastapi(request)
+        resolution = resolve_current_session(
+            make_http_request(async_request),
+            session_storage,
+            self._session_config,
+        )
+        if resolution is None:
+            return None
+        self._roll_cookie_for(resolution, response)
+        return resolution.record
+
+    def require_current_user(
+        self, request: FastAPIRequest, response: FastAPIResponse
+    ) -> User:
+        self._roll_session_cookie(request, response)
         user = self._resolve_user(request)
         if user is None:
             raise HTTPException(status_code=401)
         return user
+
+    def _roll_cookie_for(
+        self, resolution: ResolvedSession, response: FastAPIResponse
+    ) -> None:
+        """Reissue Set-Cookie when a cookie-backed session was just refreshed.
+
+        Sliding sessions (``update_age``) extend the stored ``expires_at`` on
+        read; without re-sending the cookie the browser would still drop it at
+        the original Max-Age. Bearer tokens have no cookie to roll.
+        """
+        if resolution.source == "cookie" and resolution.refreshed:
+            cookie = make_session_cookie(resolution.token, self._session_config)
+            self._set_cookie_on_response(response, cookie)
+
+    def _roll_session_cookie(
+        self, request: FastAPIRequest, response: FastAPIResponse | None
+    ) -> None:
+        # No response to write to, no store, or no sliding window -> nothing to do.
+        if response is None or self._session_storage is None:
+            return
+        if resolve_config(self._session_config).get("update_age") is None:
+            return
+        async_request = AsyncHTTPRequest.from_fastapi(request)
+        resolution = resolve_current_session(
+            make_http_request(async_request),
+            self._session_storage,
+            self._session_config,
+        )
+        if resolution is not None:
+            self._roll_cookie_for(resolution, response)
+
+    def list_sessions(
+        self,
+        user_id: Any,
+        *,
+        status: SessionStatus | None = None,
+        order_by: SessionListOrder = "updated_at_desc",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> SessionListResult:
+        return self._require_session_storage().list_for_user(
+            user_id,
+            now=datetime.now(tz=timezone.utc),
+            status=status,
+            order_by=order_by,
+            limit=limit,
+            cursor=cursor,
+        )
+
+    def get_session(self, session_id: Any, *, user_id: Any) -> SessionRecord | None:
+        session = self._require_session_storage().get_any(session_id)
+        if session is None or str(session.user_id) != str(user_id):
+            return None
+        return session
+
+    def revoke_session(self, session_id: Any, *, user_id: Any) -> None:
+        session = self.get_session(session_id, user_id=user_id)
+        if session is None:
+            return
+        self._require_session_storage().revoke(
+            session.id,
+            revoked_at=datetime.now(tz=timezone.utc),
+        )
+
+    def revoke_other_sessions(self, *, user_id: Any, keep_session_id: Any) -> int:
+        return self._require_session_storage().revoke_all_for_user(
+            user_id,
+            revoked_at=datetime.now(tz=timezone.utc),
+            except_session_id=keep_session_id,
+        )
+
+    def revoke_all_sessions(self, *, user_id: Any) -> int:
+        return self._require_session_storage().revoke_all_for_user(
+            user_id,
+            revoked_at=datetime.now(tz=timezone.utc),
+        )
 
     def authenticate(self, email: str, password: str) -> User | None:
         event = self._hooks.run_before(
@@ -308,7 +428,14 @@ class CrossAuth:
         for cookie in source.cookies or []:
             self._set_cookie_on_response(target, cookie)
 
-    def login(self, user_id: str, *, response: FastAPIResponse) -> None:
+    def login(
+        self,
+        user_id: str,
+        *,
+        response: FastAPIResponse,
+        metadata: SessionMetadata | None = None,
+    ) -> None:
+        session_storage = self._require_session_storage()
         hook_response = self._make_hook_response(response)
         event = self._hooks.run_before(
             "login",
@@ -316,39 +443,56 @@ class CrossAuth:
         )
         resolved = resolve_config(self._session_config)
         max_age = resolved["max_age"]
-        session_id, session_data = create_session(
-            event.user_id, self._storage, max_age=max_age
+        session_token, session_record = create_session(
+            event.user_id,
+            session_storage,
+            max_age=max_age,
+            metadata=metadata,
+            token_hasher=resolved["token_hasher"],
         )
-        cookie = make_session_cookie(session_id, self._session_config)
+        cookie = make_session_cookie(session_token, self._session_config)
         self._add_cookie_to_hook_response(event.response, cookie)
         self._hooks.run_after(
             "login",
             AfterLoginEvent(
                 user_id=event.user_id,
                 response=event.response,
-                session_id=session_id,
-                session_data=session_data,
+                session_record=session_record,
                 cookie=cookie,
             ),
         )
         self._apply_hook_response(event.response, response)
 
     def logout(self, request: FastAPIRequest, *, response: FastAPIResponse) -> None:
+        session_storage = self._require_session_storage()
         resolved = resolve_config(self._session_config)
-        cookie_name = resolved["cookie_name"]
+        cookie_name = resolved["cookies"]["name"]
         hook_request = make_http_request(AsyncHTTPRequest.from_fastapi(request))
         hook_response = self._make_hook_response(response)
+        session_token = hook_request.cookies.get(cookie_name)
+        session_record = (
+            get_session_by_token(
+                session_token,
+                session_storage,
+                self._session_config,
+            )
+            if session_token is not None
+            else None
+        )
         event = self._hooks.run_before(
             "logout",
             BeforeLogoutEvent(
                 request=hook_request,
                 response=hook_response,
-                session_id=hook_request.cookies.get(cookie_name),
+                session_record=session_record,
             ),
         )
 
-        if event.session_id is not None:
-            delete_session(event.session_id, self._storage)
+        if event.session_record is not None:
+            session_storage.revoke(
+                event.session_record.id,
+                revoked_at=datetime.now(tz=timezone.utc),
+            )
 
         cookie = make_clear_cookie(self._session_config)
         self._add_cookie_to_hook_response(event.response, cookie)
@@ -357,7 +501,7 @@ class CrossAuth:
             AfterLogoutEvent(
                 request=event.request,
                 response=event.response,
-                session_id=event.session_id,
+                session_record=event.session_record,
             ),
         )
         self._apply_hook_response(event.response, response)

--- a/src/cross_auth/hooks/events.py
+++ b/src/cross_auth/hooks/events.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
         AuthorizationCodeGrantRequest,
         PasswordGrantRequest,
     )
-    from .._session import SessionData
+    from .._storage import SessionRecord
     from .._storage import SocialAccount, User
     from ..models.oauth_token_response import TokenResponse
     from ..social_providers.oauth import (
@@ -45,8 +45,7 @@ class BeforeLoginEvent:
 class AfterLoginEvent:
     user_id: str
     response: Response
-    session_id: str
-    session_data: SessionData
+    session_record: SessionRecord
     cookie: Cookie
 
 
@@ -54,14 +53,14 @@ class AfterLoginEvent:
 class BeforeLogoutEvent:
     request: HTTPRequest
     response: Response
-    session_id: str | None
+    session_record: SessionRecord | None
 
 
 @dataclass(frozen=True, slots=True)
 class AfterLogoutEvent:
     request: HTTPRequest
     response: Response
-    session_id: str | None
+    session_record: SessionRecord | None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/cross_auth/router.py
+++ b/src/cross_auth/router.py
@@ -19,7 +19,8 @@ from ._config import Config
 from ._context import AccountsStorage, Context, SecondaryStorage, User
 from ._issuer import Issuer
 from ._route import Route
-from ._session import SessionConfig
+from ._storage import SessionStorage
+from ._tokens import TokenIssuer
 from .hooks import HookRegistry
 from .social_providers.oauth import OAuth2Provider
 
@@ -29,7 +30,7 @@ logger = logging.getLogger(__name__)
 FlowHandler = Callable[..., Response]
 
 
-def _provider_routes(provider: OAuth2Provider) -> list[Route]:
+def _provider_routes(provider: OAuth2Provider, *, cookie_auth: bool) -> list[Route]:
     prefix = f"/{provider.id}"
 
     def bound(
@@ -37,67 +38,77 @@ def _provider_routes(provider: OAuth2Provider) -> list[Route]:
     ) -> Callable[..., Response]:
         return partial(handler, provider)
 
-    return [
-        Route(
-            path=f"{prefix}/login",
-            methods=["GET"],
-            function=bound(start_session_flow),
-            operation_id=f"{provider.id}_login",
-        ),
-        Route(
-            path=f"{prefix}/connect",
-            methods=["GET"],
-            function=bound(start_connect_flow),
-            operation_id=f"{provider.id}_connect",
-        ),
-        Route(
-            path=f"{prefix}/social-accounts",
-            methods=["DELETE"],
-            function=bound(disconnect_provider),
-            operation_id=f"{provider.id}_disconnect",
-        ),
-        Route(
-            path=f"{prefix}/social-accounts/{{social_account_id}}",
-            methods=["DELETE"],
-            function=bound(disconnect_provider),
-            operation_id=f"{provider.id}_disconnect_account",
-            path_parameters=[
-                {
-                    "name": "social_account_id",
-                    "in": "path",
-                    "required": True,
-                    "schema": {"type": "string", "title": "Social Account Id"},
-                }
-            ],
-        ),
-        Route(
-            path=f"{prefix}/authorize",
-            methods=["GET"],
-            function=bound(start_token_flow),
-            operation_id=f"{provider.id}_authorize",
-        ),
-        Route(
-            path=f"{prefix}/callback",
-            methods=["GET", "POST"],  # POST for Apple (response_mode=form_post)
-            function=bound(handle_callback),
-            operation_id=f"{provider.id}_callback",
-            read_form_data=True,
-        ),
-        Route(
-            path=f"{prefix}/link",
-            methods=["POST"],
-            function=bound(start_link_flow),
-            operation_id=f"{provider.id}_link",
-            read_body=True,
-        ),
-        Route(
-            path=f"{prefix}/finalize-link",
-            methods=["POST"],
-            function=bound(finalize_link),
-            operation_id=f"{provider.id}_finalize_link",
-            read_body=True,
-        ),
-    ]
+    routes: list[Route] = []
+
+    if cookie_auth:
+        routes.append(
+            Route(
+                path=f"{prefix}/login",
+                methods=["GET"],
+                function=bound(start_session_flow),
+                operation_id=f"{provider.id}_login",
+            )
+        )
+
+    routes.extend(
+        [
+            Route(
+                path=f"{prefix}/connect",
+                methods=["GET"],
+                function=bound(start_connect_flow),
+                operation_id=f"{provider.id}_connect",
+            ),
+            Route(
+                path=f"{prefix}/social-accounts",
+                methods=["DELETE"],
+                function=bound(disconnect_provider),
+                operation_id=f"{provider.id}_disconnect",
+            ),
+            Route(
+                path=f"{prefix}/social-accounts/{{social_account_id}}",
+                methods=["DELETE"],
+                function=bound(disconnect_provider),
+                operation_id=f"{provider.id}_disconnect_account",
+                path_parameters=[
+                    {
+                        "name": "social_account_id",
+                        "in": "path",
+                        "required": True,
+                        "schema": {"type": "string", "title": "Social Account Id"},
+                    }
+                ],
+            ),
+            Route(
+                path=f"{prefix}/authorize",
+                methods=["GET"],
+                function=bound(start_token_flow),
+                operation_id=f"{provider.id}_authorize",
+            ),
+            Route(
+                path=f"{prefix}/callback",
+                methods=["GET", "POST"],  # POST for Apple (response_mode=form_post)
+                function=bound(handle_callback),
+                operation_id=f"{provider.id}_callback",
+                read_form_data=True,
+            ),
+            Route(
+                path=f"{prefix}/link",
+                methods=["POST"],
+                function=bound(start_link_flow),
+                operation_id=f"{provider.id}_link",
+                read_body=True,
+            ),
+            Route(
+                path=f"{prefix}/finalize-link",
+                methods=["POST"],
+                function=bound(finalize_link),
+                operation_id=f"{provider.id}_finalize_link",
+                read_body=True,
+            ),
+        ]
+    )
+
+    return routes
 
 
 class AuthRouter(APIRouter):
@@ -109,12 +120,11 @@ class AuthRouter(APIRouter):
         secondary_storage: SecondaryStorage,
         accounts_storage: AccountsStorage,
         get_user_from_request: Callable[[HTTPRequest], User | None],
-        create_token: Callable[[str], tuple[str, int]],
         trusted_origins: list[str],
+        session_storage: SessionStorage | None = None,
+        token_issuer: TokenIssuer | None = None,
         base_url: str | None = None,
         config: Config | None = None,
-        session_enabled: bool = False,
-        session_config: SessionConfig | None = None,
         default_next_url: str = "/",
         hooks: HookRegistry | None = None,
     ):
@@ -126,20 +136,21 @@ class AuthRouter(APIRouter):
         context = Context(
             secondary_storage=secondary_storage,
             accounts_storage=accounts_storage,
-            create_token=create_token,
+            session_storage=session_storage,
+            token_issuer=token_issuer,
             trusted_origins=trusted_origins,
             get_user_from_request=get_user_from_request,
             base_url=base_url,
             config=config,
-            session_enabled=session_enabled,
-            session_config=session_config,
             default_next_url=default_next_url,
             hooks=hooks,
         )
 
         provider_routes: list[Route] = []
         for provider in providers:
-            provider_routes.extend(_provider_routes(provider))
+            provider_routes.extend(
+                _provider_routes(provider, cookie_auth=context.cookie_auth_enabled)
+            )
 
         for route in provider_routes + self.issuer.routes:
             self.add_api_route(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,19 @@ import pytest
 from cross_web import HTTPRequest
 from passlib.context import CryptContext
 
+from cross_auth._auth_flow import LinkCodeData
 from cross_auth._context import Context
 from cross_auth._issuer import AuthorizationCodeGrantData, Issuer
-from cross_auth._storage import AccountsStorage, SecondaryStorage, User as UserProtocol
+from cross_auth._storage import (
+    AccountsStorage,
+    SecondaryStorage,
+    SessionListOrder,
+    SessionListResult,
+    SessionStatus,
+    SessionStorage,
+    User as UserProtocol,
+)
 from cross_auth.exceptions import CrossAuthException
-from cross_auth._auth_flow import LinkCodeData
 
 pytestmark = pytest.mark.asyncio
 
@@ -70,6 +78,164 @@ class MemoryStorage(SecondaryStorage):
     def pop(self, key: str) -> str | None:
         """Atomically get and delete a key. Returns None if key doesn't exist."""
         return self.data.pop(key, None)
+
+
+@dataclass
+class MemorySessionRecord:
+    id: str
+    token_hash: str
+    user_id: str
+    created_at: datetime
+    updated_at: datetime
+    expires_at: datetime
+    last_active_at: datetime | None = None
+    revoked_at: datetime | None = None
+    client_id: str | None = None
+    client_name: str | None = None
+    user_agent: str | None = None
+    ip: str | None = None
+
+    @property
+    def status(self) -> SessionStatus:
+        if self.revoked_at is not None:
+            return "revoked"
+        if datetime.now(tz=timezone.utc) > self.expires_at:
+            return "expired"
+        return "active"
+
+
+@dataclass
+class MemorySessionListResult:
+    records: list[MemorySessionRecord]
+    next_cursor: str | None = None
+
+
+class MemorySessionStorage(SessionStorage):
+    def __init__(self):
+        self.records: dict[str, MemorySessionRecord] = {}
+
+    def create(
+        self,
+        *,
+        token_hash: str,
+        user_id: Any,
+        created_at: datetime,
+        updated_at: datetime,
+        expires_at: datetime,
+        client_id: str | None = None,
+        client_name: str | None = None,
+        user_agent: str | None = None,
+        ip: str | None = None,
+        last_active_at: datetime | None = None,
+    ) -> MemorySessionRecord:
+        record = MemorySessionRecord(
+            id=str(uuid.uuid4()),
+            token_hash=token_hash,
+            user_id=str(user_id),
+            created_at=created_at,
+            updated_at=updated_at,
+            expires_at=expires_at,
+            client_id=client_id,
+            client_name=client_name,
+            user_agent=user_agent,
+            ip=ip,
+            last_active_at=last_active_at,
+        )
+        self.records[record.id] = record
+        return record
+
+    def get(self, *, token_hash: str, now: datetime) -> MemorySessionRecord | None:
+        record = next(
+            (
+                record
+                for record in self.records.values()
+                if record.token_hash == token_hash
+            ),
+            None,
+        )
+        if record is None or record.revoked_at is not None or now > record.expires_at:
+            return None
+        return record
+
+    def get_any(self, session_id: Any) -> MemorySessionRecord | None:
+        return self.records.get(str(session_id))
+
+    def list_for_user(
+        self,
+        user_id: Any,
+        *,
+        now: datetime,
+        status: SessionStatus | None = None,
+        order_by: SessionListOrder = "updated_at_desc",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> SessionListResult:
+        records = [
+            record for record in self.records.values() if record.user_id == str(user_id)
+        ]
+        if status is not None:
+            records = [
+                record
+                for record in records
+                if _session_status(record, now=now) == status
+            ]
+
+        field, direction = order_by.rsplit("_", 1)
+        records.sort(
+            key=lambda record: getattr(record, field),
+            reverse=direction == "desc",
+        )
+        return cast(
+            SessionListResult,
+            MemorySessionListResult(records=records[:limit]),
+        )
+
+    def refresh(
+        self,
+        session_id: Any,
+        *,
+        updated_at: datetime,
+        expires_at: datetime,
+        last_active_at: datetime | None = None,
+    ) -> MemorySessionRecord | None:
+        record = self.get_any(session_id)
+        if record is None:
+            return None
+        record.updated_at = updated_at
+        record.expires_at = expires_at
+        record.last_active_at = last_active_at
+        return record
+
+    def revoke(self, session_id: Any, *, revoked_at: datetime) -> None:
+        record = self.get_any(session_id)
+        if record is not None:
+            record.revoked_at = revoked_at
+
+    def revoke_all_for_user(
+        self,
+        user_id: Any,
+        *,
+        revoked_at: datetime,
+        except_session_id: Any | None = None,
+    ) -> int:
+        count = 0
+        for record in self.records.values():
+            if record.user_id != str(user_id):
+                continue
+            if except_session_id is not None and record.id == str(except_session_id):
+                continue
+            if record.revoked_at is None:
+                record.revoked_at = revoked_at
+                count += 1
+        return count
+
+
+def _session_status(record: MemorySessionRecord, *, now: datetime) -> SessionStatus:
+    if record.revoked_at is not None:
+        return "revoked"
+    if now > record.expires_at:
+        return "expired"
+    return "active"
 
 
 class MemoryAccountsStorage:
@@ -251,6 +417,11 @@ def secondary_storage() -> SecondaryStorage:
 
 
 @pytest.fixture
+def session_storage() -> MemorySessionStorage:
+    return MemorySessionStorage()
+
+
+@pytest.fixture
 def accounts_storage(test_password_hash: str) -> MemoryAccountsStorage:
     return MemoryAccountsStorage(test_password_hash)
 
@@ -266,6 +437,7 @@ def logged_in_user(accounts_storage: MemoryAccountsStorage) -> User:
 def context(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
     logged_in_user: User,
 ) -> Context:
     def _get_user_from_request(request: HTTPRequest) -> UserProtocol | None:
@@ -277,7 +449,7 @@ def context(
     return Context(
         secondary_storage=secondary_storage,
         accounts_storage=accounts_storage,
-        create_token=lambda id: (f"token-{id}", 0),
+        session_storage=session_storage,
         get_user_from_request=_get_user_from_request,
         trusted_origins=["valid-frontend.com"],
     )

--- a/tests/fastapi/conftest.py
+++ b/tests/fastapi/conftest.py
@@ -6,6 +6,7 @@ from fastapi.openapi.utils import get_openapi
 from fastapi.testclient import TestClient
 
 from cross_auth._context import AccountsStorage, SecondaryStorage
+from cross_auth._storage import SessionStorage
 from cross_auth.router import AuthRouter
 
 
@@ -13,6 +14,7 @@ from cross_auth.router import AuthRouter
 def test_app(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
 ) -> FastAPI:
     app = FastAPI()
 
@@ -20,8 +22,8 @@ def test_app(
         providers=[],
         secondary_storage=secondary_storage,
         accounts_storage=accounts_storage,
+        session_storage=session_storage,
         get_user_from_request=lambda _: None,
-        create_token=lambda _: ("", 0),
         trusted_origins=[],
     )
 

--- a/tests/fastapi/test_cross_auth.py
+++ b/tests/fastapi/test_cross_auth.py
@@ -1,10 +1,11 @@
 from typing import Annotated
 
-from fastapi import Depends, FastAPI, Request
+import pytest
+from fastapi import Depends, FastAPI, Request, Response
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
-from cross_auth import AccountsStorage, SecondaryStorage, User
+from cross_auth import AccountsStorage, SecondaryStorage, SessionStorage, User
 from cross_auth._session import create_session, get_session
 from cross_auth.fastapi import CrossAuth
 from cross_auth.router import AuthRouter
@@ -12,16 +13,88 @@ from cross_auth.router import AuthRouter
 TEST_PASSWORD = "password123"  # noqa: S105
 
 
+def test_token_only_mode_without_session_storage(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+):
+    auth = CrossAuth(
+        providers=[],
+        storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        trusted_origins=[],
+    )
+    assert auth.router is not None
+
+
+def test_token_endpoint_uses_token_issuer_without_session_storage(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+):
+    issued_requests = []
+
+    def issue_token(request):
+        issued_requests.append(request)
+        return "stateless-token", 900
+
+    auth = CrossAuth(
+        providers=[],
+        storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        token_issuer=issue_token,
+        trusted_origins=[],
+    )
+    app = FastAPI()
+    app.include_router(auth.router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/token",
+            data={
+                "grant_type": "password",
+                "client_id": "mobile-app",
+                "username": "test@example.com",
+                "password": TEST_PASSWORD,
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["access_token"] == "stateless-token"
+    assert response.json()["expires_in"] == 900
+
+    [token_request] = issued_requests
+    assert token_request.user_id == "test"
+    assert token_request.client_id == "mobile-app"
+    assert token_request.grant_type == "password"
+    assert token_request.username == "test@example.com"
+
+
+def test_get_current_session_requires_session_storage(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+):
+    auth = CrossAuth(
+        providers=[],
+        storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        trusted_origins=[],
+    )
+    request = Request({"type": "http", "method": "GET", "path": "/", "headers": []})
+    response = Response()
+    with pytest.raises(RuntimeError, match="session_storage is required"):
+        auth.get_current_session(request, response)
+
+
 def _make_auth(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
     **kwargs,
 ) -> CrossAuth:
     return CrossAuth(
         providers=[],
         storage=secondary_storage,
         accounts_storage=accounts_storage,
-        create_token=lambda _: ("", 0),
+        session_storage=session_storage,
         trusted_origins=[],
         **kwargs,
     )
@@ -30,8 +103,9 @@ def _make_auth(
 def test_get_current_user(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(secondary_storage, accounts_storage, session_storage)
     app = FastAPI()
     app.include_router(auth.router)
 
@@ -41,7 +115,7 @@ def test_get_current_user(
             return {"user": None}
         return {"user": user.id}
 
-    session_id, _ = create_session("test", secondary_storage)
+    session_id, _ = create_session("test", session_storage)
 
     with TestClient(app) as client:
         resp = client.get("/me", cookies={"session_id": session_id})
@@ -52,8 +126,9 @@ def test_get_current_user(
 def test_get_current_user_no_cookie(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(secondary_storage, accounts_storage, session_storage)
     app = FastAPI()
 
     @app.get("/me")
@@ -69,8 +144,9 @@ def test_get_current_user_no_cookie(
 def test_require_current_user(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(secondary_storage, accounts_storage, session_storage)
     app = FastAPI()
 
     @app.get("/me")
@@ -81,7 +157,7 @@ def test_require_current_user(
         resp = client.get("/me")
         assert resp.status_code == 401
 
-    session_id, _ = create_session("test", secondary_storage)
+    session_id, _ = create_session("test", session_storage)
 
     with TestClient(app) as client:
         resp = client.get("/me", cookies={"session_id": session_id})
@@ -92,11 +168,13 @@ def test_require_current_user(
 def test_get_current_user_custom_session_config(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
 ):
     auth = _make_auth(
         secondary_storage,
         accounts_storage,
-        session_config={"cookie_name": "my_sid"},
+        session_storage,
+        config={"session": {"cookies": {"name": "my_sid"}}},
     )
     app = FastAPI()
 
@@ -106,7 +184,7 @@ def test_get_current_user_custom_session_config(
             return {"user": None}
         return {"user": user.id}
 
-    session_id, _ = create_session("test", secondary_storage)
+    session_id, _ = create_session("test", session_storage)
 
     with TestClient(app) as client:
         # Default cookie name should not work
@@ -122,8 +200,9 @@ def test_get_current_user_custom_session_config(
 def test_router_property(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(secondary_storage, accounts_storage, session_storage)
     assert isinstance(auth.router, AuthRouter)
 
     app = FastAPI()
@@ -133,20 +212,21 @@ def test_router_property(
 def test_auto_wired_get_user_from_request(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
 ):
     """Verify that when no get_user_from_request is provided, the router's
     context uses session-based lookup. We expose the context's callback
     through an endpoint that calls it directly."""
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(secondary_storage, accounts_storage, session_storage)
 
-    session_id, _ = create_session("test", secondary_storage)
+    session_id, _ = create_session("test", session_storage)
 
     app = FastAPI()
     app.include_router(auth.router)
 
     @app.get("/check")
-    async def check(request: Request):
-        user = auth.get_current_user(request)
+    async def check(request: Request, response: Response):
+        user = auth.get_current_user(request, response)
         if user is None:
             return {"user": None}
         return {"user": user.id}
@@ -164,8 +244,9 @@ def test_auto_wired_get_user_from_request(
 def test_authenticate(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(secondary_storage, accounts_storage, session_storage)
     user = auth.authenticate("test@example.com", TEST_PASSWORD)
     assert user is not None
     assert user.email == "test@example.com"
@@ -174,8 +255,9 @@ def test_authenticate(
 def test_authenticate_wrong_password(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(secondary_storage, accounts_storage, session_storage)
     result = auth.authenticate("test@example.com", "wrong-password")
     assert result is None
 
@@ -183,8 +265,9 @@ def test_authenticate_wrong_password(
 def test_login(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(secondary_storage, accounts_storage, session_storage)
     app = FastAPI()
 
     @app.post("/do-login")
@@ -207,8 +290,9 @@ def test_login(
 def test_login_preserves_existing_response_cookies(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(secondary_storage, accounts_storage, session_storage)
     app = FastAPI()
 
     @app.post("/do-login")
@@ -231,11 +315,13 @@ def test_login_preserves_existing_response_cookies(
 def test_login_custom_session_config(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
 ):
     auth = _make_auth(
         secondary_storage,
         accounts_storage,
-        session_config={"cookie_name": "my_sid", "max_age": 3600},
+        session_storage,
+        config={"session": {"max_age": 3600, "cookies": {"name": "my_sid"}}},
     )
     app = FastAPI()
 
@@ -255,8 +341,9 @@ def test_login_custom_session_config(
 def test_login_creates_valid_session(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(secondary_storage, accounts_storage, session_storage)
     app = FastAPI()
 
     @app.post("/do-login")
@@ -272,7 +359,7 @@ def test_login_creates_valid_session(
         assert session_id
 
     # The session should be retrievable.
-    session = get_session(session_id, secondary_storage)
+    session = get_session(session_id, session_storage)
     assert session is not None
     assert session.user_id == "test"
 
@@ -280,13 +367,14 @@ def test_login_creates_valid_session(
 def test_logout(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(secondary_storage, accounts_storage, session_storage)
     app = FastAPI()
     app.include_router(auth.router)
 
     # Create a session first.
-    session_id, _ = create_session("test", secondary_storage)
+    session_id, _ = create_session("test", session_storage)
 
     @app.post("/do-logout")
     def do_logout(request: Request):
@@ -304,16 +392,17 @@ def test_logout(
         assert "Max-Age=0" in resp.headers["set-cookie"]
 
     # Session should be deleted
-    assert get_session(session_id, secondary_storage) is None
+    assert get_session(session_id, session_storage) is None
 
 
 def test_logout_preserves_existing_response_cookies(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(secondary_storage, accounts_storage, session_storage)
     app = FastAPI()
-    session_id, _ = create_session("test", secondary_storage)
+    session_id, _ = create_session("test", session_storage)
 
     @app.post("/do-logout")
     def do_logout(request: Request):
@@ -336,8 +425,9 @@ def test_logout_preserves_existing_response_cookies(
 def test_logout_no_session_cookie(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(secondary_storage, accounts_storage, session_storage)
     app = FastAPI()
 
     @app.post("/logout")
@@ -357,15 +447,17 @@ def test_logout_no_session_cookie(
 def test_logout_custom_cookie_name(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
 ):
     auth = _make_auth(
         secondary_storage,
         accounts_storage,
-        session_config={"cookie_name": "my_sid"},
+        session_storage,
+        config={"session": {"cookies": {"name": "my_sid"}}},
     )
     app = FastAPI()
 
-    session_id, _ = create_session("test", secondary_storage)
+    session_id, _ = create_session("test", session_storage)
 
     @app.post("/logout")
     def do_logout(request: Request):
@@ -382,4 +474,4 @@ def test_logout_custom_cookie_name(
         assert "Max-Age=0" in resp.headers["set-cookie"]
 
     # Session should be deleted
-    assert get_session(session_id, secondary_storage) is None
+    assert get_session(session_id, session_storage) is None

--- a/tests/fastapi/test_hooks.py
+++ b/tests/fastapi/test_hooks.py
@@ -13,6 +13,7 @@ from fastapi.testclient import TestClient
 from respx import MockRouter
 
 from cross_auth._auth_flow import AuthRequest, LinkCodeData
+from cross_auth._config import Config
 from cross_auth._issuer import AuthorizationCodeGrantData
 from cross_auth._session import get_session
 from cross_auth.exceptions import CrossAuthException
@@ -56,15 +57,18 @@ def _make_auth(
     secondary_storage,
     accounts_storage,
     *,
+    session_storage,
     providers: list[OAuth2Provider] | None = None,
     get_user_from_request=None,
-    config=None,
+    config: Config | None = None,
 ) -> CrossAuth:
+    if config is None:
+        config = {"session": {"cookies": {"auth": True}}}
     return CrossAuth(
         providers=providers if providers is not None else [],
         storage=secondary_storage,
         accounts_storage=accounts_storage,
-        create_token=lambda user_id: (f"token-{user_id}", 0),
+        session_storage=session_storage,
         trusted_origins=["valid-frontend.com"],
         get_user_from_request=get_user_from_request,
         config=config,
@@ -74,8 +78,13 @@ def _make_auth(
 def test_authenticate_hooks(
     secondary_storage,
     accounts_storage,
+    session_storage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(
+        secondary_storage,
+        accounts_storage,
+        session_storage=session_storage,
+    )
     seen: dict[str, str | None] = {}
 
     @auth.before("authenticate")
@@ -96,8 +105,13 @@ def test_authenticate_hooks(
 def test_login_hooks_mutate_user_id_and_response(
     secondary_storage,
     accounts_storage,
+    session_storage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(
+        secondary_storage,
+        accounts_storage,
+        session_storage=session_storage,
+    )
     app = FastAPI()
 
     @auth.before("login")
@@ -125,7 +139,7 @@ def test_login_hooks_mutate_user_id_and_response(
     assert session_id is not None
     assert resp.headers["x-session-user"] == "test"
 
-    session = get_session(session_id, secondary_storage)
+    session = get_session(session_id, session_storage)
     assert session is not None
     assert session.user_id == "test"
 
@@ -133,25 +147,32 @@ def test_login_hooks_mutate_user_id_and_response(
 def test_logout_hooks(
     secondary_storage,
     accounts_storage,
+    session_storage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(
+        secondary_storage,
+        accounts_storage,
+        session_storage=session_storage,
+    )
     seen: dict[str, str | None] = {}
     session_response = Response()
     auth.login("test", response=session_response)
     session_cookie = session_response.headers["set-cookie"].split(";", 1)[0]
     session_id = session_cookie.split("=", 1)[1]
+    session_record = get_session(session_id, session_storage)
+    assert session_record is not None
 
     @auth.before("logout")
     def capture_before(event: BeforeLogoutEvent) -> None:
         assert isinstance(event.request, HTTPRequest)
         assert isinstance(event.response, CrossWebResponse)
-        seen["before"] = event.session_id
+        seen["before"] = str(event.session_record.id) if event.session_record else None
 
     @auth.after("logout")
     def capture_after(event: AfterLogoutEvent) -> None:
         assert isinstance(event.request, HTTPRequest)
         assert isinstance(event.response, CrossWebResponse)
-        seen["after"] = event.session_id
+        seen["after"] = str(event.session_record.id) if event.session_record else None
 
     request = Request(
         {
@@ -165,34 +186,29 @@ def test_logout_hooks(
     response = Response()
     auth.logout(request, response=response)
 
-    assert seen == {"before": session_id, "after": session_id}
-    assert get_session(session_id, secondary_storage) is None
+    assert seen == {"before": str(session_record.id), "after": str(session_record.id)}
+    assert get_session(session_id, session_storage) is None
 
 
 def test_logout_hooks_without_session_cookie(
     secondary_storage,
     accounts_storage,
-    monkeypatch,
+    session_storage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
-    seen: dict[str, str | None] = {}
-    delete_calls: list[str] = []
-
-    def fail_if_delete_session_is_called(session_id, storage) -> None:
-        delete_calls.append(session_id)
-
-    monkeypatch.setattr(
-        "cross_auth.fastapi.delete_session",
-        fail_if_delete_session_is_called,
+    auth = _make_auth(
+        secondary_storage,
+        accounts_storage,
+        session_storage=session_storage,
     )
+    seen: dict[str, str | None] = {}
 
     @auth.before("logout")
     def capture_before(event: BeforeLogoutEvent) -> None:
-        seen["before"] = event.session_id
+        seen["before"] = str(event.session_record.id) if event.session_record else None
 
     @auth.after("logout")
     def capture_after(event: AfterLogoutEvent) -> None:
-        seen["after"] = event.session_id
+        seen["after"] = str(event.session_record.id) if event.session_record else None
 
     request = Request(
         {
@@ -207,14 +223,18 @@ def test_logout_hooks_without_session_cookie(
     auth.logout(request, response=response)
 
     assert seen == {"before": None, "after": None}
-    assert delete_calls == []
 
 
 def test_sync_events_reject_async_hooks(
     secondary_storage,
     accounts_storage,
+    session_storage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(
+        secondary_storage,
+        accounts_storage,
+        session_storage=session_storage,
+    )
 
     with pytest.raises(
         TypeError, match="login hooks for sync events must be synchronous"
@@ -252,11 +272,13 @@ def test_policy_only_before_hooks_reject_replacement():
 def test_oauth_authorize_hooks(
     secondary_storage,
     accounts_storage,
+    session_storage,
     oauth_provider,
 ):
     auth = _make_auth(
         secondary_storage,
         accounts_storage,
+        session_storage=session_storage,
         providers=[oauth_provider],
     )
     seen: dict[str, str] = {}
@@ -302,12 +324,14 @@ def test_oauth_authorize_hooks(
 def test_oauth_callback_hooks(
     secondary_storage,
     accounts_storage,
+    session_storage,
     oauth_provider,
     respx_mock: MockRouter,
 ):
     auth = _make_auth(
         secondary_storage,
         accounts_storage,
+        session_storage=session_storage,
         providers=[oauth_provider],
     )
     seen: dict[str, str] = {}
@@ -386,12 +410,14 @@ def test_oauth_callback_hooks(
 def test_oauth_callback_hooks_run_for_session_flow(
     secondary_storage,
     accounts_storage,
+    session_storage,
     oauth_provider,
     respx_mock: MockRouter,
 ):
     auth = _make_auth(
         secondary_storage,
         accounts_storage,
+        session_storage=session_storage,
         providers=[oauth_provider],
     )
     seen: dict[str, str] = {}
@@ -457,7 +483,7 @@ def test_oauth_callback_hooks_run_for_session_flow(
     assert seen == {"email": "session-hooked@example.com"}
     assert accounts_storage.find_user_by_email("session-hooked@example.com") is not None
 
-    session = get_session(session_id, secondary_storage)
+    session = get_session(session_id, session_storage)
     assert session is not None
     assert session.user_id == "session-provider-user-id"
 
@@ -465,12 +491,14 @@ def test_oauth_callback_hooks_run_for_session_flow(
 def test_login_hooks_run_for_oauth_session_flow(
     secondary_storage,
     accounts_storage,
+    session_storage,
     oauth_provider,
     respx_mock: MockRouter,
 ):
     auth = _make_auth(
         secondary_storage,
         accounts_storage,
+        session_storage=session_storage,
         providers=[oauth_provider],
     )
     seen: dict[str, str] = {}
@@ -529,7 +557,7 @@ def test_login_hooks_run_for_oauth_session_flow(
         "after_user_id": "oauth-session-user-id",
     }
 
-    session = get_session(session_id, secondary_storage)
+    session = get_session(session_id, session_storage)
     assert session is not None
     assert session.user_id == "oauth-session-user-id"
 
@@ -537,12 +565,14 @@ def test_login_hooks_run_for_oauth_session_flow(
 def test_oauth_link_hooks(
     secondary_storage,
     accounts_storage,
+    session_storage,
     logged_in_user,
     oauth_provider,
 ):
     auth = _make_auth(
         secondary_storage,
         accounts_storage,
+        session_storage=session_storage,
         providers=[oauth_provider],
         get_user_from_request=lambda request: (
             logged_in_user
@@ -584,6 +614,7 @@ def test_oauth_link_hooks(
 def test_oauth_finalize_link_hooks(
     secondary_storage,
     accounts_storage,
+    session_storage,
     logged_in_user,
     oauth_provider,
     respx_mock: MockRouter,
@@ -591,6 +622,7 @@ def test_oauth_finalize_link_hooks(
     auth = _make_auth(
         secondary_storage,
         accounts_storage,
+        session_storage=session_storage,
         providers=[oauth_provider],
         get_user_from_request=lambda request: (
             logged_in_user
@@ -662,8 +694,13 @@ def test_oauth_finalize_link_hooks(
 def test_token_hooks(
     secondary_storage,
     accounts_storage,
+    session_storage,
 ):
-    auth = _make_auth(secondary_storage, accounts_storage)
+    auth = _make_auth(
+        secondary_storage,
+        accounts_storage,
+        session_storage=session_storage,
+    )
     blocked = False
     seen: dict[str, str] = {}
 
@@ -725,4 +762,5 @@ def test_token_hooks(
         "error_description": "Password grant disabled",
     }
     assert success_resp.status_code == 200
-    assert seen == {"access_token": "token-test"}
+    assert seen["access_token"] != "token-test"
+    assert get_session(seen["access_token"], session_storage) is not None

--- a/tests/fastapi/test_issuer.py
+++ b/tests/fastapi/test_issuer.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from fastapi.testclient import TestClient
 from inline_snapshot import snapshot
 
@@ -186,7 +188,10 @@ def test_returns_error_response_if_redirect_uri_does_not_match(
     )
 
 
-def test_returns_token_if_code_is_valid(client: TestClient, valid_code: str) -> None:
+def test_returns_token_if_code_is_valid(
+    client: TestClient,
+    valid_code: str,
+) -> None:
     response = client.post(
         "/token",
         data={
@@ -201,9 +206,9 @@ def test_returns_token_if_code_is_valid(client: TestClient, valid_code: str) -> 
     assert response.status_code == 200
     assert response.json() == snapshot(
         {
-            "access_token": "",
+            "access_token": mock.ANY,
             "token_type": "Bearer",
-            "expires_in": 0,
+            "expires_in": 86400,
             "refresh_token": None,
             "refresh_token_expires_in": None,
             "scope": "",
@@ -244,7 +249,9 @@ def test_password_grant_invalid_username(client: TestClient) -> None:
     )
 
 
-def test_password_grant_success(client: TestClient) -> None:
+def test_password_grant_success(
+    client: TestClient,
+) -> None:
     response = client.post(
         "/token",
         data={
@@ -257,9 +264,9 @@ def test_password_grant_success(client: TestClient) -> None:
     assert response.status_code == 200
     assert response.json() == snapshot(
         {
-            "access_token": "",
+            "access_token": mock.ANY,
             "token_type": "Bearer",
-            "expires_in": 0,
+            "expires_in": 86400,
             "refresh_token": None,
             "refresh_token_expires_in": None,
             "scope": "",
@@ -268,7 +275,9 @@ def test_password_grant_success(client: TestClient) -> None:
     )
 
 
-def test_password_grant_with_scope(client: TestClient) -> None:
+def test_password_grant_with_scope(
+    client: TestClient,
+) -> None:
     response = client.post(
         "/token",
         data={
@@ -282,9 +291,9 @@ def test_password_grant_with_scope(client: TestClient) -> None:
     assert response.status_code == 200
     assert response.json() == snapshot(
         {
-            "access_token": "",
+            "access_token": mock.ANY,
             "token_type": "Bearer",
-            "expires_in": 0,
+            "expires_in": 86400,
             "refresh_token": None,
             "refresh_token_expires_in": None,
             "scope": "",

--- a/tests/providers/test_oauth_authorize.py
+++ b/tests/providers/test_oauth_authorize.py
@@ -170,7 +170,6 @@ def test_authorize_rejects_invalid_client_id(
     context_with_client_validation = Context(
         secondary_storage=secondary_storage,
         accounts_storage=accounts_storage,
-        create_token=lambda id: (f"token-{id}", 0),
         get_user_from_request=lambda r: (
             logged_in_user if r.headers.get("Authorization") == "Bearer test" else None
         ),
@@ -212,7 +211,6 @@ def test_authorize_accepts_valid_client_id(
     context_with_client_validation = Context(
         secondary_storage=secondary_storage,
         accounts_storage=accounts_storage,
-        create_token=lambda id: (f"token-{id}", 0),
         get_user_from_request=lambda r: (
             logged_in_user if r.headers.get("Authorization") == "Bearer test" else None
         ),

--- a/tests/router/conftest.py
+++ b/tests/router/conftest.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 
 from cross_auth._auth_flow import AuthRequest
 from cross_auth._config import Config
-from cross_auth._storage import AccountsStorage, SecondaryStorage, User
+from cross_auth._storage import AccountsStorage, SecondaryStorage, SessionStorage, User
 from cross_auth.fastapi import CrossAuth
 from cross_auth.social_providers.oauth import OAuth2Provider
 
@@ -58,16 +58,19 @@ def _build_auth(
     *,
     storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
     providers: list[OAuth2Provider],
     trusted_origins: list[str] | None = None,
     config: Config | None = None,
     default_next_url: str = "/",
 ) -> CrossAuth:
+    if config is None:
+        config = {"session": {"cookies": {"auth": True}}}
     return CrossAuth(
         providers=providers,
         storage=storage,
         accounts_storage=accounts_storage,
-        create_token=lambda user_id: (f"token-{user_id}", 0),
+        session_storage=session_storage,
         trusted_origins=trusted_origins or ["client.example"],
         config=config,
         default_next_url=default_next_url,
@@ -79,11 +82,13 @@ def _build_auth(
 def auth(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
     fake_provider: FakeProvider,
 ) -> CrossAuth:
     return _build_auth(
         storage=secondary_storage,
         accounts_storage=accounts_storage,
+        session_storage=session_storage,
         providers=[fake_provider],
     )
 
@@ -92,12 +97,14 @@ def auth(
 def build_auth(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
     fake_provider: FakeProvider,
 ):
     def _make(**overrides: Any) -> CrossAuth:
         return _build_auth(
             storage=secondary_storage,
             accounts_storage=accounts_storage,
+            session_storage=session_storage,
             providers=[fake_provider],
             **overrides,
         )

--- a/tests/router/test_provider_hooks.py
+++ b/tests/router/test_provider_hooks.py
@@ -96,11 +96,13 @@ def hooked_provider() -> HookedFakeProvider:
 def client(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,
+    session_storage,
     hooked_provider: HookedFakeProvider,
 ) -> Generator[TestClient, None, None]:
     auth = _build_auth(
         storage=secondary_storage,
         accounts_storage=accounts_storage,
+        session_storage=session_storage,
         providers=[hooked_provider],
     )
     app = FastAPI()

--- a/tests/router/test_session_flow.py
+++ b/tests/router/test_session_flow.py
@@ -8,8 +8,9 @@ import respx
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from cross_auth._auth_flow import AuthRequest
 from cross_auth._session import get_session
-from cross_auth._storage import SecondaryStorage
+from cross_auth._storage import SecondaryStorage, SessionStorage
 
 from .conftest import (
     load_auth_request,
@@ -68,7 +69,8 @@ def test_login_respects_custom_default_next_url(
 
 @respx.mock
 def test_session_callback_creates_session_and_redirects_to_next(
-    client: TestClient, secondary_storage: SecondaryStorage
+    client: TestClient,
+    session_storage: SessionStorage,
 ):
     mock_token_and_userinfo(email="alice@example.com")
 
@@ -83,7 +85,7 @@ def test_session_callback_creates_session_and_redirects_to_next(
     session_cookie = resp.cookies.get("session_id")
     assert session_cookie is not None
 
-    session = get_session(session_cookie, secondary_storage)
+    session = get_session(session_cookie, session_storage)
     assert session is not None
 
 
@@ -113,3 +115,50 @@ def test_session_callback_reports_provider_error(client: TestClient):
     )
     assert resp.status_code == 400
     assert resp.json()["error"] == "access_denied"
+
+
+def test_login_route_unregistered_without_cookie_auth(build_auth):
+    auth = build_auth(config={})  # cookie_auth disabled
+    app = FastAPI()
+    app.include_router(auth.router)
+    with TestClient(app, follow_redirects=False) as client:
+        assert client.get("/fake/login").status_code == 404
+
+
+def test_login_route_registered_with_cookie_auth(build_auth):
+    auth = build_auth(config={"session": {"cookies": {"auth": True}}})
+    app = FastAPI()
+    app.include_router(auth.router)
+    with TestClient(app, follow_redirects=False) as client:
+        assert client.get("/fake/login").status_code == 302
+
+
+@respx.mock
+def test_session_callback_errors_without_cookie_auth(
+    build_auth,
+    secondary_storage: SecondaryStorage,
+):
+    auth = build_auth(config={})  # cookie_auth disabled; /login not registered
+    app = FastAPI()
+    app.include_router(auth.router)
+
+    mock_token_and_userinfo(email="alice@example.com")
+
+    # Inject a session-flow auth request directly (no /login route to start one).
+    secondary_storage.set(
+        "oauth:authorization_request:state-1",
+        AuthRequest(
+            flow="session",
+            provider_id="fake",
+            state="state-1",
+            next_url="/dashboard",
+        ).model_dump_json(),
+    )
+
+    with TestClient(app, follow_redirects=False) as client:
+        resp = client.get(
+            "/fake/callback", params={"code": "provider-code", "state": "state-1"}
+        )
+
+    assert resp.status_code == 400
+    assert "cookies" in resp.text

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,26 +4,68 @@ from cross_auth._context import Context
 from cross_auth._session import get_session
 
 
-def test_is_session_enabled_false_without_session_support(context: Context):
-    assert context.is_session_enabled is False
-    with pytest.raises(RuntimeError, match="Session flow not configured"):
-        context.create_session_cookie("test")
-
-
-def test_is_session_enabled_true_with_session_support(
+def test_create_session_cookie_rejects_without_session_storage(
     secondary_storage, accounts_storage
 ):
     context = Context(
         secondary_storage=secondary_storage,
         accounts_storage=accounts_storage,
-        create_token=lambda user_id: (user_id, 0),
         trusted_origins=[],
         get_user_from_request=lambda _: None,
-        session_enabled=True,
     )
 
-    assert context.is_session_enabled is True
+    with pytest.raises(RuntimeError, match="Session flow not configured"):
+        context.create_session_cookie("test")
+
+
+def test_create_session_cookie_uses_session_storage(
+    secondary_storage, accounts_storage, session_storage
+):
+    context = Context(
+        secondary_storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        session_storage=session_storage,
+        trusted_origins=[],
+        get_user_from_request=lambda _: None,
+    )
+
     cookie = context.create_session_cookie("test-user")
-    session = get_session(cookie.value, secondary_storage)
+    session = get_session(cookie.value, session_storage)
     assert session is not None
     assert session.user_id == "test-user"
+
+
+def test_cookie_auth_enabled_reflects_config(
+    secondary_storage, accounts_storage, session_storage
+):
+    enabled = Context(
+        secondary_storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        session_storage=session_storage,
+        trusted_origins=[],
+        get_user_from_request=lambda _: None,
+        config={"session": {"cookies": {"auth": True}}},
+    )
+    disabled = Context(
+        secondary_storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        session_storage=session_storage,
+        trusted_origins=[],
+        get_user_from_request=lambda _: None,
+    )
+
+    assert enabled.cookie_auth_enabled is True
+    assert disabled.cookie_auth_enabled is False
+
+
+def test_cookie_auth_without_session_storage_raises(
+    secondary_storage, accounts_storage
+):
+    with pytest.raises(ValueError, match="cookies"):
+        Context(
+            secondary_storage=secondary_storage,
+            accounts_storage=accounts_storage,
+            trusted_origins=[],
+            get_user_from_request=lambda _: None,
+            config={"session": {"cookies": {"auth": True}}},
+        )

--- a/tests/test_durable_session.py
+++ b/tests/test_durable_session.py
@@ -1,0 +1,502 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest import mock
+
+import pytest
+import time_machine
+from cross_web import HTTPRequest, TestingHTTPRequestAdapter
+from fastapi import Depends, FastAPI, Request, Response
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from inline_snapshot import snapshot
+
+from cross_auth._config import Config
+from cross_auth._context import Context
+from cross_auth._issuer import AuthorizationCodeGrantData, Issuer
+from cross_auth._session import (
+    SessionConfig,
+    create_session,
+    delete_session,
+    get_current_session,
+    get_current_user,
+    get_session,
+    hash_session_token,
+)
+from cross_auth._storage import AccountsStorage, SecondaryStorage
+from cross_auth.fastapi import CrossAuth
+
+from .conftest import MemorySessionStorage
+
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def _request(
+    *,
+    cookies: dict[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+    post_data: dict[str, str] | None = None,
+) -> HTTPRequest:
+    return HTTPRequest(
+        TestingHTTPRequestAdapter(
+            cookies=cookies,
+            headers=headers,
+            post_data=post_data,
+        )
+    )
+
+
+def _make_auth(
+    *,
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+    session_storage: MemorySessionStorage | None,
+    config: Config | None = None,
+) -> CrossAuth:
+    return CrossAuth(
+        providers=[],
+        storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        session_storage=session_storage,
+        trusted_origins=[],
+        config=config,
+    )
+
+
+@time_machine.travel(NOW, tick=False)
+def test_create_session_hashes_token_and_stores_metadata(
+    session_storage: MemorySessionStorage,
+):
+    session_token, record = create_session(
+        "test",
+        session_storage,
+        max_age=3600,
+        metadata={
+            "client_id": "web",
+            "client_name": "Example Web",
+            "user_agent": "Mozilla/5.0",
+            "ip": "203.0.113.10",
+        },
+    )
+
+    assert session_token
+    assert record.user_id == "test"
+    assert record.created_at == NOW
+    assert record.updated_at == NOW
+    assert record.last_active_at == NOW
+    assert record.expires_at == NOW + timedelta(seconds=3600)
+    assert record.client_id == "web"
+    assert record.client_name == "Example Web"
+    assert record.user_agent == "Mozilla/5.0"
+    assert record.ip == "203.0.113.10"
+
+    stored = next(iter(session_storage.records.values()))
+    assert stored.token_hash == hash_session_token(session_token)
+    assert stored.token_hash != session_token
+
+
+@time_machine.travel(NOW, tick=False)
+def test_lookup_rejects_expired_and_revoked_sessions_without_deleting_records(
+    session_storage: MemorySessionStorage,
+):
+    expired_token, expired_record = create_session("test", session_storage, max_age=1)
+    revoked_token, revoked_record = create_session(
+        "test", session_storage, max_age=3600
+    )
+
+    with time_machine.travel(NOW + timedelta(seconds=2), tick=False):
+        assert get_session(expired_token, session_storage) is None
+
+    assert session_storage.get_any(expired_record.id) is expired_record
+
+    with time_machine.travel(NOW + timedelta(seconds=3), tick=False):
+        delete_session(revoked_token, session_storage)
+        assert get_session(revoked_token, session_storage) is None
+
+    assert session_storage.get_any(revoked_record.id) is revoked_record
+    assert revoked_record.revoked_at == NOW + timedelta(seconds=3)
+
+
+@time_machine.travel(NOW, tick=False)
+def test_get_current_user_resolves_cookie_then_bearer_and_refreshes(
+    accounts_storage: AccountsStorage,
+    session_storage: MemorySessionStorage,
+):
+    config: SessionConfig = {"max_age": 60, "update_age": 10}
+
+    cookie_token, cookie_record = create_session("test", session_storage, max_age=60)
+    bearer_token, bearer_record = create_session("test", session_storage, max_age=60)
+
+    cookie_request = _request(cookies={"session_id": cookie_token})
+    bearer_request = _request(headers={"Authorization": f"Bearer {bearer_token}"})
+
+    with time_machine.travel(NOW + timedelta(seconds=11), tick=False):
+        user = get_current_user(
+            cookie_request,
+            session_storage,
+            accounts_storage,
+            config,
+        )
+        current_session = get_current_session(
+            bearer_request,
+            session_storage,
+            config,
+        )
+
+    assert user is not None
+    assert user.id == "test"
+    assert cookie_record.updated_at == NOW + timedelta(seconds=11)
+    assert cookie_record.expires_at == NOW + timedelta(seconds=71)
+    assert cookie_record.last_active_at == NOW + timedelta(seconds=11)
+    assert current_session is bearer_record
+
+
+@time_machine.travel(NOW, tick=False)
+def test_cross_auth_management_apis_enforce_ownership_and_revoke_sessions(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+    session_storage: MemorySessionStorage,
+):
+    auth = _make_auth(
+        secondary_storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        session_storage=session_storage,
+    )
+
+    _, current_record = create_session("test", session_storage, max_age=3600)
+    with time_machine.travel(NOW + timedelta(seconds=1), tick=False):
+        _, other_record = create_session("test", session_storage, max_age=3600)
+    with time_machine.travel(NOW + timedelta(seconds=2), tick=False):
+        _, different_user_record = create_session(
+            "different", session_storage, max_age=3600
+        )
+
+    listed = auth.list_sessions("test")
+    assert [record.id for record in listed.records] == [
+        other_record.id,
+        current_record.id,
+    ]
+    assert auth.get_session(different_user_record.id, user_id="test") is None
+
+    with time_machine.travel(NOW + timedelta(seconds=1), tick=False):
+        auth.revoke_session(other_record.id, user_id="test")
+    assert other_record.revoked_at == NOW + timedelta(seconds=1)
+
+    with time_machine.travel(NOW + timedelta(seconds=2), tick=False):
+        revoked = auth.revoke_other_sessions(
+            user_id="test",
+            keep_session_id=current_record.id,
+        )
+    assert revoked == 0
+    assert current_record.revoked_at is None
+
+    with time_machine.travel(NOW + timedelta(seconds=3), tick=False):
+        revoked = auth.revoke_all_sessions(user_id="test")
+    assert revoked == 1
+    assert current_record.revoked_at == NOW + timedelta(seconds=3)
+    assert different_user_record.revoked_at is None
+
+
+def test_cross_auth_allows_missing_session_storage(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+):
+    auth = _make_auth(
+        secondary_storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        session_storage=None,
+    )
+
+    # Session-management methods require session_storage and must fail clearly.
+    response = Response()
+    with pytest.raises(RuntimeError, match="session_storage is required"):
+        auth.login("test", response=response)
+
+
+def test_cookie_auth_without_session_storage_fails_fast(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+):
+    with pytest.raises(ValueError, match="cookies"):
+        _make_auth(
+            secondary_storage=secondary_storage,
+            accounts_storage=accounts_storage,
+            session_storage=None,
+            config={"session": {"cookies": {"auth": True}}},
+        )
+
+
+def test_after_login_event_exposes_only_session_record_and_cookie(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+    session_storage: MemorySessionStorage,
+):
+    auth = _make_auth(
+        secondary_storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        session_storage=session_storage,
+    )
+    seen: list[Any] = []
+
+    @auth.after("login")
+    def capture(event):
+        seen.append(event)
+
+    app = FastAPI()
+
+    @app.post("/login")
+    def login(request: Request):
+        response = JSONResponse({"ok": True})
+        auth.login(
+            "test",
+            response=response,
+            metadata={"user_agent": request.headers.get("User-Agent")},
+        )
+        return response
+
+    with TestClient(app) as client:
+        response = client.post("/login", headers={"User-Agent": "test-browser"})
+
+    session_token = response.cookies["session_id"]
+    assert len(seen) == 1
+    event = seen[0]
+    assert event.cookie.value == session_token
+    assert event.session_record.user_agent == "test-browser"
+    assert event.session_record.token_hash == hash_session_token(session_token)
+    assert not hasattr(event, "session_token")
+    assert not hasattr(event, "session_id")
+    assert not hasattr(event, "session_data")
+    assert not hasattr(event, "session_record_id")
+
+
+@time_machine.travel(NOW, tick=False)
+def test_authorization_code_token_endpoint_creates_session_with_session_storage(
+    secondary_storage: SecondaryStorage,
+    session_storage: MemorySessionStorage,
+    context: Context,
+):
+    issuer = Issuer()
+    code = "code-1"
+    secondary_storage.set(
+        f"oauth:code:{code}",
+        AuthorizationCodeGrantData(
+            user_id="test",
+            expires_at=NOW + timedelta(seconds=60),
+            client_id="ios-app",
+            redirect_uri="https://client.example/callback",
+            code_challenge="n4bQgYhMfWWaL-qgxVrQFaO_TxsrC4Is0V1sFbDwCgg",
+            code_challenge_method="S256",
+        ).model_dump_json(),
+    )
+
+    response = issuer.token(
+        _request(
+            headers={"User-Agent": "ios-app/1.0"},
+            post_data={
+                "grant_type": "authorization_code",
+                "client_id": "ios-app",
+                "code": code,
+                "redirect_uri": "https://client.example/callback",
+                "code_verifier": "test",
+            },
+        ),
+        context,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == snapshot(
+        {
+            "access_token": mock.ANY,
+            "token_type": "Bearer",
+            "expires_in": 86400,
+            "refresh_token": None,
+            "refresh_token_expires_in": None,
+            "scope": "",
+            "id_token": None,
+        }
+    )
+    assert [
+        {
+            "token_hash": record.token_hash,
+            "user_id": record.user_id,
+            "client_id": record.client_id,
+            "user_agent": record.user_agent,
+        }
+        for record in session_storage.records.values()
+    ] == snapshot(
+        [
+            {
+                "token_hash": mock.ANY,
+                "user_id": "test",
+                "client_id": "ios-app",
+                "user_agent": "ios-app/1.0",
+            }
+        ]
+    )
+
+
+@time_machine.travel(NOW, tick=False)
+def test_password_token_endpoint_creates_session_with_session_storage(
+    session_storage: MemorySessionStorage,
+    context: Context,
+):
+    issuer = Issuer()
+
+    response = issuer.token(
+        _request(
+            headers={"User-Agent": "ios-app/1.0"},
+            post_data={
+                "grant_type": "password",
+                "client_id": "ios-app",
+                "username": "test@example.com",
+                "password": "password123",
+            },
+        ),
+        context,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == snapshot(
+        {
+            "access_token": mock.ANY,
+            "token_type": "Bearer",
+            "expires_in": 86400,
+            "refresh_token": None,
+            "refresh_token_expires_in": None,
+            "scope": "",
+            "id_token": None,
+        }
+    )
+    assert [
+        {
+            "token_hash": record.token_hash,
+            "user_id": record.user_id,
+            "client_id": record.client_id,
+            "user_agent": record.user_agent,
+        }
+        for record in session_storage.records.values()
+    ] == snapshot(
+        [
+            {
+                "token_hash": mock.ANY,
+                "user_id": "test",
+                "client_id": "ios-app",
+                "user_agent": "ios-app/1.0",
+            }
+        ]
+    )
+
+
+def test_token_endpoint_errors_without_token_issuer_or_session_storage(
+    issuer: Issuer,
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+    valid_code: str,
+):
+    context = Context(
+        secondary_storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        session_storage=None,
+        get_user_from_request=lambda _: None,
+        trusted_origins=["client.example"],
+    )
+
+    response = issuer.token(
+        HTTPRequest.from_form_data(
+            data={
+                "grant_type": "authorization_code",
+                "client_id": "test",
+                "code": valid_code,
+                "redirect_uri": "test",
+                "code_verifier": "test",
+            }
+        ),
+        context,
+    )
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body == {
+        "error": "server_error",
+        "error_description": (
+            "The token endpoint requires token_issuer or session_storage"
+        ),
+    }
+
+
+def _sliding_app(auth: CrossAuth) -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/me")
+    def me(user: Any = Depends(auth.get_current_user)) -> dict[str, Any]:
+        return {"user": None if user is None else user.id}
+
+    return app
+
+
+@time_machine.travel(NOW, tick=False)
+def test_cookie_session_is_rolled_when_refreshed(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+    session_storage: MemorySessionStorage,
+):
+    auth = _make_auth(
+        secondary_storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        session_storage=session_storage,
+        config={
+            "session": {
+                "max_age": 60,
+                "update_age": 10,
+                "cookies": {"secure": False},
+            }
+        },
+    )
+    token, record = create_session("test", session_storage, max_age=60)
+    client = TestClient(_sliding_app(auth))
+
+    # Within update_age: no refresh, so the cookie is left untouched.
+    with time_machine.travel(NOW + timedelta(seconds=5), tick=False):
+        resp = client.get("/me", cookies={"session_id": token})
+    assert resp.json() == {"user": "test"}
+    assert "set-cookie" not in resp.headers
+
+    # Past update_age: the record rolls forward AND the cookie is reissued with
+    # a fresh Max-Age so the browser copy slides too.
+    with time_machine.travel(NOW + timedelta(seconds=20), tick=False):
+        resp = client.get("/me", cookies={"session_id": token})
+    assert resp.json() == {"user": "test"}
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "session_id=" in set_cookie
+    assert "Max-Age=60" in set_cookie
+    assert record.expires_at == NOW + timedelta(seconds=80)
+
+
+@time_machine.travel(NOW, tick=False)
+def test_bearer_session_refreshes_without_setting_cookie(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+    session_storage: MemorySessionStorage,
+):
+    auth = _make_auth(
+        secondary_storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        session_storage=session_storage,
+        config={
+            "session": {
+                "max_age": 60,
+                "update_age": 10,
+                "cookies": {"secure": False},
+            }
+        },
+    )
+    token, record = create_session("test", session_storage, max_age=60)
+    client = TestClient(_sliding_app(auth))
+
+    # Bearer transport has no cookie to roll, but the record still slides.
+    with time_machine.travel(NOW + timedelta(seconds=20), tick=False):
+        resp = client.get("/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.json() == {"user": "test"}
+    assert "set-cookie" not in resp.headers
+    assert record.expires_at == NOW + timedelta(seconds=80)

--- a/tests/test_issuer.py
+++ b/tests/test_issuer.py
@@ -1,13 +1,17 @@
 from datetime import datetime, timedelta, timezone
+from unittest import mock
 
 from cross_web import HTTPRequest
 from inline_snapshot import snapshot
 
 from cross_auth._context import Context
 from cross_auth._issuer import AuthorizationCodeGrantData, Issuer
+from cross_auth._password import DUMMY_PASSWORD_HASH
 from cross_auth._storage import SecondaryStorage
 from cross_auth.exceptions import CrossAuthException
 from cross_auth.hooks import BeforeTokenPasswordEvent
+
+from .conftest import MemorySessionStorage
 
 
 def test_issuer(issuer: Issuer):
@@ -225,8 +229,11 @@ def test_returns_error_response_if_client_id_does_not_match(
     )
 
 
-def test_returns_token_if_code_is_valid(
-    issuer: Issuer, context: Context, valid_code: str
+def test_returns_opaque_session_token_if_code_is_valid(
+    issuer: Issuer,
+    context: Context,
+    valid_code: str,
+    session_storage: MemorySessionStorage,
 ):
     response = issuer.token(
         HTTPRequest.from_form_data(
@@ -244,13 +251,176 @@ def test_returns_token_if_code_is_valid(
     assert response.status_code == 200
     assert response.json() == snapshot(
         {
-            "access_token": "token-test",
+            "access_token": mock.ANY,
             "token_type": "Bearer",
-            "expires_in": 0,
+            "expires_in": 86400,
             "refresh_token": None,
             "refresh_token_expires_in": None,
             "scope": "",
             "id_token": None,
+        }
+    )
+    assert [
+        {
+            "token_hash": record.token_hash,
+            "user_id": record.user_id,
+            "client_id": record.client_id,
+        }
+        for record in session_storage.records.values()
+    ] == snapshot(
+        [
+            {
+                "token_hash": mock.ANY,
+                "user_id": "test",
+                "client_id": "test",
+            }
+        ]
+    )
+
+
+def test_authorization_code_grant_uses_token_issuer_without_session_storage(
+    issuer: Issuer,
+    secondary_storage: SecondaryStorage,
+    accounts_storage,
+    valid_code: str,
+):
+    issued_requests = []
+
+    def issue_token(request):
+        issued_requests.append(request)
+        return "stateless-token", 3600
+
+    context = Context(
+        secondary_storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        session_storage=None,
+        token_issuer=issue_token,
+        get_user_from_request=lambda _: None,
+        trusted_origins=["valid-frontend.com"],
+    )
+
+    http_request = HTTPRequest.from_form_data(
+        data={
+            "grant_type": "authorization_code",
+            "client_id": "test",
+            "code": valid_code,
+            "redirect_uri": "test",
+            "code_verifier": "test",
+        }
+    )
+
+    response = issuer.token(http_request, context)
+
+    assert response.status_code == 200
+    assert response.json() == snapshot(
+        {
+            "access_token": "stateless-token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": None,
+            "refresh_token_expires_in": None,
+            "scope": "",
+            "id_token": None,
+        }
+    )
+
+    [token_request] = issued_requests
+    assert token_request.user_id == "test"
+    assert token_request.client_id == "test"
+    assert token_request.grant_type == "authorization_code"
+    assert token_request.scope is None
+    assert token_request.username is None
+    assert token_request.http_request is http_request
+
+
+def test_password_grant_uses_token_issuer_without_session_storage(
+    issuer: Issuer,
+    secondary_storage: SecondaryStorage,
+    accounts_storage,
+):
+    issued_requests = []
+
+    def issue_token(request):
+        issued_requests.append(request)
+        return "password-token", 1800
+
+    context = Context(
+        secondary_storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        session_storage=None,
+        token_issuer=issue_token,
+        get_user_from_request=lambda _: None,
+        trusted_origins=["valid-frontend.com"],
+    )
+
+    http_request = HTTPRequest.from_form_data(
+        data={
+            "grant_type": "password",
+            "client_id": "test",
+            "username": "test@example.com",
+            "password": "password123",
+            "scope": "read write",
+        }
+    )
+
+    response = issuer.token(http_request, context)
+
+    assert response.status_code == 200
+    assert response.json() == snapshot(
+        {
+            "access_token": "password-token",
+            "token_type": "Bearer",
+            "expires_in": 1800,
+            "refresh_token": None,
+            "refresh_token_expires_in": None,
+            "scope": "",
+            "id_token": None,
+        }
+    )
+
+    [token_request] = issued_requests
+    assert token_request.user_id == "test"
+    assert token_request.client_id == "test"
+    assert token_request.grant_type == "password"
+    assert token_request.scope == "read write"
+    assert token_request.username == "test@example.com"
+    assert token_request.http_request is http_request
+
+
+def test_token_endpoint_errors_without_token_issuer_or_session_storage(
+    issuer: Issuer,
+    secondary_storage: SecondaryStorage,
+    accounts_storage,
+    valid_code: str,
+):
+    context = Context(
+        secondary_storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        session_storage=None,
+        get_user_from_request=lambda _: None,
+        trusted_origins=["valid-frontend.com"],
+    )
+
+    response = issuer.token(
+        HTTPRequest.from_form_data(
+            data={
+                "grant_type": "authorization_code",
+                "client_id": "test",
+                "code": valid_code,
+                "redirect_uri": "test",
+                "code_verifier": "test",
+            }
+        ),
+        context,
+    )
+
+    assert response.status_code == 400
+    assert response.json() == snapshot(
+        {
+            "error": "server_error",
+            "error_description": (
+                "The token endpoint requires token_issuer or session_storage"
+            ),
         }
     )
 
@@ -402,7 +572,11 @@ def test_password_grant_preserves_unknown_hook_error_type(
     )
 
 
-def test_password_grant_success(issuer: Issuer, context: Context):
+def test_password_grant_success(
+    issuer: Issuer,
+    context: Context,
+    session_storage: MemorySessionStorage,
+):
     response = issuer.token(
         HTTPRequest.from_form_data(
             data={
@@ -417,18 +591,38 @@ def test_password_grant_success(issuer: Issuer, context: Context):
     assert response.status_code == 200
     assert response.json() == snapshot(
         {
-            "access_token": "token-test",
+            "access_token": mock.ANY,
             "token_type": "Bearer",
-            "expires_in": 0,
+            "expires_in": 86400,
             "refresh_token": None,
             "refresh_token_expires_in": None,
             "scope": "",
             "id_token": None,
         }
     )
+    assert [
+        {
+            "token_hash": record.token_hash,
+            "user_id": record.user_id,
+            "client_id": record.client_id,
+        }
+        for record in session_storage.records.values()
+    ] == snapshot(
+        [
+            {
+                "token_hash": mock.ANY,
+                "user_id": "test",
+                "client_id": "test",
+            }
+        ]
+    )
 
 
-def test_password_grant_with_scope(issuer: Issuer, context: Context):
+def test_password_grant_with_scope(
+    issuer: Issuer,
+    context: Context,
+    session_storage: MemorySessionStorage,
+):
     response = issuer.token(
         HTTPRequest.from_form_data(
             data={
@@ -444,71 +638,70 @@ def test_password_grant_with_scope(issuer: Issuer, context: Context):
     assert response.status_code == 200
     assert response.json() == snapshot(
         {
-            "access_token": "token-test",
+            "access_token": mock.ANY,
             "token_type": "Bearer",
-            "expires_in": 0,
+            "expires_in": 86400,
             "refresh_token": None,
             "refresh_token_expires_in": None,
             "scope": "",
             "id_token": None,
         }
     )
-
-
-def test_password_grant_has_consistent_timing(issuer: Issuer, context: Context):
-    """
-    Test that password grant has consistent timing for existing and non-existing users.
-    This prevents timing attacks that could be used to enumerate valid user accounts.
-
-    Both scenarios should take roughly the same time because we always perform
-    password verification, even for non-existent users (using a dummy hash).
-    """
-    import time
-
-    # Measure timing for non-existent user (should run dummy hash verification)
-    nonexistent_times = []
-    for _ in range(3):
-        start = time.perf_counter()
-        issuer.token(
-            HTTPRequest.from_form_data(
-                data={
-                    "grant_type": "password",
-                    "client_id": "test",
-                    "username": "nonexistent@example.com",
-                    "password": "wrong_password",
-                }
-            ),
-            context,
-        )
-        end = time.perf_counter()
-        nonexistent_times.append(end - start)
-
-    # Measure timing for existing user with wrong password (should run real hash verification)
-    existing_times = []
-    for _ in range(3):
-        start = time.perf_counter()
-        issuer.token(
-            HTTPRequest.from_form_data(
-                data={
-                    "grant_type": "password",
-                    "client_id": "test",
-                    "username": "test@example.com",
-                    "password": "wrong_password",
-                }
-            ),
-            context,
-        )
-        end = time.perf_counter()
-        existing_times.append(end - start)
-
-    avg_nonexistent = sum(nonexistent_times) / len(nonexistent_times)
-    avg_existing = sum(existing_times) / len(existing_times)
-    difference = abs(avg_existing - avg_nonexistent)
-
-    # The timing difference should be minimal (<50ms)
-    # If it's larger, it indicates a timing attack vulnerability
-    assert difference < 0.05, (
-        f"Timing difference too large: {difference * 1000:.2f}ms. "
-        f"Non-existent: {avg_nonexistent * 1000:.2f}ms, "
-        f"Existing: {avg_existing * 1000:.2f}ms"
+    assert [
+        {
+            "token_hash": record.token_hash,
+            "user_id": record.user_id,
+            "client_id": record.client_id,
+        }
+        for record in session_storage.records.values()
+    ] == snapshot(
+        [
+            {
+                "token_hash": mock.ANY,
+                "user_id": "test",
+                "client_id": "test",
+            }
+        ]
     )
+
+
+def test_password_grant_verifies_password_hash_for_unknown_users(
+    issuer: Issuer,
+    context: Context,
+):
+    existing_user = context.accounts_storage.find_user_by_email("test@example.com")
+    assert existing_user is not None
+    assert existing_user.hashed_password is not None
+
+    verification_calls: list[tuple[str, str]] = []
+
+    def record_password_verification(password: str, password_hash: str) -> bool:
+        verification_calls.append((password, password_hash))
+        return False
+
+    def request_password_token(username: str):
+        return issuer.token(
+            HTTPRequest.from_form_data(
+                data={
+                    "grant_type": "password",
+                    "client_id": "test",
+                    "username": username,
+                    "password": "wrong_password",
+                }
+            ),
+            context,
+        )
+
+    with mock.patch(
+        "cross_auth._password.pwd_context.verify",
+        side_effect=record_password_verification,
+    ):
+        existing_response = request_password_token("test@example.com")
+        unknown_response = request_password_token("nonexistent@example.com")
+
+    assert existing_response.status_code == 400
+    assert unknown_response.status_code == 400
+    assert verification_calls == [
+        ("wrong_password", existing_user.hashed_password),
+        ("wrong_password", DUMMY_PASSWORD_HASH),
+    ]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from cross_web import HTTPRequest, TestingHTTPRequestAdapter
 
-from cross_auth import AccountsStorage, SecondaryStorage
+from cross_auth import AccountsStorage, SessionStorage
 from cross_auth._password import authenticate
 from cross_auth._session import (
     SessionConfig,
@@ -34,57 +34,58 @@ def test_authenticate_nonexistent_user(accounts_storage: AccountsStorage):
     assert result is None
 
 
-def test_create_session(secondary_storage: SecondaryStorage):
-    session_id, session_data = create_session("test-user", secondary_storage)
+def test_create_session(session_storage: SessionStorage):
+    session_id, session_record = create_session("test-user", session_storage)
 
     assert isinstance(session_id, str)
     assert len(session_id) > 0
-    assert session_data.user_id == "test-user"
-    assert session_data.created_at is not None
-    assert session_data.expires_at is not None
-    assert session_data.expires_at > session_data.created_at
+    assert session_record.user_id == "test-user"
+    assert session_record.created_at is not None
+    assert session_record.expires_at is not None
+    assert session_record.expires_at > session_record.created_at
 
-    raw = secondary_storage.get(f"session:{session_id}")
-    assert raw is not None
+    stored = session_storage.get_any(session_record.id)
+    assert stored is session_record
 
 
-def test_get_session(secondary_storage: SecondaryStorage):
-    session_id, original = create_session("test-user", secondary_storage)
+def test_get_session(session_storage: SessionStorage):
+    session_id, original = create_session("test-user", session_storage)
 
-    retrieved = get_session(session_id, secondary_storage)
+    retrieved = get_session(session_id, session_storage)
     assert retrieved is not None
     assert retrieved.user_id == "test-user"
     assert retrieved.created_at == original.created_at
 
 
-def test_get_session_expired(secondary_storage: SecondaryStorage):
-    session_id, _ = create_session("test-user", secondary_storage, max_age=1)
+def test_get_session_expired(session_storage: SessionStorage):
+    session_id, session = create_session("test-user", session_storage, max_age=1)
 
     future = datetime(2099, 1, 1, tzinfo=timezone.utc)
     with patch("cross_auth._session.datetime") as mock_dt:
         mock_dt.now.return_value = future
-        result = get_session(session_id, secondary_storage)
+        result = get_session(session_id, session_storage)
 
     assert result is None
-    assert secondary_storage.get(f"session:{session_id}") is None
+    assert session_storage.get_any(session.id) is session
 
 
-def test_get_session_not_found(secondary_storage: SecondaryStorage):
-    result = get_session("nonexistent-id", secondary_storage)
-    assert result is None
-
-
-def test_delete_session(secondary_storage: SecondaryStorage):
-    session_id, _ = create_session("test-user", secondary_storage)
-
-    delete_session(session_id, secondary_storage)
-
-    result = get_session(session_id, secondary_storage)
+def test_get_session_not_found(session_storage: SessionStorage):
+    result = get_session("nonexistent-id", session_storage)
     assert result is None
 
 
-def test_delete_session_not_found(secondary_storage: SecondaryStorage):
-    delete_session("nonexistent-id", secondary_storage)
+def test_delete_session(session_storage: SessionStorage):
+    session_id, session = create_session("test-user", session_storage)
+
+    delete_session(session_id, session_storage)
+
+    result = get_session(session_id, session_storage)
+    assert result is None
+    assert session.revoked_at is not None
+
+
+def test_delete_session_not_found(session_storage: SessionStorage):
+    delete_session("nonexistent-id", session_storage)
 
 
 def test_make_session_cookie():
@@ -101,13 +102,15 @@ def test_make_session_cookie():
 
 def test_make_session_cookie_custom_config():
     config: SessionConfig = {
-        "cookie_name": "my_session",
         "max_age": 3600,
-        "secure": False,
-        "httponly": False,
-        "samesite": "strict",
-        "path": "/app",
-        "domain": "example.com",
+        "cookies": {
+            "name": "my_session",
+            "secure": False,
+            "httponly": False,
+            "samesite": "strict",
+            "path": "/app",
+            "domain": "example.com",
+        },
     }
     cookie = make_session_cookie("my-session-id", config)
 
@@ -123,9 +126,11 @@ def test_make_session_cookie_custom_config():
 
 def test_make_clear_cookie():
     config: SessionConfig = {
-        "cookie_name": "my_session",
-        "path": "/app",
-        "domain": "example.com",
+        "cookies": {
+            "name": "my_session",
+            "path": "/app",
+            "domain": "example.com",
+        },
     }
     cookie = make_clear_cookie(config)
 
@@ -142,12 +147,12 @@ def _make_request(cookies: dict[str, str] | None = None) -> HTTPRequest:
 
 def test_get_current_user(
     accounts_storage: AccountsStorage,
-    secondary_storage: SecondaryStorage,
+    session_storage: SessionStorage,
 ):
-    session_id, _ = create_session("test", secondary_storage)
+    session_id, _ = create_session("test", session_storage)
     request = _make_request({"session_id": session_id})
 
-    user = get_current_user(request, secondary_storage, accounts_storage)
+    user = get_current_user(request, session_storage, accounts_storage)
 
     assert user is not None
     assert user.email == "test@example.com"
@@ -155,62 +160,62 @@ def test_get_current_user(
 
 def test_get_current_user_no_cookie(
     accounts_storage: AccountsStorage,
-    secondary_storage: SecondaryStorage,
+    session_storage: SessionStorage,
 ):
     request = _make_request()
 
-    result = get_current_user(request, secondary_storage, accounts_storage)
+    result = get_current_user(request, session_storage, accounts_storage)
 
     assert result is None
 
 
 def test_get_current_user_invalid_session(
     accounts_storage: AccountsStorage,
-    secondary_storage: SecondaryStorage,
+    session_storage: SessionStorage,
 ):
     request = _make_request({"session_id": "nonexistent"})
 
-    result = get_current_user(request, secondary_storage, accounts_storage)
+    result = get_current_user(request, session_storage, accounts_storage)
 
     assert result is None
 
 
 def test_get_current_user_expired_session(
     accounts_storage: AccountsStorage,
-    secondary_storage: SecondaryStorage,
+    session_storage: SessionStorage,
 ):
-    session_id, _ = create_session("test", secondary_storage, max_age=1)
+    session_id, _ = create_session("test", session_storage, max_age=1)
     request = _make_request({"session_id": session_id})
 
     future = datetime(2099, 1, 1, tzinfo=timezone.utc)
     with patch("cross_auth._session.datetime") as mock_dt:
         mock_dt.now.return_value = future
-        result = get_current_user(request, secondary_storage, accounts_storage)
+        result = get_current_user(request, session_storage, accounts_storage)
 
     assert result is None
 
 
 def test_get_current_user_user_not_found(
     accounts_storage: AccountsStorage,
-    secondary_storage: SecondaryStorage,
+    session_storage: SessionStorage,
 ):
-    session_id, _ = create_session("nonexistent-user", secondary_storage)
+    session_id, _ = create_session("nonexistent-user", session_storage)
     request = _make_request({"session_id": session_id})
 
-    result = get_current_user(request, secondary_storage, accounts_storage)
+    result = get_current_user(request, session_storage, accounts_storage)
 
     assert result is None
 
 
 def test_get_current_user_custom_cookie_name(
     accounts_storage: AccountsStorage,
-    secondary_storage: SecondaryStorage,
+    session_storage: SessionStorage,
 ):
-    session_id, _ = create_session("test", secondary_storage)
-    config: SessionConfig = {"cookie_name": "my_session"}
+    session_id, _ = create_session("test", session_storage)
+    config: SessionConfig = {"cookies": {"name": "my_session"}}
     request = _make_request({"my_session": session_id})
 
-    user = get_current_user(request, secondary_storage, accounts_storage, config)
+    user = get_current_user(request, session_storage, accounts_storage, config)
 
     assert user is not None
     assert user.email == "test@example.com"

--- a/website/content/docs/api/models.md
+++ b/website/content/docs/api/models.md
@@ -5,28 +5,50 @@ order: 3
 section: API Reference
 ---
 
-## SessionData
+## SessionRecord
 
-Pydantic model stored in `SecondaryStorage` as JSON under the key
-`session:{session_id}`.
+Protocol for durable session rows stored in `SessionStorage`.
 
 ```python
-from cross_auth import SessionData
+from cross_auth import SessionRecord
 ```
 
 ### Fields
 
-| Field        | Type            | Description                         |
-| ------------ | --------------- | ----------------------------------- |
-| `user_id`    | `str`           | The ID of the authenticated user.   |
-| `created_at` | `AwareDatetime` | When the session was created (UTC). |
-| `expires_at` | `AwareDatetime` | When the session expires (UTC).     |
+| Field            | Type                                 | Description                             |
+| ---------------- | ------------------------------------ | --------------------------------------- |
+| `id`             | `Any`                                | Stable database ID for the session.     |
+| `user_id`        | `Any`                                | The ID of the authenticated user.       |
+| `created_at`     | `AwareDatetime`                      | When the session was created (UTC).     |
+| `updated_at`     | `AwareDatetime`                      | When the session was last refreshed.    |
+| `expires_at`     | `AwareDatetime`                      | When the session expires (UTC).         |
+| `last_active_at` | `AwareDatetime \| None`              | Last activity timestamp.                |
+| `revoked_at`     | `AwareDatetime \| None`              | When the session was revoked.           |
+| `client_id`      | `str \| None`                        | OAuth client ID for bearer tokens.      |
+| `client_name`    | `str \| None`                        | Display name for the client.            |
+| `user_agent`     | `str \| None`                        | User agent associated with the session. |
+| `ip`             | `str \| None`                        | IP address associated with the session. |
+| `status`         | `"active" \| "expired" \| "revoked"` | Derived status.                         |
+
+## SessionListResult
+
+Protocol returned by session-listing APIs.
+
+```python
+from cross_auth import SessionListResult
+```
+
+| Field         | Type                      | Description                 |
+| ------------- | ------------------------- | --------------------------- |
+| `records`     | `Sequence[SessionRecord]` | Session records for a page. |
+| `next_cursor` | `str \| None`             | Cursor for the next page.   |
 
 ---
 
 ## SessionConfig
 
-TypedDict for configuring session cookie behavior. All fields are optional.
+TypedDict for configuring session behavior. All fields are optional. Cookie
+attributes live in the nested `cookies` field (see `SessionCookieConfig`).
 
 ```python
 from cross_auth import SessionConfig
@@ -34,24 +56,48 @@ from cross_auth import SessionConfig
 
 ### Fields
 
-| Field         | Type                          | Default        | Description                              |
-| ------------- | ----------------------------- | -------------- | ---------------------------------------- |
-| `cookie_name` | `str`                         | `"session_id"` | Name of the session cookie.              |
-| `max_age`     | `int`                         | `86400`        | Cookie lifetime in seconds (24 hours).   |
-| `secure`      | `bool`                        | `True`         | Only send cookie over HTTPS.             |
-| `httponly`    | `bool`                        | `True`         | Prevent JavaScript access to the cookie. |
-| `samesite`    | `"lax" \| "strict" \| "none"` | `"lax"`        | SameSite cookie attribute.               |
-| `path`        | `str`                         | `"/"`          | URL path the cookie is valid for.        |
-| `domain`      | `str \| None`                 | `None`         | Domain the cookie is valid for.          |
+| Field          | Type                   | Default | Description                                                                                                                                                       |
+| -------------- | ---------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `max_age`      | `int`                  | `86400` | Session lifetime in seconds (24 hours); also the session cookie's `Max-Age`.                                                                                      |
+| `update_age`   | `int \| None`          | `None`  | Sliding-session interval. After this many seconds a read rolls `expires_at` forward; cookie clients also get a fresh `Set-Cookie` so the browser copy slides too. |
+| `token_hasher` | `Callable[[str], str]` | SHA-256 | Hash function for persisted tokens.                                                                                                                               |
+| `cookies`      | `SessionCookieConfig`  | —       | Session cookie attributes (see below).                                                                                                                            |
 
 ### Example
 
 ```python
 config: SessionConfig = {
-    "cookie_name": "my_app_session",
     "max_age": 3600,
-    "secure": True,
-    "samesite": "strict",
-    "domain": ".example.com",
+    "update_age": 600,
+    "cookies": {
+        "auth": True,
+        "name": "my_app_session",
+        "secure": True,
+        "samesite": "strict",
+        "domain": ".example.com",
+    },
 }
 ```
+
+---
+
+## SessionCookieConfig
+
+TypedDict for the session cookie's attributes, nested under
+`SessionConfig["cookies"]`. All fields are optional.
+
+```python
+from cross_auth import SessionCookieConfig
+```
+
+### Fields
+
+| Field      | Type                          | Default        | Description                                                                           |
+| ---------- | ----------------------------- | -------------- | ------------------------------------------------------------------------------------- |
+| `auth`     | `bool`                        | `False`        | Register the `GET /{provider}/login` browser cookie flow. Requires `session_storage`. |
+| `name`     | `str`                         | `"session_id"` | Name of the session cookie.                                                           |
+| `secure`   | `bool`                        | `True`         | Only send cookie over HTTPS.                                                          |
+| `httponly` | `bool`                        | `True`         | Prevent JavaScript access to the cookie.                                              |
+| `samesite` | `"lax" \| "strict" \| "none"` | `"lax"`        | SameSite cookie attribute.                                                            |
+| `path`     | `str`                         | `"/"`          | URL path the cookie is valid for.                                                     |
+| `domain`   | `str \| None`                 | `None`         | Domain the cookie is valid for.                                                       |

--- a/website/content/docs/api/session-functions.md
+++ b/website/content/docs/api/session-functions.md
@@ -22,7 +22,7 @@ Creates a session and sets the session cookie directly on the provided FastAPI
 
 ### `logout(request, response=...)`
 
-Reads the session cookie from the request, deletes the session, and sets a
+Reads the session cookie from the request, revokes the session, and sets a
 clear-cookie directive on the provided FastAPI `Response`.
 
 ### `before(event)`
@@ -36,12 +36,37 @@ Registers a typed hook that runs after a Cross-Auth lifecycle event succeeds.
 ### `get_current_user(request)`
 
 A bound method usable as a FastAPI dependency. Resolves the current user from
-the session cookie. Returns `User | None`.
+the session cookie or `Authorization: Bearer ...` header. Returns `User | None`.
 
 ### `require_current_user(request)`
 
 A bound method usable as a FastAPI dependency. Same as `get_current_user` but
 raises a 401 `HTTPException` if no user is found. Returns `User`.
+
+### `list_sessions(user_id, ...)`
+
+Lists session records for a user. Supports status filters, ordering, limits, and
+cursors through the configured `SessionStorage`.
+
+### `get_session(session_id, user_id=...)`
+
+Returns one session record for the user, or `None` if the session does not exist
+or belongs to a different user.
+
+### `revoke_session(session_id, user_id=...)`
+
+Revokes one session record owned by the user.
+
+### `revoke_other_sessions(user_id=..., keep_session_id=...)`
+
+Revokes all of a user's sessions except one session ID and returns the number of
+revoked sessions.
+
+### `revoke_all_sessions(user_id=...)`
+
+Revokes all sessions for a user and returns the number of revoked sessions.
+
+Session methods require `session_storage` to be configured.
 
 ---
 
@@ -52,86 +77,88 @@ imported directly for custom framework integrations.
 
 ### create_session()
 
-Creates a new session in storage and returns the session ID and data.
+Creates a new session in storage and returns the opaque session token and
+session record.
 
 ```python
 from cross_auth._session import create_session
 
-session_id, session_data = create_session(user_id, storage, max_age=86400)
+session_token, session_record = create_session(user_id, storage, max_age=86400)
 ```
 
 #### Parameters
 
-| Parameter | Type               | Default | Description                       |
-| --------- | ------------------ | ------- | --------------------------------- |
-| `user_id` | `str`              | —       | The ID of the authenticated user. |
-| `storage` | `SecondaryStorage` | —       | Storage backend for sessions.     |
-| `max_age` | `int`              | `86400` | Session lifetime in seconds.      |
+| Parameter | Type             | Default | Description                       |
+| --------- | ---------------- | ------- | --------------------------------- |
+| `user_id` | `str`            | —       | The ID of the authenticated user. |
+| `storage` | `SessionStorage` | —       | Storage backend for sessions.     |
+| `max_age` | `int`            | `86400` | Session lifetime in seconds.      |
 
 #### Returns
 
-`tuple[str, SessionData]` -- The session ID and session data.
+`tuple[str, SessionRecord]` -- The opaque session token and session record.
 
 ---
 
 ### get_session()
 
-Retrieves a session from storage by its ID.
+Retrieves a session from storage by its opaque token.
 
 ```python
 from cross_auth._session import get_session
 
-session = get_session(session_id, storage)
+session = get_session(session_token, storage)
 ```
 
 #### Parameters
 
-| Parameter    | Type               | Description                     |
-| ------------ | ------------------ | ------------------------------- |
-| `session_id` | `str`              | The session ID from the cookie. |
-| `storage`    | `SecondaryStorage` | Storage backend for sessions.   |
+| Parameter       | Type             | Description                          |
+| --------------- | ---------------- | ------------------------------------ |
+| `session_token` | `str`            | The token from a cookie or header.   |
+| `storage`       | `SessionStorage` | Storage backend for session records. |
 
 #### Returns
 
-`SessionData | None` -- The session data, or `None` if not found or expired.
+`SessionRecord | None` -- The session record, or `None` if not found, expired,
+or revoked.
 
 ---
 
 ### delete_session()
 
-Deletes a session from storage. No-op if the session doesn't exist.
+Revokes a session in storage. No-op if the session doesn't exist.
 
 ```python
 from cross_auth._session import delete_session
 
-delete_session(session_id, storage)
+delete_session(session_token, storage)
 ```
 
 #### Parameters
 
-| Parameter    | Type               | Description                   |
-| ------------ | ------------------ | ----------------------------- |
-| `session_id` | `str`              | The session ID to delete.     |
-| `storage`    | `SecondaryStorage` | Storage backend for sessions. |
+| Parameter       | Type             | Description                          |
+| --------------- | ---------------- | ------------------------------------ |
+| `session_token` | `str`            | The session token to revoke.         |
+| `storage`       | `SessionStorage` | Storage backend for session records. |
 
 ---
 
 ### make_session_cookie()
 
-Creates a `Cookie` object with the session ID and secure defaults.
+Creates a `Cookie` object with the session token and secure defaults.
 
 ```python
 from cross_auth._session import make_session_cookie
 
-cookie = make_session_cookie(session_id, config=None)
+cookie = make_session_cookie(session_token, config=None)
 ```
 
 #### Parameters
 
-| Parameter    | Type                    | Default | Description                            |
-| ------------ | ----------------------- | ------- | -------------------------------------- |
-| `session_id` | `str`                   | —       | The session ID to store in the cookie. |
-| `config`     | `SessionConfig \| None` | `None`  | Optional configuration overrides.      |
+| Parameter       | Type                    | Default | Description                               |
+| --------------- | ----------------------- | ------- | ----------------------------------------- |
+| `session_token` | `str`                   | —       | The session token to store in the cookie. |
+| `config`        | `SessionConfig \| None` | `None`  | Optional configuration overrides.         |
 
 #### Returns
 

--- a/website/content/docs/hooks.md
+++ b/website/content/docs/hooks.md
@@ -27,9 +27,9 @@ from cross_auth.fastapi import CrossAuth
 
 auth = CrossAuth(
     providers=[],
-    storage=session_storage,
+    storage=secondary_storage,
     accounts_storage=accounts_storage,
-    create_token=lambda _: ("", 0),
+    session_storage=session_storage,
     trusted_origins=["https://myapp.com"],
 )
 ```
@@ -138,13 +138,14 @@ from cross_auth.hooks import AfterLogoutEvent, BeforeLogoutEvent
 
 @auth.before("logout")
 def require_active_session(event: BeforeLogoutEvent) -> None:
-    if event.session_id is None:
+    if event.session_record is None:
         raise CrossAuthException("unauthorized", "No active session", 401)
 
 
 @auth.after("logout")
 def audit_logout(event: AfterLogoutEvent) -> None:
-    audit_log.record("session_logout", session_id=event.session_id)
+    session_id = None if event.session_record is None else event.session_record.id
+    audit_log.record("session_logout", session_id=session_id)
 ```
 
 ## OAuth Hooks

--- a/website/content/docs/introduction.md
+++ b/website/content/docs/introduction.md
@@ -33,8 +33,8 @@ framework-specific decorators or middleware.
 
 Cross-Auth separates concerns into three layers:
 
-1. **Storage protocols** -- Define how users and sessions are persisted. You
-   implement these for your database.
+1. **Storage protocols** -- Define how users, transient OAuth data, and durable
+   sessions are persisted. You implement these for your database.
 2. **Core functions** -- Plain Python functions for authentication, session
    management, and token issuance.
 3. **Framework integration** -- Optional route handlers and middleware for your
@@ -47,9 +47,9 @@ from fastapi.responses import JSONResponse
 
 auth = CrossAuth(
     providers=[],
-    storage=session_storage,
+    storage=secondary_storage,
     accounts_storage=accounts_storage,
-    create_token=lambda _: ("", 0),
+    session_storage=session_storage,
     trusted_origins=["https://myapp.com"],
 )
 

--- a/website/content/docs/oauth.md
+++ b/website/content/docs/oauth.md
@@ -25,6 +25,11 @@ The recommended flow for public clients (SPAs, mobile apps):
 5. Client exchanges the code + `code_verifier` for an access token at the token
    endpoint.
 
+The token endpoint issues opaque bearer tokens backed by `SessionStorage`. These
+tokens are revocable session records, not JWTs. Configure `session_storage` on
+`CrossAuth` to enable token issuance; without it, `/token` returns an OAuth
+error instead of minting a token.
+
 ### Password Grant
 
 Available for first-party applications where the client is trusted:
@@ -38,6 +43,18 @@ grant_type=password&client_id=my-app&username=user@example.com&password=secret
 
 > **Note:** The password grant is less secure than the authorization code flow
 > and should only be used by first-party clients.
+
+## Token Usage
+
+Use the returned `access_token` as a bearer token:
+
+```http
+Authorization: Bearer <access_token>
+```
+
+Cross-Auth stores the token hash in `SessionStorage`, uses
+`SessionConfig.max_age` for `expires_in`, and can revoke tokens with the
+session-management APIs.
 
 ## Social Login
 

--- a/website/content/docs/quick-start.md
+++ b/website/content/docs/quick-start.md
@@ -15,15 +15,17 @@ cookie management for you.
 
 ## Step 1: Implement Storage
 
-Cross-Auth uses protocol classes to abstract storage. You need two
-implementations:
+Cross-Auth uses protocol classes to abstract storage. For session login you need
+three implementations:
 
 - **`AccountsStorage`** -- For looking up users by email or ID.
-- **`SecondaryStorage`** -- For storing sessions (Redis, in-memory dict,
-  database, etc.).
+- **`SecondaryStorage`** -- For transient OAuth data such as authorization
+  codes, PKCE challenges, and link codes.
+- **`SessionStorage`** -- For durable, revocable browser sessions and bearer
+  tokens.
 
 ```python
-from cross_auth import AccountsStorage, SecondaryStorage
+from cross_auth import AccountsStorage, SecondaryStorage, SessionStorage
 
 
 # Example: in-memory secondary storage (use Redis in production)
@@ -31,7 +33,7 @@ class MemoryStorage:
     def __init__(self):
         self.data = {}
 
-    def set(self, key: str, value: str):
+    def set(self, key: str, value: str, ttl: int | None = None):
         self.data[key] = value
 
     def get(self, key: str) -> str | None:
@@ -44,6 +46,9 @@ class MemoryStorage:
         return self.data.pop(key, None)
 ```
 
+Implement `SessionStorage` with your database's normal row model. The
+[Storage](/docs/storage) guide shows the full protocol.
+
 ## Step 2: Create the CrossAuth Instance
 
 ```python
@@ -51,9 +56,9 @@ from cross_auth.fastapi import CrossAuth
 
 auth = CrossAuth(
     providers=[],
-    storage=session_storage,
+    storage=secondary_storage,
     accounts_storage=accounts_storage,
-    create_token=lambda _: ("", 0),
+    session_storage=session_storage,
     trusted_origins=["https://myapp.com"],
 )
 ```

--- a/website/content/docs/session-authentication.md
+++ b/website/content/docs/session-authentication.md
@@ -9,8 +9,9 @@ section: Guides
 
 Session-based authentication is the traditional approach for server-rendered web
 applications. After a user logs in with their email and password, the server
-creates a session and sends a session ID cookie to the browser. Subsequent
-requests include this cookie, allowing the server to identify the user.
+creates a session and sends an opaque session-token cookie to the browser.
+Subsequent requests include this cookie, allowing the server to identify the
+user.
 
 Cross-Auth provides a high-level `CrossAuth` class with `login()` and `logout()`
 methods for framework integrations, as well as lower-level functions for custom
@@ -29,9 +30,9 @@ from fastapi.responses import JSONResponse
 
 auth = CrossAuth(
     providers=[],
-    storage=session_storage,
+    storage=secondary_storage,
     accounts_storage=accounts_storage,
-    create_token=lambda _: ("", 0),
+    session_storage=session_storage,
     trusted_origins=["https://myapp.com"],
 )
 
@@ -51,7 +52,7 @@ auth.login(str(user.id), response=response)
 ```python
 from fastapi import Request
 
-# Delete session + clear cookie in one step
+# Revoke session + clear cookie in one step
 response = JSONResponse({"ok": True})
 auth.logout(request, response=response)
 ```
@@ -75,6 +76,11 @@ def protected(
     user: Annotated[User, Depends(auth.require_current_user)],
 ): ...  # raises 401 if not logged in
 ```
+
+`session_storage` is optional when constructing `CrossAuth`, but session-backed
+features require it. `login()`, `logout()`, and session-management methods raise
+clearly when no `session_storage` is configured. The built-in `/token` endpoint
+is still registered, but successful token issuance requires `session_storage`.
 
 ## Lower-Level Session Functions
 
@@ -107,26 +113,27 @@ After authentication, create a session to persist the login:
 ```python
 from cross_auth._session import create_session
 
-session_id, session_data = create_session(str(user.id), session_storage)
+session_token, session_record = create_session(str(user.id), session_storage)
 ```
 
-The session ID is a cryptographically secure random token
-(`secrets.token_urlsafe(32)`, ~256 bits of entropy). Session data is stored in
-your `SecondaryStorage` under the key `session:{session_id}`.
+The session token is a cryptographically secure random value
+(`secrets.token_urlsafe(32)`, ~256 bits of entropy). Cross-Auth stores only a
+hash of that token in `SessionStorage`, together with the session metadata and
+expiry.
 
 #### Session Fixation Protection
 
 Always create a **new** session after authentication. Never reuse an existing
-session ID from before login -- this prevents session fixation attacks.
+session token from before login -- this prevents session fixation attacks.
 
 ### Reading Sessions
 
-Retrieve a session by its ID:
+Retrieve a session by its token:
 
 ```python
 from cross_auth._session import get_session
 
-session = get_session(session_id, session_storage)
+session = get_session(session_token, session_storage)
 
 if session is None:
     # Session not found or expired
@@ -134,19 +141,31 @@ if session is None:
 
 print(session.user_id)
 print(session.created_at)
+print(session.status)
 ```
 
 ### Deleting Sessions
 
-Delete a session to log the user out:
+Revoke a session to log the user out:
 
 ```python
 from cross_auth._session import delete_session
 
-delete_session(session_id, session_storage)
+delete_session(session_token, session_storage)
 ```
 
-This is a no-op if the session doesn't exist.
+This revokes the stored session record. It is a no-op if the session doesn't
+exist.
+
+### Bearer Tokens
+
+The built-in OAuth `/token` endpoint issues the same kind of opaque session
+token that `create_session()` returns. API clients send it with
+`Authorization: Bearer ...`, and Cross-Auth resolves it through
+`SessionStorage`.
+
+Because bearer tokens are session records, they are revocable with the same
+session-management APIs. Cross-Auth does not issue JWT access tokens by default.
 
 ### Cookie Helpers
 
@@ -157,7 +176,7 @@ Cross-Auth provides helpers to create properly configured session cookies:
 ```python
 from cross_auth._session import make_session_cookie
 
-cookie = make_session_cookie(session_id)
+cookie = make_session_cookie(session_token)
 # cookie.name = "session_id"
 # cookie.secure = True
 # cookie.httponly = True
@@ -184,26 +203,28 @@ from cross_auth import SessionConfig
 from cross_auth._session import make_session_cookie
 
 config: SessionConfig = {
-    "cookie_name": "my_app_session",
     "max_age": 3600,  # 1 hour
-    "secure": True,
-    "httponly": True,
-    "samesite": "strict",
-    "path": "/",
-    "domain": ".example.com",
+    "cookies": {
+        "name": "my_app_session",
+        "secure": True,
+        "httponly": True,
+        "samesite": "strict",
+        "path": "/",
+        "domain": ".example.com",
+    },
 }
 
-cookie = make_session_cookie(session_id, config)
+cookie = make_session_cookie(session_token, config)
 ```
 
 ## Cookie Defaults
 
-| Setting       | Default        | Notes                                  |
-| ------------- | -------------- | -------------------------------------- |
-| `cookie_name` | `"session_id"` | Name of the cookie                     |
-| `max_age`     | `86400` (24h)  | Session lifetime in seconds            |
-| `secure`      | `True`         | Only sent over HTTPS                   |
-| `httponly`    | `True`         | Not accessible via JavaScript          |
-| `samesite`    | `"lax"`        | Prevents CSRF on cross-origin requests |
-| `path`        | `"/"`          | Cookie is valid for all paths          |
-| `domain`      | `None`         | Scoped to the current domain           |
+| Setting            | Default        | Notes                                  |
+| ------------------ | -------------- | -------------------------------------- |
+| `max_age`          | `86400` (24h)  | Session lifetime in seconds            |
+| `cookies.name`     | `"session_id"` | Name of the cookie                     |
+| `cookies.secure`   | `True`         | Only sent over HTTPS                   |
+| `cookies.httponly` | `True`         | Not accessible via JavaScript          |
+| `cookies.samesite` | `"lax"`        | Prevents CSRF on cross-origin requests |
+| `cookies.path`     | `"/"`          | Cookie is valid for all paths          |
+| `cookies.domain`   | `None`         | Scoped to the current domain           |

--- a/website/content/docs/storage.md
+++ b/website/content/docs/storage.md
@@ -12,6 +12,13 @@ Cross-Auth uses Python protocol classes (structural subtyping) for storage. You
 don't need to inherit from a base class -- just implement the required methods
 and Cross-Auth will accept your objects.
 
+Cross-Auth separates transient OAuth state from durable session state:
+
+- `SecondaryStorage` stores short-lived values such as authorization codes, PKCE
+  challenges, and link codes.
+- `SessionStorage` stores revocable session records for browser cookies and
+  bearer tokens issued by `/token`.
+
 ## AccountsStorage
 
 The `AccountsStorage` protocol defines how Cross-Auth looks up and creates
@@ -56,12 +63,12 @@ class User(Protocol):
 
 ## SecondaryStorage
 
-The `SecondaryStorage` protocol is used for ephemeral data: sessions, OAuth
-authorization codes, and PKCE challenges.
+The `SecondaryStorage` protocol is used for ephemeral OAuth data: authorization
+codes, PKCE challenges, and link codes.
 
 ```python
 class SecondaryStorage(Protocol):
-    def set(self, key: str, value: str): ...
+    def set(self, key: str, value: str, ttl: int | None = None): ...
     def get(self, key: str) -> str | None: ...
     def delete(self, key: str): ...
     def pop(self, key: str) -> str | None: ...
@@ -77,8 +84,8 @@ class RedisStorage:
     def __init__(self, url: str = "redis://localhost:6379"):
         self.client = redis.from_url(url)
 
-    def set(self, key: str, value: str):
-        self.client.set(key, value)
+    def set(self, key: str, value: str, ttl: int | None = None):
+        self.client.set(key, value, ex=ttl)
 
     def get(self, key: str) -> str | None:
         result = self.client.get(key)
@@ -94,3 +101,61 @@ class RedisStorage:
         result, _ = pipe.execute()
         return result.decode() if result else None
 ```
+
+## SessionStorage
+
+The `SessionStorage` protocol stores durable, revocable session records. Browser
+session cookies and OAuth bearer tokens both contain opaque session tokens; only
+the token hash is stored.
+
+```python
+class SessionRecord(Protocol):
+    id: Any
+    user_id: Any
+    created_at: AwareDatetime
+    updated_at: AwareDatetime
+    expires_at: AwareDatetime
+    last_active_at: AwareDatetime | None
+    revoked_at: AwareDatetime | None
+    client_id: str | None
+    client_name: str | None
+    user_agent: str | None
+    ip: str | None
+
+    @property
+    def status(self) -> Literal["active", "expired", "revoked"]: ...
+
+
+class SessionListResult(Protocol):
+    records: Sequence[SessionRecord]
+    next_cursor: str | None
+
+
+class SessionStorage(Protocol):
+    def create(
+        self,
+        *,
+        token_hash: str,
+        user_id: Any,
+        created_at: AwareDatetime,
+        updated_at: AwareDatetime,
+        expires_at: AwareDatetime,
+        client_id: str | None = None,
+        client_name: str | None = None,
+        user_agent: str | None = None,
+        ip: str | None = None,
+        last_active_at: AwareDatetime | None = None,
+    ) -> SessionRecord: ...
+
+    def get(self, *, token_hash: str, now: AwareDatetime) -> SessionRecord | None: ...
+    def get_any(self, session_id: Any) -> SessionRecord | None: ...
+    def refresh(self, session_id: Any, **kwargs) -> SessionRecord | None: ...
+    def revoke(self, session_id: Any, *, revoked_at: AwareDatetime) -> None: ...
+    def list_for_user(self, user_id: Any, **kwargs) -> SessionListResult: ...
+    def revoke_all_for_user(self, user_id: Any, **kwargs) -> int: ...
+```
+
+`session_storage` is optional when constructing `CrossAuth`, but session-backed
+features require it. `login()`, `logout()`, and session-management methods raise
+clearly when no `session_storage` is configured. The built-in `/token` endpoint
+is still registered, but successful token issuance requires `session_storage`.


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack

- **#42** (`2026-05-24-add-support-for-durable-sessions`) <-- this PR
<!-- shortcake:end -->

## Summary by Sourcery

Introduce durable, server-side session storage with management APIs, and update FastAPI integration, issuer flows, and examples to use hashed session tokens and revocable session records.

New Features:
- Add pluggable SessionStorage and SessionRecord protocols to support durable, queryable sessions with metadata and status.
- Expose session management APIs on CrossAuth for listing, fetching, and revoking user sessions, including helpers to get the current session.
- Extend issuer token flows to optionally issue durable session-backed access tokens instead of opaque tokens when sessions are enabled.
- Add session dashboard HTML and JSON endpoints in the FastAPI example app for viewing and revoking sessions, plus navigation links to manage sessions.

Enhancements:
- Refactor session handling to store hashed session tokens, refresh expiration based on activity, and support both cookie and bearer token transport transparently.
- Extend hook events to surface session tokens and records instead of internal IDs, and enrich sessions with request-derived metadata like user agent and client information.

Tests:
- Add in-memory SessionStorage implementations and comprehensive tests for durable session behavior, token hashing, issuer integration, and CrossAuth management APIs.
- Update existing FastAPI and session tests to use the new SessionStorage abstraction and validate session lifecycle changes.