### PR TITLE
Add built-in Redis and SQLModel storage adapters

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,33 @@
+---
+release type: minor
+---
+
+This release adds built-in storage adapters, normalizes emails across every
+lookup and signup, and hardens transient OAuth state so abandoned flows don't
+linger and callbacks can't be replayed.
+
+- **Built-in storage adapters**: `SQLModelSessionStorage` and
+  `SQLModelAccountsStorage` (`cross-auth[sqlmodel]`) implement the session and
+  accounts storage protocols on your own SQLModel models, with signup hooks
+  (`build_user`, `on_signup`, `after_signup`), query filters, keyset cursor
+  pagination that raises `InvalidCursorError` for bad cursors, and model
+  validation at construction. `RedisStorage` (`cross-auth[redis]`) implements
+  `SecondaryStorage` on a synchronous redis-py client.
+- Emails are now trimmed and lowercased before every user lookup and creation —
+  password login, the token endpoint, OAuth signup, and account linking all go
+  through it. Pass `normalize_email=` to `CrossAuth` to customize the
+  normalization.
+- Transient OAuth state (authorization requests, auth codes, link codes) is now
+  stored with a 10-minute TTL, so abandoned flows no longer accumulate in
+  storage. The authorization-request state is also single-use: it's consumed on
+  the callback, so a replayed callback is rejected instead of staying valid
+  until the TTL expires.
+- New public helpers: `session_status`, the canonical active/expired/revoked
+  derivation used by the storage adapters, and `normalize_email`.
+
+**Upgrade note:** if you're upgrading from 0.16 or earlier and any stored emails
+aren't already lowercase, backfill them before upgrading — e.g.
+`UPDATE "user" SET email = lower(trim(email))` — and resolve any duplicate rows
+that produces. Skipping this means existing users with non-lowercase stored
+emails will fail password login, and OAuth sign-ins can create duplicate
+accounts instead of matching the existing one.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,14 @@ dependencies = [
     "httpx>=0.28.1",
 ]
 
+[project.optional-dependencies]
+# pop() uses getdel(), which needs redis-py >= 4.2 and a Redis server >= 6.2;
+# 5.0 is the current baseline we test against.
+redis = ["redis>=5.0"]
+# 0.0.28 is the oldest release that works across our supported Python range;
+# earlier releases cannot define table models on Python 3.14.
+sqlmodel = ["sqlmodel>=0.0.28"]
+
 [tool.uv.workspace]
 members = ["website", "examples/fastapi"]
 
@@ -35,6 +43,10 @@ dev = [
     "coverage>=7.8.0",
     "time-machine>=2.16.0",
     "ty>=0.0.29",
+    "redis>=5.0",
+    "sqlmodel>=0.0.28",
+    "testcontainers>=4.8",
+    "psycopg[binary]>=3.1",
 ]
 
 

--- a/src/cross_auth/exceptions.py
+++ b/src/cross_auth/exceptions.py
@@ -8,3 +8,12 @@ class CrossAuthException(Exception):
         self.error = error
         self.error_description = error_description
         self.status_code = status_code
+
+
+class InvalidCursorError(ValueError):
+    """Raised when a session pagination cursor is malformed, tampered with, or
+    was created under a different ordering than the current request.
+
+    Custom ``SessionStorage`` implementations should raise this from
+    ``list_for_user`` too, so applications can map bad cursors to a 400
+    response without caring which storage backend is configured."""

--- a/src/cross_auth/storage/__init__.py
+++ b/src/cross_auth/storage/__init__.py
@@ -1,0 +1,4 @@
+# Canonical home is cross_auth.exceptions; re-exported here for convenience.
+from cross_auth.exceptions import InvalidCursorError
+
+__all__ = ["InvalidCursorError"]

--- a/src/cross_auth/storage/_cursor.py
+++ b/src/cross_auth/storage/_cursor.py
@@ -1,0 +1,81 @@
+import base64
+import binascii
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+from cross_auth.exceptions import InvalidCursorError
+
+
+@dataclass(frozen=True)
+class Cursor:
+    order_by: str
+    value: datetime
+    row_id: object
+
+
+def encode_cursor(order_by: str, order_value: datetime, row_id: object) -> str:
+    payload = {
+        "o": order_by,
+        "v": order_value.isoformat(),
+        "id": _serialize_cursor_id(row_id),
+    }
+    raw = json.dumps(payload, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).decode()
+
+
+# Legitimate cursors are ~100-200 bytes; a much longer one is crafted. Reject
+# it before decoding — a deeply nested payload (e.g. `"["*1500`) makes
+# json.loads raise RecursionError instead of a clean parse failure.
+_MAX_CURSOR_LENGTH = 512
+
+
+def decode_cursor(cursor: str) -> Cursor:
+    if len(cursor) > _MAX_CURSOR_LENGTH:
+        raise InvalidCursorError("Invalid session pagination cursor")
+    try:
+        raw = base64.urlsafe_b64decode(cursor.encode())
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            raise InvalidCursorError("Invalid session pagination cursor")
+        order_by = payload["o"]
+        value = payload["v"]
+        if not isinstance(order_by, str) or not isinstance(value, str):
+            raise InvalidCursorError("Invalid session pagination cursor")
+        return Cursor(
+            order_by=order_by,
+            value=datetime.fromisoformat(value),
+            row_id=_deserialize_cursor_id(payload["id"]),
+        )
+    except (
+        ValueError,
+        KeyError,
+        TypeError,
+        binascii.Error,
+        RecursionError,
+    ) as exc:
+        raise InvalidCursorError("Invalid session pagination cursor") from exc
+
+
+def _serialize_cursor_id(row_id: object) -> object:
+    if isinstance(row_id, uuid.UUID):
+        return {"t": "uuid", "v": str(row_id)}
+    # bool is excluded explicitly: it is an int subclass but never a valid id.
+    if isinstance(row_id, bool) or not isinstance(row_id, (int, str)):
+        raise TypeError(
+            f"Unsupported session id type for cursor pagination: "
+            f"{type(row_id).__name__!r} (supported: int, str, uuid.UUID)"
+        )
+    return row_id
+
+
+def _deserialize_cursor_id(value: object) -> object:
+    match value:
+        case {"t": "uuid", "v": str(raw)}:
+            return uuid.UUID(raw)
+        case bool():
+            raise InvalidCursorError("Invalid session pagination cursor")
+        case int() | str():
+            return value
+    raise InvalidCursorError("Invalid session pagination cursor")

--- a/src/cross_auth/storage/redis.py
+++ b/src/cross_auth/storage/redis.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import inspect
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from redis import Redis
+
+RedisValue = bytes | str | None
+
+
+def _decode(value: RedisValue) -> str | None:
+    """Normalize a redis response to ``str | None``.
+
+    Default clients return ``bytes``; clients created with
+    ``decode_responses=True`` already return ``str``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode()
+    return value
+
+
+class RedisStorage:
+    """Store transient auth data (OAuth, PKCE, verification, reset) in Redis.
+
+    Pass an existing redis client::
+
+        import redis
+        from cross_auth.storage.redis import RedisStorage
+
+        storage = RedisStorage(redis.Redis.from_url("redis://localhost:6379"))
+
+    Requires a synchronous client (not ``redis.asyncio.Redis`` — every method
+    would silently return an unawaited coroutine instead of doing anything)
+    with ``GETDEL`` support: a Redis server >= 6.2 and redis-py >= 4.2
+    (``pop`` uses the ``GETDEL`` command).
+
+    The client is fixed at construction. To point tests elsewhere, construct
+    a new ``RedisStorage`` with a different client rather than patching the
+    settings the client was built from.
+    """
+
+    def __init__(self, client: Redis):
+        if not callable(getattr(client, "getdel", None)):
+            raise TypeError(
+                f"{type(self).__name__} requires a Redis client with GETDEL "
+                f"support (redis-py 4.2 or newer) — pop() calls "
+                f"client.getdel(), which {type(client).__name__!r} does not "
+                f"have."
+            )
+        # A synchronous client's `get` returns a value directly; an async
+        # client's does too (it just hands back the coroutine created by its
+        # own async execute_command), so `get` itself doesn't look like a
+        # coroutine function. Check execute_command as well, since that one
+        # is genuinely `async def` on an async client.
+        get = getattr(client, "get", None)
+        execute_command = getattr(client, "execute_command", None)
+        if inspect.iscoroutinefunction(get) or inspect.iscoroutinefunction(
+            execute_command
+        ):
+            raise TypeError(
+                f"{type(self).__name__} requires a synchronous Redis client "
+                f"(e.g. redis.Redis), not an async one like "
+                f"{type(client).__name__!r} — every method would return an "
+                f"unawaited coroutine instead of a value."
+            )
+        self._client = client
+
+    def set(self, key: str, value: str, ttl: int | None = None) -> None:
+        if ttl is not None and ttl <= 0:
+            # Already expired; Redis rejects EX <= 0 with an error.
+            self._client.delete(key)
+            return
+        self._client.set(key, value, ex=ttl)
+
+    def get(self, key: str) -> str | None:
+        return _decode(self._client.get(key))
+
+    def delete(self, key: str) -> None:
+        self._client.delete(key)
+
+    def pop(self, key: str) -> str | None:
+        """Atomically get and delete a key. Returns ``None`` if it is missing.
+
+        Uses Redis ``GETDEL``, available on server 6.2 and newer.
+        """
+        return _decode(self._client.getdel(key))

--- a/src/cross_auth/storage/sqlmodel.py
+++ b/src/cross_auth/storage/sqlmodel.py
@@ -1,0 +1,986 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, ClassVar, Generic, TypeVar, overload
+
+try:
+    from sqlalchemy import BigInteger, SmallInteger, and_, inspect, or_, update
+    from sqlalchemy.orm import selectinload
+    from sqlmodel import SQLModel, Session, select
+    from sqlmodel.sql.expression import SelectOfScalar
+except ImportError as exc:  # pragma: no cover - exercised only without the extra
+    raise ImportError(
+        "cross_auth.storage.sqlmodel requires SQLModel. "
+        "Install it with: pip install 'cross-auth[sqlmodel]'"
+    ) from exc
+
+from cross_auth._storage import SessionListOrder, SessionStatus
+from cross_auth.exceptions import InvalidCursorError
+from cross_auth.storage._cursor import decode_cursor, encode_cursor
+
+SessionModelT = TypeVar("SessionModelT", bound=SQLModel)
+UserModelT = TypeVar("UserModelT", bound=SQLModel)
+SocialAccountModelT = TypeVar("SocialAccountModelT", bound=SQLModel)
+
+_ORDER_FIELDS: dict[SessionListOrder, tuple[str, bool]] = {
+    # order_by -> (attribute name, descending?)
+    "updated_at_desc": ("updated_at", True),
+    "updated_at_asc": ("updated_at", False),
+    "created_at_desc": ("created_at", True),
+    "created_at_asc": ("created_at", False),
+    "expires_at_desc": ("expires_at", True),
+    "expires_at_asc": ("expires_at", False),
+}
+
+_SESSION_DATETIME_FIELDS = (
+    "created_at",
+    "updated_at",
+    "expires_at",
+    "last_active_at",
+    "revoked_at",
+)
+
+_SOCIAL_ACCOUNT_DATETIME_FIELDS = (
+    "access_token_expires_at",
+    "refresh_token_expires_at",
+)
+
+# Write-only columns the default payload builders populate, beyond the
+# protocol fields already checked via _required_models. SQLModel table models
+# silently ignore unknown constructor kwargs, so without this check a missing
+# column would silently drop OAuth tokens instead of failing.
+_SOCIAL_ACCOUNT_WRITE_FIELDS = (
+    "access_token",
+    "refresh_token",
+    "access_token_expires_at",
+    "refresh_token_expires_at",
+    "scope",
+)
+
+# Sentinel for ids that cannot possibly match the column type (e.g. "abc"
+# against an integer primary key).
+_NO_MATCH = object()
+
+
+def _column(model: type[SQLModel], field: str) -> Any:
+    # Resolve by the mapped attribute name, not ``__table__.columns`` — that
+    # collection is keyed by the database column name, which diverges from the
+    # attribute when a column is renamed via ``sa_column``. The mapper's column
+    # collection is keyed by the attribute, so it resolves either way (and still
+    # returns None for non-column attributes such as a ``status`` property).
+    return inspect(model).columns.get(field)
+
+
+def _bind_datetime(
+    model: type[SQLModel], field: str, value: datetime | None
+) -> datetime | None:
+    """Normalize an inbound datetime for one of ``model``'s columns.
+
+    Values are converted to UTC. For timezone-naive columns the tzinfo is then
+    stripped so the UTC wall time is stored and compared as-is — otherwise
+    PostgreSQL converts aware parameters through the connection's TimeZone
+    before dropping the offset, silently shifting every stored timestamp.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    value = value.astimezone(timezone.utc)
+    column = _column(model, field)
+    if column is not None and not getattr(column.type, "timezone", False):
+        return value.replace(tzinfo=None)
+    return value
+
+
+def _int_column_range(column_type: Any) -> tuple[int, int]:
+    """Signed integer range representable by an int-typed column.
+
+    BigInteger and SmallInteger both subclass Integer, so they must be
+    checked before falling back to the plain-Integer (32-bit) range.
+    """
+    if isinstance(column_type, BigInteger):
+        bits = 64
+    elif isinstance(column_type, SmallInteger):
+        bits = 16
+    else:
+        bits = 32
+    return -(2 ** (bits - 1)), 2 ** (bits - 1) - 1
+
+
+def _coerce_id(model: type[SQLModel], field: str, value: object) -> object:
+    """Coerce an externally-supplied id to the column's Python type.
+
+    HTTP path params arrive as strings; comparing a text parameter against an
+    int or UUID column raises a database error on PostgreSQL (SQLite silently
+    matches nothing). Returns ``_NO_MATCH`` when the value cannot possibly
+    match any row, so callers can answer ``None`` instead of crashing.
+    """
+    column = _column(model, field)
+    if column is None or value is None:
+        return value
+    try:
+        python_type = column.type.python_type
+    except NotImplementedError:
+        return value
+    if python_type is int:
+        if isinstance(value, str):
+            try:
+                value = int(value)
+            except ValueError:
+                return _NO_MATCH
+        if not isinstance(value, int):
+            # e.g. a uuid.UUID id decoded from a crafted pagination cursor —
+            # comparing it against an int column would otherwise reach the
+            # database as `integer < uuid`, raising ProgrammingError on
+            # PostgreSQL.
+            return _NO_MATCH
+        low, high = _int_column_range(column.type)
+        if not (low <= value <= high):
+            # Outside the column type's representable range: passed through,
+            # this raises DataError (PostgreSQL) or OverflowError (SQLite) at
+            # the driver instead of matching no row.
+            return _NO_MATCH
+        return value
+    if python_type is uuid.UUID:
+        if isinstance(value, str):
+            try:
+                return uuid.UUID(value)
+            except ValueError:
+                return _NO_MATCH
+        if not isinstance(value, uuid.UUID):
+            # e.g. an int id — comparing it against a UUID column would
+            # otherwise reach the database as `uuid < integer`, raising
+            # ProgrammingError on PostgreSQL.
+            return _NO_MATCH
+        return value
+    if python_type is str and not isinstance(value, str):
+        return str(value)
+    return value
+
+
+def _ensure_aware_datetime(value: object) -> object:
+    if not isinstance(value, datetime) or value.tzinfo is not None:
+        return value
+    return value.replace(tzinfo=timezone.utc)
+
+
+@overload
+def _prepare_record(record: None, fields: tuple[str, ...]) -> None: ...
+
+
+@overload
+def _prepare_record(
+    record: SessionModelT, fields: tuple[str, ...]
+) -> SessionModelT: ...
+
+
+def _prepare_record(record, fields):
+    """Label naive datetimes read back from the database as UTC."""
+    if record is None:
+        return None
+    for field in fields:
+        if hasattr(record, field):
+            setattr(record, field, _ensure_aware_datetime(getattr(record, field)))
+    return record
+
+
+class _SQLModelStorageBase:
+    """Shared construction, validation, and session handling."""
+
+    session_factory: Callable[[], Session]
+
+    # (class attribute holding the model, attributes the model must expose).
+    # Checked at construction so misconfiguration fails at startup with a
+    # clear error instead of an AttributeError on the first auth request.
+    _required_models: ClassVar[tuple[tuple[str, tuple[str, ...]], ...]] = ()
+
+    # How to supply a missing model; session storage also accepts it in the
+    # constructor and overrides this hint.
+    _missing_model_hint: ClassVar[str] = (
+        "declare a class attribute (e.g. `{attr} = MyModel`)"
+    )
+
+    def __init__(self, *, session_factory: Callable[[], Session]):
+        if not callable(session_factory):
+            raise TypeError(
+                f"{type(self).__name__} session_factory must be a callable "
+                f"returning a new Session, got {session_factory!r}"
+            )
+        self.session_factory = session_factory
+        self._validate_models()
+
+    def _validate_models(self) -> None:
+        for attr, required_fields in self._required_models:
+            # Instance lookup, so a model passed to the constructor (stored on
+            # the instance) and one declared as a class attribute both resolve.
+            model = getattr(self, attr, None)
+            if not isinstance(model, type):
+                raise TypeError(
+                    f"{type(self).__name__} must be given the {attr} model — "
+                    + self._missing_model_hint.format(attr=attr)
+                )
+            for field in required_fields:
+                if not hasattr(model, field):
+                    raise TypeError(
+                        f"{model.__name__} is missing the {field!r} attribute "
+                        f"required by {type(self).__name__}"
+                    )
+
+    @contextmanager
+    def _open_session(self) -> Iterator[Session]:
+        session = self.session_factory()
+        # Keep loaded values after commit so returned instances stay readable
+        # once the session closes. Only columns that were set in Python (or
+        # eager-loaded) are guaranteed readable: a column populated purely by a
+        # database server-side default is not re-fetched on create, so pass its
+        # value explicitly if you need it on the returned record.
+        session.expire_on_commit = False
+        with session:
+            yield session
+
+
+def _prepare_session_record(record):
+    return _prepare_record(record, _SESSION_DATETIME_FIELDS)
+
+
+def _prepare_social_account(record):
+    return _prepare_record(record, _SOCIAL_ACCOUNT_DATETIME_FIELDS)
+
+
+class SQLModelSessionStorage(_SQLModelStorageBase, Generic[SessionModelT]):
+    """Implements cross_auth.SessionStorage for a SQLModel model.
+
+    Pass your session model to the constructor::
+
+        store = SQLModelSessionStorage(
+            UserSession, session_factory=lambda: Session(engine)
+        )
+
+    Or subclass (e.g. to override behaviour) and declare ``SessionModel``::
+
+        class SessionStore(SQLModelSessionStorage[UserSession]):
+            SessionModel = UserSession
+
+    The model's datetime columns may be timezone-naive (values are stored as
+    UTC wall time and labeled UTC when read back) or declared with
+    ``DateTime(timezone=True)``. Configuration is validated at construction.
+    """
+
+    SessionModel: type[SessionModelT]
+
+    _missing_model_hint = (
+        "pass it to the constructor (e.g. `SQLModelSessionStorage(MySession, "
+        "session_factory=...)`) or declare `SessionModel = MySession` on a "
+        "subclass"
+    )
+
+    def __init__(
+        self,
+        model: type[SessionModelT] | None = None,
+        *,
+        session_factory: Callable[[], Session],
+    ):
+        if model is not None:
+            self.SessionModel = model
+        super().__init__(session_factory=session_factory)
+
+    # The full cross_auth.SessionRecord protocol surface plus the internal
+    # token_hash column. `status` is never read by the adapter itself, but the
+    # protocol requires it — checking it here surfaces the missing property at
+    # startup instead of when a session listing is first serialized.
+    _required_models = (
+        (
+            "SessionModel",
+            (
+                "id",
+                "token_hash",
+                "user_id",
+                "created_at",
+                "updated_at",
+                "expires_at",
+                "last_active_at",
+                "revoked_at",
+                "client_id",
+                "client_name",
+                "user_agent",
+                "ip",
+                "status",
+            ),
+        ),
+    )
+
+    def create(
+        self,
+        *,
+        token_hash: str,
+        user_id: object,
+        created_at: datetime,
+        updated_at: datetime,
+        expires_at: datetime,
+        client_id: str | None = None,
+        client_name: str | None = None,
+        user_agent: str | None = None,
+        ip: str | None = None,
+        last_active_at: datetime | None = None,
+    ) -> SessionModelT:
+        model = self.SessionModel
+        coerced_user_id = _coerce_id(model, "user_id", user_id)
+        record = model(
+            token_hash=token_hash,
+            user_id=user_id if coerced_user_id is _NO_MATCH else coerced_user_id,
+            created_at=_bind_datetime(model, "created_at", created_at),
+            updated_at=_bind_datetime(model, "updated_at", updated_at),
+            expires_at=_bind_datetime(model, "expires_at", expires_at),
+            client_id=client_id,
+            client_name=client_name,
+            user_agent=user_agent,
+            ip=ip,
+            last_active_at=_bind_datetime(model, "last_active_at", last_active_at),
+        )
+        with self._open_session() as session:
+            session.add(record)
+            session.commit()
+        return _prepare_session_record(record)
+
+    def get(self, *, token_hash: str, now: datetime) -> SessionModelT | None:
+        model = self.SessionModel
+        now_bound = _bind_datetime(model, "expires_at", now)
+        with self._open_session() as session:
+            statement = select(model).where(
+                getattr(model, "token_hash") == token_hash,
+                getattr(model, "revoked_at") == None,  # noqa: E711
+                # A session is active up to and including the expiry instant,
+                # matching cross_auth.session_status.
+                getattr(model, "expires_at") >= now_bound,
+            )
+            record = session.exec(statement).first()
+        return _prepare_session_record(record)
+
+    def get_any(self, session_id: object) -> SessionModelT | None:
+        session_id = _coerce_id(self.SessionModel, "id", session_id)
+        if session_id is _NO_MATCH:
+            return None
+        with self._open_session() as session:
+            record = session.get(self.SessionModel, session_id)
+        return _prepare_session_record(record)
+
+    def list_for_user(
+        self,
+        user_id: object,
+        *,
+        now: datetime,
+        status: SessionStatus | None = None,
+        order_by: SessionListOrder = "updated_at_desc",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> _SessionListResult[SessionModelT]:
+        if limit < 1:
+            raise ValueError("limit must be >= 1")
+        try:
+            order_field, descending = _ORDER_FIELDS[order_by]
+        except KeyError:
+            raise ValueError(f"Unsupported order_by: {order_by!r}") from None
+        model = self.SessionModel
+        order_column = getattr(model, order_field)
+        id_column = getattr(model, "id")
+        now_bound = _bind_datetime(model, "expires_at", now)
+
+        user_id = _coerce_id(model, "user_id", user_id)
+        if user_id is _NO_MATCH:
+            return _SessionListResult(records=[], next_cursor=None)
+
+        with self._open_session() as session:
+            statement = select(model).where(getattr(model, "user_id") == user_id)
+
+            if status == "revoked":
+                statement = statement.where(getattr(model, "revoked_at") != None)  # noqa: E711
+            elif status == "active":
+                statement = statement.where(
+                    getattr(model, "revoked_at") == None,  # noqa: E711
+                    getattr(model, "expires_at") >= now_bound,
+                )
+            elif status == "expired":
+                statement = statement.where(
+                    getattr(model, "revoked_at") == None,  # noqa: E711
+                    getattr(model, "expires_at") < now_bound,
+                )
+
+            if cursor is not None:
+                decoded = decode_cursor(cursor)
+                if decoded.order_by != order_by:
+                    raise InvalidCursorError(
+                        f"Cursor was created with order_by="
+                        f"{decoded.order_by!r}, not {order_by!r}"
+                    )
+                cursor_id = _coerce_id(model, "id", decoded.row_id)
+                if cursor_id is _NO_MATCH:
+                    raise InvalidCursorError("Invalid session pagination cursor")
+                cursor_value = _bind_datetime(model, order_field, decoded.value)
+                if descending:
+                    boundary = or_(
+                        order_column < cursor_value,
+                        and_(
+                            order_column == cursor_value,
+                            id_column < cursor_id,
+                        ),
+                    )
+                else:
+                    boundary = or_(
+                        order_column > cursor_value,
+                        and_(
+                            order_column == cursor_value,
+                            id_column > cursor_id,
+                        ),
+                    )
+                statement = statement.where(boundary)
+
+            if descending:
+                statement = statement.order_by(order_column.desc(), id_column.desc())
+            else:
+                statement = statement.order_by(order_column.asc(), id_column.asc())
+
+            rows = session.exec(statement.limit(limit + 1)).all()
+
+        has_more = len(rows) > limit
+        records = [_prepare_session_record(record) for record in rows[:limit]]
+        next_cursor = None
+        if has_more and records:
+            last = records[-1]
+            next_cursor = encode_cursor(
+                order_by, getattr(last, order_field), getattr(last, "id")
+            )
+
+        return _SessionListResult(records=records, next_cursor=next_cursor)
+
+    def refresh(
+        self,
+        session_id: object,
+        *,
+        updated_at: datetime,
+        expires_at: datetime,
+        last_active_at: datetime | None = None,
+    ) -> SessionModelT | None:
+        model = self.SessionModel
+        session_id = _coerce_id(model, "id", session_id)
+        if session_id is _NO_MATCH:
+            return None
+        with self._open_session() as session:
+            record = session.get(model, session_id)
+            if record is None:
+                return None
+            record.updated_at = _bind_datetime(model, "updated_at", updated_at)
+            record.expires_at = _bind_datetime(model, "expires_at", expires_at)
+            if last_active_at is not None:
+                record.last_active_at = _bind_datetime(
+                    model, "last_active_at", last_active_at
+                )
+            session.add(record)
+            session.commit()
+        return _prepare_session_record(record)
+
+    def revoke(self, session_id: object, *, revoked_at: datetime) -> None:
+        model = self.SessionModel
+        session_id = _coerce_id(model, "id", session_id)
+        if session_id is _NO_MATCH:
+            return
+        with self._open_session() as session:
+            statement = (
+                update(model)
+                .where(
+                    getattr(model, "id") == session_id,
+                    # Don't shift the audit timestamp of an already-revoked
+                    # session.
+                    getattr(model, "revoked_at") == None,  # noqa: E711
+                )
+                .values(revoked_at=_bind_datetime(model, "revoked_at", revoked_at))
+            )
+            session.exec(statement)  # type: ignore[call-overload]
+            session.commit()
+
+    def revoke_all_for_user(
+        self,
+        user_id: object,
+        *,
+        revoked_at: datetime,
+        except_session_id: object | None = None,
+    ) -> int:
+        model = self.SessionModel
+        user_id = _coerce_id(model, "user_id", user_id)
+        if user_id is _NO_MATCH:
+            return 0
+        with self._open_session() as session:
+            statement = (
+                update(model)
+                .where(
+                    getattr(model, "user_id") == user_id,
+                    getattr(model, "revoked_at") == None,  # noqa: E711
+                )
+                .values(revoked_at=_bind_datetime(model, "revoked_at", revoked_at))
+            )
+            if except_session_id is not None:
+                except_session_id = _coerce_id(model, "id", except_session_id)
+                # An id that can't match any row excludes nothing.
+                if except_session_id is not _NO_MATCH:
+                    statement = statement.where(
+                        getattr(model, "id") != except_session_id
+                    )
+            result = session.exec(statement)  # type: ignore[call-overload]
+            session.commit()
+            return result.rowcount
+
+
+@dataclass
+class _SessionListResult(Generic[SessionModelT]):
+    records: list[SessionModelT]
+    next_cursor: str | None
+
+
+class SQLModelAccountsStorage(
+    _SQLModelStorageBase,
+    Generic[UserModelT, SocialAccountModelT],
+):
+    """Implements cross_auth.AccountsStorage for SQLModel models.
+
+    Pass your models to the constructor::
+
+        store = SQLModelAccountsStorage(
+            User, SocialAccount, session_factory=lambda: Session(engine)
+        )
+
+    App-specific signup behaviour hangs off three hooks around the signup
+    transaction: ``build_user`` (construct the instance — required when your
+    model needs more than ``UserModel(email=..., email_verified=...)``),
+    ``on_signup`` (inside the transaction, pre-commit), and ``after_signup``
+    (post-commit side effects)::
+
+        class AccountsStore(SQLModelAccountsStorage[User, SocialAccount]):
+            UserModel = User
+            SocialAccountModel = SocialAccount
+
+            def on_signup(self, *, session, user, user_info, email_verified):
+                if not is_invited(user.email):
+                    raise CrossAuthException(...)  # aborts; nothing persists
+                session.add(Team(owner=user))      # joins the same commit
+
+            def after_signup(self, *, user, user_info):
+                telemetry.capture("account_created", user_id=user.id)
+
+    Override the query and payload hooks for behaviour such as excluding
+    soft-deleted users, tenant scoping, or mapping provider-specific fields
+    onto extra columns. ``filter_social_account_query`` is applied to reads
+    and writes alike — except the eager-loaded ``user.social_accounts``
+    relationship on a returned user, which is loaded unfiltered; go through
+    ``list_social_accounts`` for a filtered read. Configuration is validated
+    at construction.
+    """
+
+    UserModel: type[UserModelT]
+    SocialAccountModel: type[SocialAccountModelT]
+
+    # The full cross_auth.User / cross_auth.SocialAccount protocol surfaces.
+    # Core reads some of these mid-flow (e.g. has_usable_password during
+    # account linking), so checking them here surfaces a non-compliant model
+    # at startup instead of as an AttributeError halfway through an OAuth
+    # login. Properties and relationships satisfy hasattr on the class.
+    _required_models = (
+        (
+            "UserModel",
+            (
+                "id",
+                "email",
+                "email_verified",
+                "hashed_password",
+                "has_usable_password",
+                "social_accounts",
+            ),
+        ),
+        (
+            "SocialAccountModel",
+            (
+                "id",
+                "user_id",
+                "provider",
+                "provider_user_id",
+                "provider_email",
+                "provider_email_verified",
+                "is_login_method",
+            ),
+        ),
+    )
+
+    _missing_model_hint = (
+        "pass the models to the constructor (e.g. "
+        "`SQLModelAccountsStorage(User, SocialAccount, session_factory=...)`) "
+        "or declare `{attr} = MyModel` on a subclass"
+    )
+
+    def __init__(
+        self,
+        user_model: type[UserModelT] | None = None,
+        social_account_model: type[SocialAccountModelT] | None = None,
+        *,
+        session_factory: Callable[[], Session],
+    ):
+        if user_model is not None:
+            self.UserModel = user_model
+        if social_account_model is not None:
+            self.SocialAccountModel = social_account_model
+        super().__init__(session_factory=session_factory)
+        self._user_query_options = self._resolve_user_query_options()
+        self._validate_social_account_write_fields()
+
+    def _validate_social_account_write_fields(self) -> None:
+        # Only enforced while the default payload builders are in use: a store
+        # that overrides them decides itself which columns to write (e.g. an
+        # app that never persists provider tokens).
+        cls = SQLModelAccountsStorage
+        uses_default_builders = (
+            type(self).build_social_account_create_values
+            is cls.build_social_account_create_values
+            or type(self).build_social_account_update_values
+            is cls.build_social_account_update_values
+        )
+        if not uses_default_builders:
+            return
+        model = self.SocialAccountModel
+        missing = [
+            field
+            for field in _SOCIAL_ACCOUNT_WRITE_FIELDS
+            if _column(model, field) is None
+        ]
+        if missing:
+            raise TypeError(
+                f"{model.__name__} is missing the {missing!r} mapped column(s) "
+                f"written by {type(self).__name__}. SQLModel's constructor only "
+                f"accepts pydantic fields — a property is not settable through "
+                f"it, so these values would be silently lost. Add the columns, "
+                f"or override build_social_account_create_values / "
+                f"build_social_account_update_values to drop them."
+            )
+
+    def _check_social_account_values(self, values: dict[str, object]) -> None:
+        model = self.SocialAccountModel
+        unknown = [key for key in values if _column(model, key) is None]
+        if unknown:
+            raise TypeError(
+                f"{model.__name__} has no mapped column(s) {unknown!r}, but "
+                f"the social-account payload builder returned them. SQLModel's "
+                f"constructor only accepts pydantic fields — a property is not "
+                f"settable through it, so these values would be silently lost."
+            )
+
+    def _resolve_user_query_options(self) -> tuple[Any, ...]:
+        # Eager-load social_accounts only when it is a mapped relationship;
+        # the User protocol also allows it to be a plain property.
+        model = self.UserModel
+        if "social_accounts" in inspect(model).relationships:
+            return (selectinload(getattr(model, "social_accounts")),)
+        return ()
+
+    def _find_user(self, *where: Any) -> UserModelT | None:
+        model = self.UserModel
+        with self._open_session() as session:
+            statement = self.filter_user_query(
+                select(model).where(*where).options(*self._user_query_options)
+            )
+            return session.exec(statement).first()
+
+    def find_user_by_email(self, email: str) -> UserModelT | None:
+        return self._find_user(getattr(self.UserModel, "email") == email)
+
+    def find_user_by_id(self, id: object) -> UserModelT | None:
+        id = _coerce_id(self.UserModel, "id", id)
+        if id is _NO_MATCH:
+            return None
+        return self._find_user(getattr(self.UserModel, "id") == id)
+
+    def create_user(
+        self,
+        *,
+        user_info: dict[str, object],
+        email: str,
+        email_verified: bool,
+    ) -> UserModelT:
+        """Create a user in a single adapter-owned transaction.
+
+        Asks ``build_user`` for the instance, adds it, runs the ``on_signup``
+        hook, commits, and returns the user safe to read after the session
+        closes (scalar columns loaded, ``social_accounts`` eager-loaded); the
+        ``after_signup`` hook then runs post-commit. Unlike ``find_user_by_id``
+        this does not apply ``filter_user_query``, so a freshly created user
+        is always returned.
+        """
+        model = self.UserModel
+        with self._open_session() as session:
+            user = self.build_user(
+                session=session,
+                user_info=user_info,
+                email=email,
+                email_verified=email_verified,
+            )
+            session.add(user)
+            self.on_signup(
+                session=session,
+                user=user,
+                user_info=user_info,
+                email_verified=email_verified,
+            )
+            session.commit()
+            statement = (
+                select(model)
+                .where(getattr(model, "id") == getattr(user, "id"))
+                .options(*self._user_query_options)
+            )
+            user = session.exec(statement).one()
+        self.after_signup(user=user, user_info=user_info)
+        return user
+
+    def _find_social_account(self, *where: Any) -> SocialAccountModelT | None:
+        model = self.SocialAccountModel
+        with self._open_session() as session:
+            statement = self.filter_social_account_query(select(model).where(*where))
+            record = session.exec(statement).first()
+        return _prepare_social_account(record)
+
+    def find_social_account(
+        self, *, provider: str, provider_user_id: str
+    ) -> SocialAccountModelT | None:
+        model = self.SocialAccountModel
+        return self._find_social_account(
+            getattr(model, "provider") == provider,
+            getattr(model, "provider_user_id") == provider_user_id,
+        )
+
+    def find_social_account_by_id(
+        self, social_account_id: object
+    ) -> SocialAccountModelT | None:
+        model = self.SocialAccountModel
+        social_account_id = _coerce_id(model, "id", social_account_id)
+        if social_account_id is _NO_MATCH:
+            return None
+        return self._find_social_account(getattr(model, "id") == social_account_id)
+
+    def list_social_accounts(self, *, user_id: object) -> list[SocialAccountModelT]:
+        model = self.SocialAccountModel
+        user_id = _coerce_id(model, "user_id", user_id)
+        if user_id is _NO_MATCH:
+            return []
+        with self._open_session() as session:
+            statement = self.filter_social_account_query(
+                select(model).where(getattr(model, "user_id") == user_id)
+            )
+            rows = list(session.exec(statement).all())
+        return [_prepare_social_account(row) for row in rows]
+
+    def create_social_account(
+        self,
+        *,
+        user_id: object,
+        provider: str,
+        provider_user_id: str,
+        access_token: str | None,
+        refresh_token: str | None,
+        access_token_expires_at: datetime | None,
+        refresh_token_expires_at: datetime | None,
+        scope: str | None,
+        user_info: dict[str, object],
+        provider_email: str | None,
+        provider_email_verified: bool | None,
+        is_login_method: bool,
+    ) -> SocialAccountModelT:
+        coerced_user_id = _coerce_id(self.SocialAccountModel, "user_id", user_id)
+        values = self.build_social_account_create_values(
+            user_id=user_id if coerced_user_id is _NO_MATCH else coerced_user_id,
+            provider=provider,
+            provider_user_id=provider_user_id,
+            access_token=access_token,
+            refresh_token=refresh_token,
+            access_token_expires_at=access_token_expires_at,
+            refresh_token_expires_at=refresh_token_expires_at,
+            scope=scope,
+            user_info=user_info,
+            provider_email=provider_email,
+            provider_email_verified=provider_email_verified,
+            is_login_method=is_login_method,
+        )
+        self._check_social_account_values(values)
+        values = self._bind_social_account_datetimes(values)
+        with self._open_session() as session:
+            row = self.SocialAccountModel(**values)
+            session.add(row)
+            session.commit()
+        return _prepare_social_account(row)
+
+    def update_social_account(
+        self,
+        social_account_id: object,
+        *,
+        access_token: str | None,
+        refresh_token: str | None,
+        access_token_expires_at: datetime | None,
+        refresh_token_expires_at: datetime | None,
+        scope: str | None,
+        user_info: dict[str, object],
+        provider_email: str | None,
+        provider_email_verified: bool | None,
+    ) -> SocialAccountModelT:
+        with self._open_session() as session:
+            row = self._get_social_account_for_write(session, social_account_id)
+            if row is None:
+                raise ValueError(f"Social account {social_account_id!r} does not exist")
+            values = self.build_social_account_update_values(
+                record=row,
+                access_token=access_token,
+                refresh_token=refresh_token,
+                access_token_expires_at=access_token_expires_at,
+                refresh_token_expires_at=refresh_token_expires_at,
+                scope=scope,
+                user_info=user_info,
+                provider_email=provider_email,
+                provider_email_verified=provider_email_verified,
+            )
+            self._check_social_account_values(values)
+            values = self._bind_social_account_datetimes(values)
+            for key, value in values.items():
+                setattr(row, key, value)
+            session.add(row)
+            session.commit()
+        return _prepare_social_account(row)
+
+    def delete_social_account(self, social_account_id: object) -> None:
+        with self._open_session() as session:
+            row = self._get_social_account_for_write(session, social_account_id)
+            if row is None:
+                return
+            session.delete(row)
+            session.commit()
+
+    def _get_social_account_for_write(
+        self, session: Session, social_account_id: object
+    ) -> SocialAccountModelT | None:
+        # Writes go through filter_social_account_query too, so a store that
+        # scopes lookups (e.g. by tenant) can't be made to mutate rows its
+        # finds would never return.
+        model = self.SocialAccountModel
+        social_account_id = _coerce_id(model, "id", social_account_id)
+        if social_account_id is _NO_MATCH:
+            return None
+        statement = self.filter_social_account_query(
+            select(model).where(getattr(model, "id") == social_account_id)
+        )
+        return session.exec(statement).first()
+
+    def _bind_social_account_datetimes(
+        self, values: dict[str, object]
+    ) -> dict[str, object]:
+        model = self.SocialAccountModel
+        return {
+            key: _bind_datetime(model, key, value)
+            if isinstance(value, datetime)
+            else value
+            for key, value in values.items()
+        }
+
+    def build_user(
+        self,
+        *,
+        session: Session,
+        user_info: dict[str, object],
+        email: str,
+        email_verified: bool,
+    ) -> UserModelT:
+        """Construct the new user instance for ``create_user``.
+
+        Override when the default ``UserModel(email=..., email_verified=...)``
+        call doesn't fit — extra required columns, generated fields (e.g. a
+        unique username, which is why the open ``session`` is provided), or a
+        differently-named column: SQLModel silently ignores unknown
+        constructor kwargs, so a model storing verification under another
+        name must be constructed explicitly here. Return the instance without
+        adding or committing it; ``create_user`` does both.
+        """
+        return self.UserModel(email=email, email_verified=email_verified)
+
+    def on_signup(
+        self,
+        *,
+        session: Session,
+        user: UserModelT,
+        user_info: dict[str, object],
+        email_verified: bool,
+    ) -> None:
+        """Attach app-specific signup behaviour. Runs inside the signup
+        transaction, after ``user`` is added but before the commit.
+
+        - Raise (e.g. ``CrossAuthException`` for an invite check) to abort the
+          signup: the transaction rolls back and nothing is persisted.
+        - Mutate ``user`` to set extra columns (profile defaults, values
+          derived from ``user_info``).
+        - ``session.add(...)`` related rows (a team, a billing record) to
+          include them in the same commit.
+
+        ``user`` is not flushed yet, so ``user.id`` may be unset; call
+        ``session.flush()`` if you need it. The default does nothing.
+        """
+
+    def after_signup(
+        self,
+        *,
+        user: UserModelT,
+        user_info: dict[str, object],
+    ) -> None:
+        """Run side effects after the signup transaction has committed —
+        telemetry, welcome emails, queueing background work.
+
+        ``user`` is the committed, fully-loaded instance ``create_user`` is
+        about to return. Raising here does NOT undo the signup; the user is
+        already persisted. The default does nothing.
+        """
+
+    def filter_user_query(
+        self, statement: SelectOfScalar[UserModelT]
+    ) -> SelectOfScalar[UserModelT]:
+        """Customize user lookups, e.g. exclude soft-deleted users."""
+        return statement
+
+    def filter_social_account_query(
+        self, statement: SelectOfScalar[SocialAccountModelT]
+    ) -> SelectOfScalar[SocialAccountModelT]:
+        """Customize social account reads and writes, e.g. tenant scoping.
+
+        Not applied to the eager-loaded ``user.social_accounts`` relationship
+        on a user returned by this store — that collection is loaded
+        unfiltered; filtered reads must go through ``list_social_accounts``.
+        """
+        return statement
+
+    def build_social_account_create_values(
+        self, *, user_info: dict[str, object], **fields: object
+    ) -> dict[str, object]:
+        """Build the column values for a new social account row.
+
+        ``user_info`` is provided for apps that derive extra columns (such as a
+        provider username); by default it is not persisted. Override to map
+        provider-specific fields onto your own columns.
+        """
+        return fields
+
+    def build_social_account_update_values(
+        self,
+        *,
+        user_info: dict[str, object],
+        record: SocialAccountModelT,
+        **fields: object,
+    ) -> dict[str, object]:
+        """Build the column values for updating a social account row.
+
+        ``record`` is the loaded row being updated — read its current state
+        (e.g. ``record.provider`` / ``record.provider_user_id``) to derive
+        columns such as a provider username. Return the values to write
+        rather than mutating ``record`` directly.
+        """
+        return fields

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, create_engine
+
+from . import models  # noqa: F401 - registers the test tables on the metadata
+
+
+def make_sqlite_engine():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture
+def engine():
+    return make_sqlite_engine()

--- a/tests/storage/models.py
+++ b/tests/storage/models.py
@@ -1,0 +1,299 @@
+"""Shared SQLModel test models for the storage adapter tests.
+
+Defined once at module level so every table is registered on
+``SQLModel.metadata`` before the conftest engine runs ``create_all``.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime
+from sqlmodel import Field, Relationship, Session, SQLModel
+from sqlmodel.sql.expression import SelectOfScalar
+
+from cross_auth import SessionStatus, session_status
+from cross_auth.storage.sqlmodel import (
+    SQLModelAccountsStorage,
+    SQLModelSessionStorage,
+)
+
+
+class UserSession(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    token_hash: str = Field(index=True)
+    user_id: str = Field(index=True)
+    created_at: datetime
+    updated_at: datetime
+    expires_at: datetime
+    last_active_at: datetime | None = None
+    revoked_at: datetime | None = None
+    client_id: str | None = None
+    client_name: str | None = None
+    user_agent: str | None = None
+    ip: str | None = None
+
+    @property
+    def status(self) -> SessionStatus:
+        return session_status(self)
+
+
+class SessionStore(SQLModelSessionStorage[UserSession]):
+    SessionModel = UserSession
+
+
+class UuidUserSession(SQLModel, table=True):
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    token_hash: str = Field(index=True)
+    user_id: str = Field(index=True)
+    created_at: datetime
+    updated_at: datetime
+    expires_at: datetime
+    last_active_at: datetime | None = None
+    revoked_at: datetime | None = None
+    client_id: str | None = None
+    client_name: str | None = None
+    user_agent: str | None = None
+    ip: str | None = None
+
+    @property
+    def status(self) -> SessionStatus:
+        return session_status(self)
+
+
+class UuidSessionStore(SQLModelSessionStorage[UuidUserSession]):
+    SessionModel = UuidUserSession
+
+
+class IntUserIdSession(SQLModel, table=True):
+    """Session model whose ``user_id`` is an integer foreign-key-style column.
+    Cross-Auth passes user ids as strings; the adapter coerces them to the
+    column type."""
+
+    id: int | None = Field(default=None, primary_key=True)
+    token_hash: str = Field(index=True)
+    user_id: int = Field(index=True)
+    created_at: datetime
+    updated_at: datetime
+    expires_at: datetime
+    last_active_at: datetime | None = None
+    revoked_at: datetime | None = None
+    client_id: str | None = None
+    client_name: str | None = None
+    user_agent: str | None = None
+    ip: str | None = None
+
+    @property
+    def status(self) -> SessionStatus:
+        return session_status(self)
+
+
+class IntUserIdSessionStore(SQLModelSessionStorage[IntUserIdSession]):
+    SessionModel = IntUserIdSession
+
+
+class RenamedColumnSession(SQLModel, table=True):
+    """Session model whose id and datetime columns are mapped to differently
+    named database columns. The adapter must resolve columns by the Python
+    attribute name, not the database column name."""
+
+    id: int | None = Field(
+        default=None, primary_key=True, sa_column_kwargs={"name": "session_pk"}
+    )
+    token_hash: str = Field(index=True)
+    user_id: str = Field(index=True)
+    created_at: datetime = Field(sa_column_kwargs={"name": "created_ts"})
+    updated_at: datetime = Field(sa_column_kwargs={"name": "updated_ts"})
+    expires_at: datetime = Field(sa_column_kwargs={"name": "expires_ts"})
+    last_active_at: datetime | None = Field(
+        default=None, sa_column_kwargs={"name": "last_active_ts"}
+    )
+    revoked_at: datetime | None = Field(
+        default=None, sa_column_kwargs={"name": "revoked_ts"}
+    )
+    client_id: str | None = None
+    client_name: str | None = None
+    user_agent: str | None = None
+    ip: str | None = None
+
+    @property
+    def status(self) -> SessionStatus:
+        return session_status(self)
+
+
+class RenamedColumnSessionStore(SQLModelSessionStorage[RenamedColumnSession]):
+    SessionModel = RenamedColumnSession
+
+
+class TzAwareUserSession(SQLModel, table=True):
+    """Session model with timezone-aware (``timestamptz``) datetime columns, the
+    alternative to the naive-column default the other models use."""
+
+    id: int | None = Field(default=None, primary_key=True)
+    token_hash: str = Field(index=True)
+    user_id: str = Field(index=True)
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True)))
+    updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True)))
+    expires_at: datetime = Field(sa_column=Column(DateTime(timezone=True)))
+    last_active_at: datetime | None = Field(
+        default=None, sa_column=Column(DateTime(timezone=True))
+    )
+    revoked_at: datetime | None = Field(
+        default=None, sa_column=Column(DateTime(timezone=True))
+    )
+    client_id: str | None = None
+    client_name: str | None = None
+    user_agent: str | None = None
+    ip: str | None = None
+
+    @property
+    def status(self) -> SessionStatus:
+        return session_status(self)
+
+
+class TzAwareSessionStore(SQLModelSessionStorage[TzAwareUserSession]):
+    SessionModel = TzAwareUserSession
+
+
+class SocialAccount(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id")
+    provider: str
+    provider_user_id: str
+    access_token: str | None = None
+    refresh_token: str | None = None
+    access_token_expires_at: datetime | None = None
+    refresh_token_expires_at: datetime | None = None
+    scope: str | None = None
+    provider_email: str | None = None
+    provider_email_verified: bool | None = None
+    is_login_method: bool = True
+
+    user: "User" = Relationship(back_populates="social_accounts")
+
+
+class User(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    email: str = Field(index=True)
+    email_verified: bool = False
+    hashed_password: str | None = None
+    deleted: bool = False
+
+    social_accounts: list[SocialAccount] = Relationship(back_populates="user")
+
+    @property
+    def has_usable_password(self) -> bool:
+        return self.hashed_password is not None
+
+
+class AccountsStore(SQLModelAccountsStorage[User, SocialAccount]):
+    UserModel = User
+    SocialAccountModel = SocialAccount
+
+    def on_signup(
+        self,
+        *,
+        session: Session,
+        user: User,
+        user_info: dict[str, object],
+        email_verified: bool,
+    ) -> None:
+        hashed_password = user_info.get("hashed_password")
+        assert hashed_password is None or isinstance(hashed_password, str)
+        user.hashed_password = hashed_password
+
+
+class SoftDeleteAccountsStore(AccountsStore):
+    def filter_user_query(
+        self, statement: SelectOfScalar[User]
+    ) -> SelectOfScalar[User]:
+        return statement.where(User.deleted == False)  # noqa: E712
+
+
+class LeanSocialAccount(SQLModel, table=True):
+    """Social account without the token/scope columns — for an app that never
+    persists provider tokens. Only valid together with payload builders that
+    drop those fields (see LeanAccountsStore)."""
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id")
+    provider: str
+    provider_user_id: str
+    provider_email: str | None = None
+    provider_email_verified: bool | None = None
+    is_login_method: bool = True
+
+
+_TOKEN_FIELDS = (
+    "access_token",
+    "refresh_token",
+    "access_token_expires_at",
+    "refresh_token_expires_at",
+    "scope",
+)
+
+
+class LeanAccountsStore(AccountsStore):
+    SocialAccountModel = LeanSocialAccount  # type: ignore[assignment]
+
+    def build_social_account_create_values(
+        self, *, user_info: dict[str, object], **fields: object
+    ) -> dict[str, object]:
+        return {k: v for k, v in fields.items() if k not in _TOKEN_FIELDS}
+
+    def build_social_account_update_values(
+        self,
+        *,
+        user_info: dict[str, object],
+        # Annotated with the class's declared generic (the runtime rows are
+        # LeanSocialAccount, see the SocialAccountModel reassignment above).
+        record: SocialAccount,
+        **fields: object,
+    ) -> dict[str, object]:
+        return {k: v for k, v in fields.items() if k not in _TOKEN_FIELDS}
+
+
+class PropertyScopeSocialAccount(SQLModel, table=True):
+    """A social account whose ``scope`` write field is a read-only property
+    instead of a mapped column. ``hasattr(model, "scope")`` is True here, but
+    SQLModel's constructor only accepts pydantic fields — a property is
+    silently dropped rather than set, which is exactly the failure mode the
+    write-field validation exists to catch at construction."""
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id")
+    provider: str
+    provider_user_id: str
+    access_token: str | None = None
+    refresh_token: str | None = None
+    access_token_expires_at: datetime | None = None
+    refresh_token_expires_at: datetime | None = None
+    provider_email: str | None = None
+    provider_email_verified: bool | None = None
+    is_login_method: bool = True
+
+    @property
+    def scope(self) -> str | None:
+        return None
+
+
+class PropUser(SQLModel, table=True):
+    """A protocol-compliant user whose ``social_accounts`` is a plain property
+    rather than an ORM relationship."""
+
+    id: int | None = Field(default=None, primary_key=True)
+    email: str = Field(index=True)
+    email_verified: bool = False
+    hashed_password: str | None = None
+
+    @property
+    def has_usable_password(self) -> bool:
+        return self.hashed_password is not None
+
+    @property
+    def social_accounts(self) -> list[SocialAccount]:
+        return []
+
+
+class PropAccountsStore(SQLModelAccountsStorage[PropUser, SocialAccount]):
+    UserModel = PropUser
+    SocialAccountModel = SocialAccount

--- a/tests/storage/test_cursor.py
+++ b/tests/storage/test_cursor.py
@@ -1,0 +1,92 @@
+import base64
+import json
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from cross_auth.storage import InvalidCursorError
+from cross_auth.storage._cursor import decode_cursor, encode_cursor
+
+NOW = datetime(2026, 6, 6, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _craft(payload: object) -> str:
+    return base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+
+
+@pytest.mark.parametrize("row_id", [42, "row-1", uuid.uuid4()])
+def test_round_trip(row_id):
+    cursor = encode_cursor("updated_at_desc", NOW, row_id)
+
+    decoded = decode_cursor(cursor)
+
+    assert decoded.order_by == "updated_at_desc"
+    assert decoded.value == NOW
+    assert decoded.row_id == row_id
+    assert type(decoded.row_id) is type(row_id)
+
+
+def test_invalid_cursor_error_is_a_value_error():
+    assert issubclass(InvalidCursorError, ValueError)
+
+
+def test_invalid_cursor_error_canonical_home_is_exceptions():
+    # Custom SessionStorage implementations import it from cross_auth.exceptions
+    # without touching the adapter package; cross_auth.storage re-exports it.
+    from cross_auth import exceptions
+
+    assert InvalidCursorError is exceptions.InvalidCursorError
+
+
+@pytest.mark.parametrize(
+    "cursor",
+    [
+        "not base64 at all!",
+        base64.urlsafe_b64encode(b"not json").decode(),
+        _craft(["a", "list"]),
+        _craft({"v": NOW.isoformat(), "id": 1}),  # missing order
+        _craft({"o": "updated_at_desc", "id": 1}),  # missing value
+        _craft({"o": "updated_at_desc", "v": "not-a-date", "id": 1}),
+        _craft({"o": "updated_at_desc", "v": NOW.isoformat()}),  # missing id
+        _craft({"o": "updated_at_desc", "v": NOW.isoformat(), "id": {"x": 1}}),
+        _craft({"o": "updated_at_desc", "v": NOW.isoformat(), "id": None}),
+        _craft({"o": "updated_at_desc", "v": NOW.isoformat(), "id": True}),
+        _craft({"o": "updated_at_desc", "v": NOW.isoformat(), "id": [1]}),
+        _craft({"o": "updated_at_desc", "v": NOW.isoformat(), "id": {"t": "uuid"}}),
+        _craft(
+            {
+                "o": "updated_at_desc",
+                "v": NOW.isoformat(),
+                "id": {"t": "uuid", "v": "not-a-uuid"},
+            }
+        ),
+    ],
+)
+def test_decode_rejects_malformed_cursors(cursor):
+    with pytest.raises(InvalidCursorError):
+        decode_cursor(cursor)
+
+
+def test_decode_rejects_oversized_cursor():
+    # Legitimate cursors are ~100-200 bytes; a much longer one is crafted.
+    with pytest.raises(InvalidCursorError):
+        decode_cursor("a" * 513)
+
+
+def test_decode_rejects_deeply_nested_payload():
+    # A deeply nested payload can make json.loads raise RecursionError
+    # instead of a clean parse failure (observed on Python 3.11); the
+    # oversized cursor must be rejected before decoding is even attempted.
+    crafted = base64.urlsafe_b64encode(("[" * 1500).encode()).decode()
+
+    with pytest.raises(InvalidCursorError):
+        decode_cursor(crafted)
+
+
+def test_encode_rejects_unsupported_id_types():
+    with pytest.raises(TypeError, match="bytes"):
+        encode_cursor("updated_at_desc", NOW, b"binary-id")
+
+    with pytest.raises(TypeError, match="bool"):
+        encode_cursor("updated_at_desc", NOW, True)

--- a/tests/storage/test_postgres.py
+++ b/tests/storage/test_postgres.py
@@ -1,0 +1,323 @@
+"""PostgreSQL integration tests for the SQLModel storage adapters.
+
+These run against a disposable Postgres container (testcontainers) whose
+connection TimeZone is deliberately non-UTC: that is the configuration that
+exposes naive/aware datetime handling and parameter-typing bugs SQLite cannot
+reproduce (SQLite stores datetimes as strings and coerces text ids silently).
+The tests skip automatically when Docker is unavailable.
+"""
+
+import base64
+import json
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import cast
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+
+from cross_auth._session import create_session, get_session
+from cross_auth._storage import SessionStorage
+from cross_auth.exceptions import InvalidCursorError
+
+from .models import (
+    AccountsStore,
+    RenamedColumnSessionStore,
+    SessionStore,
+    UuidSessionStore,
+)
+
+pytest.importorskip("psycopg")
+testcontainers_postgres = pytest.importorskip("testcontainers.postgres")
+
+
+@pytest.fixture(scope="module")
+def pg_engine():
+    try:
+        container = testcontainers_postgres.PostgresContainer(
+            "postgres:16-alpine", driver="psycopg"
+        )
+        container.start()
+    except Exception as exc:  # docker missing or unreachable
+        # In CI, Docker must be available; skipping silently would hide a
+        # broken test environment instead of failing the build.
+        if os.environ.get("CI"):
+            raise
+        pytest.skip(f"Docker unavailable for testcontainers: {exc}")
+    engine = create_engine(
+        container.get_connection_url(),
+        # A non-UTC connection TimeZone is what breaks naive-datetime
+        # handling in production; keep it weird on purpose.
+        connect_args={"options": "-c TimeZone=America/New_York"},
+    )
+    SQLModel.metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+    container.stop()
+
+
+@pytest.fixture
+def store(pg_engine):
+    return SessionStore(session_factory=lambda: Session(pg_engine))
+
+
+@pytest.fixture
+def accounts(pg_engine):
+    return AccountsStore(session_factory=lambda: Session(pg_engine))
+
+
+@pytest.fixture
+def uuid_store(pg_engine):
+    return UuidSessionStore(session_factory=lambda: Session(pg_engine))
+
+
+def _uid() -> str:
+    return f"u-{uuid.uuid4().hex[:12]}"
+
+
+def _make(store, *, user_id, suffix="0", now, **overrides):
+    values = {
+        "token_hash": f"{user_id}-t{suffix}",
+        "user_id": user_id,
+        "created_at": now,
+        "updated_at": now,
+        "expires_at": now + timedelta(days=1),
+        **overrides,
+    }
+    return store.create(**values)
+
+
+def test_roundtrip_preserves_utc_instants(store):
+    user_id = _uid()
+    now = datetime.now(tz=timezone.utc)
+
+    record = store.create(
+        token_hash=f"{user_id}-th",
+        user_id=user_id,
+        created_at=now,
+        updated_at=now,
+        expires_at=now + timedelta(days=1),
+        last_active_at=now,
+    )
+    fetched = store.get(token_hash=f"{user_id}-th", now=now)
+
+    assert fetched is not None
+    # The exact instants survive the non-UTC connection TimeZone; a shifted
+    # value here is the bug that broke sliding refresh and reported expiry.
+    assert fetched.created_at == now
+    assert fetched.updated_at == now
+    assert fetched.last_active_at == now
+    assert fetched.expires_at == now + timedelta(days=1)
+    assert fetched.updated_at.tzinfo is not None
+
+    new_updated = now + timedelta(hours=1)
+    new_expires = now + timedelta(days=2)
+    store.refresh(
+        record.id,
+        updated_at=new_updated,
+        expires_at=new_expires,
+        last_active_at=new_updated,
+    )
+
+    # Re-read through a fresh session on the same non-UTC connection: the
+    # refresh must have been committed and the instants must survive intact.
+    persisted = store.get_any(record.id)
+    assert persisted is not None
+    assert persisted.updated_at == new_updated
+    assert persisted.expires_at == new_expires
+    assert persisted.last_active_at == new_updated
+
+
+def test_core_sliding_refresh_window_arithmetic(store):
+    # The core decides whether to roll a session via `now - updated_at`.
+    # Within the update window nothing must be refreshed; a timezone shift of
+    # the stored value makes this fire on every request (or never).
+    session_storage = cast(SessionStorage, store)
+    token, record = create_session(_uid(), session_storage)
+
+    session = get_session(token, session_storage, {"update_age": 3600})
+
+    assert session is not None
+    assert session.updated_at == record.updated_at
+
+
+def test_cursor_pagination_walks_all_pages(store):
+    user_id = _uid()
+    now = datetime.now(tz=timezone.utc)
+    for i in range(5):
+        _make(
+            store,
+            user_id=user_id,
+            suffix=str(i),
+            now=now,
+            updated_at=now + timedelta(minutes=i),
+        )
+
+    seen: list[str] = []
+    cursor = None
+    for _ in range(5):
+        page = store.list_for_user(user_id, now=now, limit=2, cursor=cursor)
+        seen.extend(r.token_hash for r in page.records)
+        cursor = page.next_cursor
+        if cursor is None:
+            break
+
+    # No rows skipped or duplicated across the cursor boundary.
+    assert seen == [f"{user_id}-t{i}" for i in (4, 3, 2, 1, 0)]
+
+
+def test_status_filters(store):
+    user_id = _uid()
+    now = datetime.now(tz=timezone.utc)
+    active = _make(store, user_id=user_id, suffix="active", now=now)
+    expired = _make(
+        store,
+        user_id=user_id,
+        suffix="expired",
+        now=now,
+        expires_at=now - timedelta(seconds=1),
+    )
+    revoked = _make(store, user_id=user_id, suffix="revoked", now=now)
+    store.revoke(revoked.id, revoked_at=now)
+
+    by_status = {
+        status: [
+            r.id for r in store.list_for_user(user_id, now=now, status=status).records
+        ]
+        for status in ("active", "expired", "revoked")
+    }
+
+    assert by_status == {
+        "active": [active.id],
+        "expired": [expired.id],
+        "revoked": [revoked.id],
+    }
+
+
+def test_string_ids_match_int_pk_instead_of_erroring(store, accounts):
+    user_id = _uid()
+    now = datetime.now(tz=timezone.utc)
+    record = _make(store, user_id=user_id, now=now)
+
+    # HTTP path params arrive as strings; without coercion Postgres raises
+    # DataError ("invalid input syntax for type ...") instead of matching.
+    assert store.get_any(str(record.id)) is not None
+    assert store.get_any("abc") is None
+    store.revoke("abc", revoked_at=now)  # no-op, not a 500
+
+    user = accounts.create_user(
+        user_info={}, email=f"{user_id}@example.com", email_verified=True
+    )
+    assert accounts.find_user_by_id(str(user.id)) is not None
+    assert accounts.find_user_by_id("abc") is None
+    assert accounts.find_social_account_by_id("abc") is None
+
+
+def test_session_user_id_string_column_matches_core_usage(store):
+    # Core always passes user ids as str (login(user_id: str)); the documented
+    # session model declares user_id: str so inserts and filters type-match.
+    user_id_as_core_sends_it = str(12345)
+    now = datetime.now(tz=timezone.utc)
+    record = _make(store, user_id=user_id_as_core_sends_it, now=now)
+
+    result = store.list_for_user(user_id_as_core_sends_it, now=now)
+    assert [r.id for r in result.records] == [record.id]
+
+
+def test_social_account_token_expiry_roundtrips_aware(accounts):
+    user = accounts.create_user(
+        user_info={}, email=f"{_uid()}@example.com", email_verified=True
+    )
+    expires = datetime.now(tz=timezone.utc) + timedelta(hours=1)
+
+    account = accounts.create_social_account(
+        user_id=user.id,
+        provider="github",
+        provider_user_id=_uid(),
+        access_token="at",
+        refresh_token=None,
+        access_token_expires_at=expires,
+        refresh_token_expires_at=None,
+        scope=None,
+        user_info={},
+        provider_email=None,
+        provider_email_verified=None,
+        is_login_method=True,
+    )
+
+    fetched = accounts.find_social_account_by_id(account.id)
+    assert fetched.access_token_expires_at == expires
+    assert fetched.access_token_expires_at.tzinfo is not None
+
+
+def test_renamed_columns_preserve_utc_on_non_utc_connection(pg_engine):
+    # Renamed naive datetime columns must still be stored as UTC wall time on a
+    # non-UTC connection. Resolving the column by its database name instead of
+    # its attribute would skip tz-stripping and silently shift every instant.
+    store = RenamedColumnSessionStore(session_factory=lambda: Session(pg_engine))
+    user_id = _uid()
+    now = datetime.now(tz=timezone.utc)
+    store.create(
+        token_hash=f"{user_id}-rt",
+        user_id=user_id,
+        created_at=now,
+        updated_at=now,
+        expires_at=now + timedelta(days=1),
+        last_active_at=now,
+    )
+
+    fetched = store.get(token_hash=f"{user_id}-rt", now=now)
+
+    assert fetched is not None
+    assert fetched.created_at == now
+    assert fetched.last_active_at == now
+    assert fetched.expires_at == now + timedelta(days=1)
+
+
+def test_revoke_all_reports_rowcount(store):
+    user_id = _uid()
+    now = datetime.now(tz=timezone.utc)
+    _make(store, user_id=user_id, suffix="a", now=now)
+    _make(store, user_id=user_id, suffix="b", now=now)
+
+    assert store.revoke_all_for_user(user_id, revoked_at=now) == 2
+    assert store.revoke_all_for_user(user_id, revoked_at=now) == 0
+
+
+def _crafted_cursor(order_by: str, now: datetime, row_id: object) -> str:
+    payload = {"o": order_by, "v": now.isoformat(), "id": row_id}
+    return base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+
+
+def test_crafted_cross_type_cursor_ids_raise_invalid_cursor(store, uuid_store):
+    # Without coercion these reach Postgres as `integer < uuid` and
+    # `uuid < integer` respectively, raising ProgrammingError instead of the
+    # documented InvalidCursorError.
+    user_id = _uid()
+    now = datetime.now(tz=timezone.utc)
+    _make(store, user_id=user_id, now=now)
+    uuid_shaped_id = {"t": "uuid", "v": str(uuid.uuid4())}
+    crafted = _crafted_cursor("updated_at_desc", now, uuid_shaped_id)
+
+    with pytest.raises(InvalidCursorError):
+        store.list_for_user(user_id, now=now, cursor=crafted)
+
+    uuid_store.create(
+        token_hash=f"{user_id}-uuid",
+        user_id=user_id,
+        created_at=now,
+        updated_at=now,
+        expires_at=now + timedelta(days=1),
+    )
+    crafted_int = _crafted_cursor("updated_at_desc", now, 1)
+
+    with pytest.raises(InvalidCursorError):
+        uuid_store.list_for_user(user_id, now=now, cursor=crafted_int)
+
+
+def test_get_any_out_of_range_id_returns_none_instead_of_data_error(store):
+    # int("99999999999") comfortably exceeds a Postgres int4 primary key,
+    # which previously raised DataError (NumericValueOutOfRange) instead of
+    # answering None.
+    assert store.get_any("99999999999") is None

--- a/tests/storage/test_redis.py
+++ b/tests/storage/test_redis.py
@@ -1,0 +1,167 @@
+from typing import cast
+
+import pytest
+from redis import Redis
+
+from cross_auth.storage.redis import RedisStorage
+
+RedisValue = bytes | str | None
+
+
+class FakeRedis:
+    """Minimal redis-py-like client backed by a dict.
+
+    ``decode_responses`` mirrors the real client: when False (default) reads
+    return ``bytes``; when True they return ``str``.
+    """
+
+    def __init__(self, *, decode_responses: bool = False):
+        self.data: dict[str, bytes] = {}
+        self.decode_responses = decode_responses
+
+    def _encode(self, value: str) -> bytes:
+        return value.encode()
+
+    def _read(self, raw: bytes | None) -> RedisValue:
+        if raw is None:
+            return None
+        return raw.decode() if self.decode_responses else raw
+
+    def set(self, name: str, value: str, ex: int | None = None) -> None:
+        self.data[name] = self._encode(value)
+        self.last_ex = ex
+
+    def get(self, name: str) -> RedisValue:
+        return self._read(self.data.get(name))
+
+    def getdel(self, name: str) -> RedisValue:
+        value = self.get(name)
+        self.delete(name)
+        return value
+
+    def delete(self, *names: str) -> int:
+        removed = 0
+        for name in names:
+            if name in self.data:
+                del self.data[name]
+                removed += 1
+        return removed
+
+
+def _typed(client: FakeRedis) -> Redis:
+    return cast(Redis, client)
+
+
+def test_set_passes_value_and_ttl():
+    client = FakeRedis()
+    storage = RedisStorage(_typed(client))
+
+    storage.set("k", "v", ttl=42)
+
+    assert client.get("k") == b"v"
+    assert client.last_ex == 42
+
+
+def test_set_without_ttl():
+    client = FakeRedis()
+    storage = RedisStorage(_typed(client))
+
+    storage.set("k", "v")
+
+    assert client.last_ex is None
+
+
+def test_set_with_non_positive_ttl_deletes_the_key():
+    # Redis rejects EX <= 0; an already-expired value must just not exist.
+    client = FakeRedis()
+    storage = RedisStorage(_typed(client))
+    storage.set("k", "v")
+
+    storage.set("k", "v2", ttl=0)
+    assert storage.get("k") is None
+
+    storage.set("other", "v", ttl=-5)
+    assert storage.get("other") is None
+
+
+def test_get_decodes_bytes():
+    client = FakeRedis(decode_responses=False)
+    storage = RedisStorage(_typed(client))
+    storage.set("k", "v")
+
+    assert storage.get("k") == "v"
+
+
+def test_get_handles_already_decoded_str():
+    client = FakeRedis(decode_responses=True)
+    storage = RedisStorage(_typed(client))
+    storage.set("k", "v")
+
+    assert storage.get("k") == "v"
+
+
+def test_get_missing_returns_none():
+    storage = RedisStorage(_typed(FakeRedis()))
+
+    assert storage.get("missing") is None
+
+
+def test_delete():
+    client = FakeRedis()
+    storage = RedisStorage(_typed(client))
+    storage.set("k", "v")
+
+    storage.delete("k")
+
+    assert storage.get("k") is None
+
+
+def test_pop_uses_getdel():
+    client = FakeRedis()
+    storage = RedisStorage(_typed(client))
+    storage.set("k", "v")
+
+    assert storage.pop("k") == "v"
+    assert storage.get("k") is None
+
+
+def test_pop_missing_returns_none():
+    storage = RedisStorage(_typed(FakeRedis()))
+
+    assert storage.pop("missing") is None
+
+
+def test_pop_handles_already_decoded_str():
+    client = FakeRedis(decode_responses=True)
+    storage = RedisStorage(_typed(client))
+    storage.set("k", "v")
+
+    assert storage.pop("k") == "v"
+    assert storage.get("k") is None
+
+
+def test_constructor_rejects_client_without_getdel():
+    # redis-py < 4.2 (or any client that doesn't expose GETDEL) would raise
+    # AttributeError on the first pop() call, mid-OAuth-callback — catch it
+    # at construction instead.
+    class NoGetDel:
+        def get(self, name: str) -> RedisValue:
+            return None
+
+    with pytest.raises(TypeError, match="getdel"):
+        RedisStorage(cast(Redis, NoGetDel()))
+
+
+def test_constructor_rejects_async_client():
+    # An async client (e.g. redis.asyncio.Redis) would make every method
+    # return an unawaited coroutine instead of doing anything — set() would
+    # silently store nothing.
+    class AsyncRedis:
+        def getdel(self, name: str) -> RedisValue:
+            return None
+
+        async def get(self, name: str) -> RedisValue:
+            return None
+
+    with pytest.raises(TypeError, match="synchronous"):
+        RedisStorage(cast(Redis, AsyncRedis()))

--- a/tests/storage/test_sqlmodel_accounts.py
+++ b/tests/storage/test_sqlmodel_accounts.py
@@ -1,0 +1,688 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlmodel import Session
+
+from cross_auth.exceptions import CrossAuthException
+from cross_auth.storage.sqlmodel import SQLModelAccountsStorage
+
+from .models import (
+    AccountsStore,
+    LeanAccountsStore,
+    LeanSocialAccount,
+    PropAccountsStore,
+    PropertyScopeSocialAccount,
+    SocialAccount,
+    SoftDeleteAccountsStore,
+    User,
+)
+
+NOW = datetime(2026, 6, 6, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def store(engine):
+    return AccountsStore(session_factory=lambda: Session(engine))
+
+
+def _seed_user(
+    engine,
+    *,
+    email: str = "a@example.com",
+    email_verified: bool = True,
+    hashed_password: str | None = None,
+    deleted: bool = False,
+) -> int:
+    with Session(engine) as session:
+        user = User(
+            email=email,
+            email_verified=email_verified,
+            hashed_password=hashed_password,
+            deleted=deleted,
+        )
+        session.add(user)
+        session.commit()
+        user_id = user.id
+    assert user_id is not None
+    return user_id
+
+
+def _seed_social(
+    engine, *, user_id, provider="github", provider_user_id="123", **kwargs
+):
+    with Session(engine) as session:
+        account = SocialAccount(
+            user_id=user_id,
+            provider=provider,
+            provider_user_id=provider_user_id,
+            **kwargs,
+        )
+        session.add(account)
+        session.commit()
+        return account.id
+
+
+def test_find_user_by_email(store, engine):
+    _seed_user(engine, email="found@example.com")
+
+    user = store.find_user_by_email("found@example.com")
+
+    assert user is not None
+    assert user.email == "found@example.com"
+
+
+def test_find_user_by_email_missing(store):
+    assert store.find_user_by_email("nope@example.com") is None
+
+
+def test_find_user_by_id(store, engine):
+    user_id = _seed_user(engine)
+
+    user = store.find_user_by_id(user_id)
+
+    assert user is not None
+    assert user.id == user_id
+
+
+def test_find_user_by_id_coerces_string_ids(store, engine):
+    # Session records store user ids as strings; the lookup must still match
+    # an int primary key (and uncastable ids must answer None, not crash).
+    user_id = _seed_user(engine)
+
+    assert store.find_user_by_id(str(user_id)) is not None
+    assert store.find_user_by_id("abc") is None
+
+
+def test_returned_user_scalars_readable_after_close(store, engine):
+    _seed_user(engine, email="x@example.com", hashed_password="hash")
+
+    user = store.find_user_by_email("x@example.com")
+
+    # No active session here; these must not trigger a DB hit.
+    assert user.email == "x@example.com"
+    assert user.email_verified is True
+    assert user.has_usable_password is True
+
+
+def test_returned_user_relationship_readable_after_close(store, engine):
+    user_id = _seed_user(engine)
+    _seed_social(engine, user_id=user_id, provider="github", provider_user_id="g1")
+
+    user = store.find_user_by_id(user_id)
+
+    # social_accounts is eager-loaded, so this works after the session closed.
+    accounts = list(user.social_accounts)
+    assert len(accounts) == 1
+    assert accounts[0].provider == "github"
+
+
+def test_user_model_with_property_social_accounts(engine):
+    # The User protocol allows social_accounts to be a plain property; the
+    # adapter must not assume a mapped relationship of that name.
+    store = PropAccountsStore(session_factory=lambda: Session(engine))
+    user = store.create_user(
+        user_info={}, email="prop@example.com", email_verified=True
+    )
+
+    assert user.id is not None
+    found = store.find_user_by_email("prop@example.com")
+    assert found is not None
+    assert list(found.social_accounts) == []
+
+
+def test_soft_delete_hook_excludes_user(engine):
+    _seed_user(engine, email="gone@example.com", deleted=True)
+    store = SoftDeleteAccountsStore(session_factory=lambda: Session(engine))
+
+    assert store.find_user_by_email("gone@example.com") is None
+
+
+def test_create_user_bypasses_filter_user_query(engine):
+    # A fresh user must always be returned, even when filter_user_query would
+    # exclude it — otherwise create_user could return None mid-signup.
+    class DeletedOnSignupStore(SoftDeleteAccountsStore):
+        def on_signup(self, *, session, user, user_info, email_verified):
+            user.deleted = True
+
+    store = DeletedOnSignupStore(session_factory=lambda: Session(engine))
+
+    user = store.create_user(
+        user_info={}, email="soft@example.com", email_verified=True
+    )
+
+    assert user.id is not None
+    assert list(user.social_accounts) == []
+    assert store.find_user_by_id(user.id) is None  # filtered lookup excludes it
+
+
+def test_on_signup_joins_the_create_user_transaction(engine):
+    # The cloud-style signup: on_signup adds related rows to the session it
+    # receives, and everything commits as one unit of work. The returned user
+    # must still satisfy the read-after-close contract, including the
+    # eager-loaded relationship rows created in the same transaction.
+    class TeamSignupStore(AccountsStore):
+        def on_signup(self, *, session, user, user_info, email_verified):
+            # user_id is populated from the relationship at flush time.
+            session.add(
+                SocialAccount(  # ty: ignore[missing-argument]
+                    user=user, provider="github", provider_user_id="linked-1"
+                )
+            )
+
+    store = TeamSignupStore(session_factory=lambda: Session(engine))
+
+    user = store.create_user(
+        user_info={}, email="team@example.com", email_verified=True
+    )
+
+    # No open session here; both reads must not hit the database.
+    assert user.email == "team@example.com"
+    accounts = list(user.social_accounts)
+    assert [a.provider_user_id for a in accounts] == ["linked-1"]
+
+
+def test_on_signup_raise_aborts_the_signup(engine):
+    # An invite check raising inside the hook rolls back the transaction:
+    # neither the user nor any related rows are persisted.
+    class InviteOnlyStore(AccountsStore):
+        def on_signup(self, *, session, user, user_info, email_verified):
+            session.add(
+                SocialAccount(  # ty: ignore[missing-argument]
+                    user=user, provider="github", provider_user_id="rollback-1"
+                )
+            )
+            raise CrossAuthException("signup_not_allowed", "Invite only")
+
+    store = InviteOnlyStore(session_factory=lambda: Session(engine))
+
+    with pytest.raises(CrossAuthException):
+        store.create_user(
+            user_info={}, email="uninvited@example.com", email_verified=True
+        )
+
+    assert store.find_user_by_email("uninvited@example.com") is None
+    assert (
+        store.find_social_account(provider="github", provider_user_id="rollback-1")
+        is None
+    )
+
+
+def test_build_user_controls_construction(engine):
+    # Models needing more than UserModel(email=..., email_verified=...) —
+    # generated usernames, renamed columns — override build_user.
+    class CustomConstructionStore(SQLModelAccountsStorage[User, SocialAccount]):
+        UserModel = User
+        SocialAccountModel = SocialAccount
+
+        def build_user(self, *, session, user_info, email, email_verified):
+            return User(
+                email=email,
+                email_verified=email_verified,
+                hashed_password=f"gen:{user_info['seed']}",
+            )
+
+    store = CustomConstructionStore(session_factory=lambda: Session(engine))
+
+    user = store.create_user(
+        user_info={"seed": "abc"}, email="built@example.com", email_verified=True
+    )
+
+    assert user.hashed_password == "gen:abc"
+    assert user.email_verified is True
+
+
+def test_on_signup_receives_email_verified(engine):
+    captured = []
+
+    class VerifiedStore(AccountsStore):
+        def on_signup(self, *, session, user, user_info, email_verified):
+            captured.append(email_verified)
+
+    store = VerifiedStore(session_factory=lambda: Session(engine))
+    store.create_user(user_info={}, email="v@example.com", email_verified=True)
+
+    assert captured == [True]
+
+
+def test_after_signup_runs_after_commit(engine):
+    seen = []
+
+    class TelemetryStore(AccountsStore):
+        def after_signup(self, *, user, user_info):
+            # The transaction is already committed: the user has its id and
+            # is visible to a fresh session.
+            found = self.find_user_by_id(user.id)
+            seen.append((user.id, found is not None))
+
+    store = TelemetryStore(session_factory=lambda: Session(engine))
+
+    user = store.create_user(
+        user_info={}, email="telemetry@example.com", email_verified=True
+    )
+
+    assert seen == [(user.id, True)]
+
+
+def test_find_social_account(store, engine):
+    user_id = _seed_user(engine)
+    _seed_social(engine, user_id=user_id, provider="github", provider_user_id="g1")
+
+    account = store.find_social_account(provider="github", provider_user_id="g1")
+
+    assert account is not None
+    assert account.provider_user_id == "g1"
+
+
+def test_find_social_account_missing(store):
+    assert store.find_social_account(provider="x", provider_user_id="y") is None
+
+
+def test_find_social_account_by_id(store, engine):
+    user_id = _seed_user(engine)
+    account_id = _seed_social(engine, user_id=user_id)
+
+    account = store.find_social_account_by_id(account_id)
+
+    assert account is not None
+    assert account.id == account_id
+
+
+def test_find_social_account_by_id_coerces_string_ids(store, engine):
+    user_id = _seed_user(engine)
+    account_id = _seed_social(engine, user_id=user_id)
+
+    assert store.find_social_account_by_id(str(account_id)) is not None
+    assert store.find_social_account_by_id("abc") is None
+
+
+def test_list_social_accounts(store, engine):
+    user_id = _seed_user(engine)
+    _seed_social(engine, user_id=user_id, provider_user_id="a")
+    _seed_social(engine, user_id=user_id, provider_user_id="b")
+
+    accounts = store.list_social_accounts(user_id=user_id)
+
+    assert len(accounts) == 2
+
+
+def test_create_social_account(store, engine):
+    user_id = _seed_user(engine)
+
+    account = store.create_social_account(
+        user_id=user_id,
+        provider="google",
+        provider_user_id="g-1",
+        access_token="at",
+        refresh_token="rt",
+        access_token_expires_at=None,
+        refresh_token_expires_at=None,
+        scope="email",
+        user_info={"foo": "bar"},
+        provider_email="g@example.com",
+        provider_email_verified=True,
+        is_login_method=True,
+    )
+
+    assert account.id is not None
+    assert account.provider == "google"
+    assert account.access_token == "at"
+    assert store.find_social_account_by_id(account.id) is not None
+
+
+def test_social_account_token_expiry_roundtrips_aware(store, engine):
+    user_id = _seed_user(engine)
+    expires = NOW + timedelta(hours=1)
+
+    account = store.create_social_account(
+        user_id=user_id,
+        provider="google",
+        provider_user_id="g-1",
+        access_token="at",
+        refresh_token=None,
+        access_token_expires_at=expires,
+        refresh_token_expires_at=None,
+        scope=None,
+        user_info={},
+        provider_email=None,
+        provider_email_verified=None,
+        is_login_method=True,
+    )
+
+    fetched = store.find_social_account_by_id(account.id)
+    # Stored as UTC and read back timezone-aware, so the core can compare it
+    # against aware "now" values without a TypeError.
+    assert fetched.access_token_expires_at == expires
+    assert fetched.access_token_expires_at.tzinfo is not None
+
+
+def test_update_social_account(store, engine):
+    user_id = _seed_user(engine)
+    account_id = _seed_social(engine, user_id=user_id, access_token="old")
+
+    updated = store.update_social_account(
+        account_id,
+        access_token="new",
+        refresh_token="rt2",
+        access_token_expires_at=None,
+        refresh_token_expires_at=None,
+        scope="profile",
+        user_info={},
+        provider_email="new@example.com",
+        provider_email_verified=False,
+    )
+
+    assert updated.access_token == "new"
+    assert updated.scope == "profile"
+
+    # Re-read through a fresh session: the rotated token must have been
+    # committed, not just applied to the in-memory row update_social_account
+    # returned.
+    persisted = store.find_social_account_by_id(account_id)
+    assert persisted is not None
+    assert persisted.access_token == "new"
+    assert persisted.scope == "profile"
+
+
+def test_update_missing_social_account_raises(store):
+    with pytest.raises(ValueError):
+        store.update_social_account(
+            99999,
+            access_token=None,
+            refresh_token=None,
+            access_token_expires_at=None,
+            refresh_token_expires_at=None,
+            scope=None,
+            user_info={},
+            provider_email=None,
+            provider_email_verified=None,
+        )
+
+
+def test_delete_social_account(store, engine):
+    user_id = _seed_user(engine)
+    account_id = _seed_social(engine, user_id=user_id)
+
+    store.delete_social_account(account_id)
+
+    assert store.find_social_account_by_id(account_id) is None
+
+
+def test_delete_missing_social_account_is_noop(store):
+    store.delete_social_account(99999)  # should not raise
+    store.delete_social_account("abc")  # uncastable id: also a no-op
+
+
+def test_filter_hook_applies_to_writes(store, engine):
+    # A scoped store must not update or delete rows its finds would never
+    # return.
+    class GithubOnlyStore(AccountsStore):
+        def filter_social_account_query(self, statement):
+            return statement.where(SocialAccount.provider == "github")
+
+    scoped = GithubOnlyStore(session_factory=lambda: Session(engine))
+    user_id = _seed_user(engine)
+    account_id = _seed_social(engine, user_id=user_id, provider="google")
+
+    scoped.delete_social_account(account_id)  # out of scope: no-op
+    assert store.find_social_account_by_id(account_id) is not None
+
+    with pytest.raises(ValueError):
+        scoped.update_social_account(
+            account_id,
+            access_token=None,
+            refresh_token=None,
+            access_token_expires_at=None,
+            refresh_token_expires_at=None,
+            scope=None,
+            user_info={},
+            provider_email=None,
+            provider_email_verified=None,
+        )
+
+
+def test_create_user_override(store):
+    user = store.create_user(
+        user_info={"hashed_password": "hashed"},
+        email="new@example.com",
+        email_verified=False,
+    )
+
+    assert user.id is not None
+    assert user.email == "new@example.com"
+    assert user.has_usable_password is True
+    assert list(user.social_accounts) == []
+
+
+def test_direct_instantiation_with_default_create_user(engine):
+    # No subclass needed: models go to the constructor and the default
+    # create_user works out of the box.
+    store = SQLModelAccountsStorage(
+        User, SocialAccount, session_factory=lambda: Session(engine)
+    )
+
+    user = store.create_user(
+        user_info={}, email="direct@example.com", email_verified=True
+    )
+
+    assert user.id is not None
+    assert user.email == "direct@example.com"
+    assert list(user.social_accounts) == []
+    assert store.find_user_by_email("direct@example.com") is not None
+
+
+def test_missing_model_declaration_raises_at_construction(engine):
+    with pytest.raises(TypeError, match="UserModel"):
+        SQLModelAccountsStorage(session_factory=lambda: Session(engine))
+
+
+def test_model_missing_required_field_raises_at_construction(engine):
+    class NotAUser:
+        id = None  # declares id but no email
+
+    class BadStore(AccountsStore):
+        UserModel = NotAUser
+
+    with pytest.raises(TypeError, match="email"):
+        BadStore(session_factory=lambda: Session(engine))
+
+
+def test_user_model_missing_protocol_property_raises_at_construction(engine):
+    # Core reads has_usable_password mid-flow (account linking); a model
+    # without it must fail at startup, not during an OAuth login.
+    class BareUser:
+        id = None
+        email = None
+        email_verified = None
+        hashed_password = None
+        social_accounts = None
+
+    class BadStore(AccountsStore):
+        UserModel = BareUser
+
+    with pytest.raises(TypeError, match="has_usable_password"):
+        BadStore(session_factory=lambda: Session(engine))
+
+
+def test_social_account_model_missing_protocol_field_raises_at_construction(engine):
+    class BareSocialAccount:
+        id = None
+        user_id = None
+        provider = None
+        provider_user_id = None
+        # missing provider_email, provider_email_verified, is_login_method
+
+    class BadStore(AccountsStore):
+        SocialAccountModel = BareSocialAccount
+
+    with pytest.raises(TypeError, match="provider_email"):
+        BadStore(session_factory=lambda: Session(engine))
+
+
+def test_missing_token_columns_with_default_builders_raises_at_construction(engine):
+    # SQLModel silently ignores unknown constructor kwargs, so a model missing
+    # the token columns would silently drop OAuth tokens. With the default
+    # payload builders this must fail at startup.
+    class BadStore(AccountsStore):
+        SocialAccountModel = LeanSocialAccount
+
+    with pytest.raises(TypeError, match="access_token"):
+        BadStore(session_factory=lambda: Session(engine))
+
+
+def test_write_field_as_property_raises_at_construction(engine):
+    # `scope` is a read-only property on this model, not a mapped column.
+    # hasattr(model, "scope") is True, but SQLModel's constructor silently
+    # drops it (it only accepts pydantic fields) — construction must fail
+    # instead of quietly losing the OAuth scope on every write.
+    class BadStore(AccountsStore):
+        SocialAccountModel = PropertyScopeSocialAccount
+
+    with pytest.raises(TypeError, match="scope"):
+        BadStore(session_factory=lambda: Session(engine))
+
+
+def test_tokenless_model_works_with_overridden_builders(engine):
+    store = LeanAccountsStore(session_factory=lambda: Session(engine))
+    user_id = _seed_user(engine)
+
+    account = store.create_social_account(
+        user_id=user_id,
+        provider="google",
+        provider_user_id="g-1",
+        access_token="secret",
+        refresh_token=None,
+        access_token_expires_at=None,
+        refresh_token_expires_at=None,
+        scope="email",
+        user_info={},
+        provider_email="a@example.com",
+        provider_email_verified=True,
+        is_login_method=True,
+    )
+
+    assert account.provider == "google"
+    assert account.provider_email == "a@example.com"
+    assert getattr(account, "access_token", None) is None
+
+    updated = store.update_social_account(
+        account.id,
+        access_token="rotated",
+        refresh_token=None,
+        access_token_expires_at=None,
+        refresh_token_expires_at=None,
+        scope="email",
+        user_info={},
+        provider_email="b@example.com",
+        provider_email_verified=True,
+    )
+
+    assert updated.provider_email == "b@example.com"
+
+
+def test_payload_builder_typo_raises_at_write(engine):
+    class TypoStore(AccountsStore):
+        def build_social_account_create_values(self, *, user_info, **fields):
+            fields["acess_token"] = fields.pop("access_token")
+            return fields
+
+    store = TypoStore(session_factory=lambda: Session(engine))
+    user_id = _seed_user(engine)
+
+    with pytest.raises(TypeError, match="acess_token"):
+        store.create_social_account(
+            user_id=user_id,
+            provider="google",
+            provider_user_id="g-1",
+            access_token="secret",
+            refresh_token=None,
+            access_token_expires_at=None,
+            refresh_token_expires_at=None,
+            scope=None,
+            user_info={},
+            provider_email=None,
+            provider_email_verified=None,
+            is_login_method=True,
+        )
+
+
+def test_payload_builder_hook(engine):
+    class CustomStore(AccountsStore):
+        def build_social_account_create_values(self, *, user_info, **fields):
+            fields["scope"] = f"derived:{user_info.get('login')}"
+            return fields
+
+    store = CustomStore(session_factory=lambda: Session(engine))
+    user_id = _seed_user(engine)
+
+    account = store.create_social_account(
+        user_id=user_id,
+        provider="google",
+        provider_user_id="g-1",
+        access_token=None,
+        refresh_token=None,
+        access_token_expires_at=None,
+        refresh_token_expires_at=None,
+        scope="ignored",
+        user_info={"login": "octocat"},
+        provider_email=None,
+        provider_email_verified=None,
+        is_login_method=True,
+    )
+
+    assert account.scope == "derived:octocat"
+
+
+def test_update_payload_builder_hook(engine):
+    class CustomStore(AccountsStore):
+        def build_social_account_update_values(self, *, user_info, record, **fields):
+            fields["scope"] = f"derived:{user_info.get('login')}"
+            return fields
+
+    store = CustomStore(session_factory=lambda: Session(engine))
+    user_id = _seed_user(engine)
+    account_id = _seed_social(engine, user_id=user_id, access_token="old")
+
+    updated = store.update_social_account(
+        account_id,
+        access_token="new",
+        refresh_token=None,
+        access_token_expires_at=None,
+        refresh_token_expires_at=None,
+        scope="ignored",
+        user_info={"login": "octocat"},
+        provider_email=None,
+        provider_email_verified=None,
+    )
+
+    assert updated.scope == "derived:octocat"
+    assert updated.access_token == "new"
+
+
+def test_update_payload_builder_receives_the_existing_record(engine):
+    # The cloud case: provider_username is recomputed on update from the
+    # row's provider and provider_user_id, which are not among the update
+    # fields — the hook must be able to read them from the loaded record.
+    class CustomStore(AccountsStore):
+        def build_social_account_update_values(self, *, user_info, record, **fields):
+            fields["scope"] = f"{record.provider}:{record.provider_user_id}"
+            return fields
+
+    store = CustomStore(session_factory=lambda: Session(engine))
+    user_id = _seed_user(engine)
+    account_id = _seed_social(
+        engine, user_id=user_id, provider="github", provider_user_id="g-7"
+    )
+
+    updated = store.update_social_account(
+        account_id,
+        access_token=None,
+        refresh_token=None,
+        access_token_expires_at=None,
+        refresh_token_expires_at=None,
+        scope=None,
+        user_info={},
+        provider_email=None,
+        provider_email_verified=None,
+    )
+
+    assert updated.scope == "github:g-7"

--- a/tests/storage/test_sqlmodel_internals.py
+++ b/tests/storage/test_sqlmodel_internals.py
@@ -1,0 +1,89 @@
+"""Unit tests for the column-resolution helpers.
+
+These guard the rule that columns are resolved by their Python attribute name,
+not their database column name — the two diverge when a model renames a column,
+and getting it wrong silently reintroduces the timezone shift and id-coercion
+that the adapter exists to prevent.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+from cross_auth.storage.sqlmodel import _NO_MATCH, _bind_datetime, _coerce_id, _column
+
+from .models import (
+    RenamedColumnSession,
+    TzAwareUserSession,
+    UserSession,
+    UuidUserSession,
+)
+
+AWARE = datetime(2026, 6, 6, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_column_resolves_renamed_column_by_attribute():
+    column = _column(RenamedColumnSession, "created_at")
+
+    assert column is not None
+    assert column.name == "created_ts"  # the database name differs
+
+
+def test_column_returns_none_for_non_column_attribute():
+    assert _column(UserSession, "status") is None  # a plain property
+    assert _column(UserSession, "does_not_exist") is None
+
+
+def test_bind_datetime_strips_tz_for_naive_column():
+    bound = _bind_datetime(UserSession, "created_at", AWARE)
+
+    assert bound is not None
+    assert bound.tzinfo is None
+
+
+def test_bind_datetime_keeps_tz_for_aware_column():
+    bound = _bind_datetime(TzAwareUserSession, "created_at", AWARE)
+
+    assert bound is not None
+    assert bound.tzinfo is not None
+
+
+def test_bind_datetime_strips_tz_for_renamed_naive_column():
+    # Regression: a renamed naive column must still be detected as naive and
+    # have its tzinfo stripped, otherwise PostgreSQL shifts the stored instant.
+    bound = _bind_datetime(RenamedColumnSession, "created_at", AWARE)
+
+    assert bound is not None
+    assert bound.tzinfo is None
+
+
+def test_coerce_id_coerces_string_for_renamed_int_pk():
+    # Regression: the renamed integer primary key must still be coerced from a
+    # string, and an uncoercible value must map to _NO_MATCH (not pass through).
+    assert _coerce_id(RenamedColumnSession, "id", "5") == 5
+    assert _coerce_id(RenamedColumnSession, "id", "abc") is _NO_MATCH
+
+
+def test_coerce_id_rejects_uuid_against_int_pk():
+    # A uuid.UUID id (e.g. decoded from a crafted pagination cursor) against
+    # an int column would otherwise reach the database as `integer < uuid`,
+    # raising ProgrammingError on PostgreSQL.
+    assert _coerce_id(UserSession, "id", uuid.uuid4()) is _NO_MATCH
+
+
+def test_coerce_id_rejects_int_against_uuid_pk():
+    # An int id against a UUID column would otherwise reach the database as
+    # `uuid < integer`, raising ProgrammingError on PostgreSQL.
+    assert _coerce_id(UuidUserSession, "id", 5) is _NO_MATCH
+
+
+def test_coerce_id_rejects_out_of_range_int():
+    # Passed through, these raise DataError (PostgreSQL int4) or
+    # OverflowError (SQLite) at the driver instead of matching no row.
+    assert _coerce_id(UserSession, "id", 2**31) is _NO_MATCH
+    assert _coerce_id(UserSession, "id", 10**100) is _NO_MATCH
+    assert _coerce_id(UserSession, "id", "99999999999") is _NO_MATCH
+
+
+def test_coerce_id_passes_through_in_range_int():
+    assert _coerce_id(UserSession, "id", 2**31 - 1) == 2**31 - 1
+    assert _coerce_id(UserSession, "id", -(2**31)) == -(2**31)

--- a/tests/storage/test_sqlmodel_session.py
+++ b/tests/storage/test_sqlmodel_session.py
@@ -1,0 +1,640 @@
+import base64
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+
+import pytest
+import time_machine
+from sqlmodel import Session
+
+from cross_auth._session import create_session, get_session
+from cross_auth._storage import SessionStorage
+from cross_auth.storage import InvalidCursorError
+from cross_auth.storage.sqlmodel import SQLModelSessionStorage
+
+from .models import (
+    IntUserIdSessionStore,
+    RenamedColumnSessionStore,
+    SessionStore,
+    TzAwareSessionStore,
+    UserSession,
+    UuidSessionStore,
+)
+
+NOW = datetime(2026, 6, 6, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def store(engine):
+    return SessionStore(session_factory=lambda: Session(engine))
+
+
+def _make(
+    store,
+    *,
+    token_hash="hash",
+    user_id="u1",
+    created=NOW,
+    updated=NOW,
+    expires=None,
+):
+    return store.create(
+        token_hash=token_hash,
+        user_id=user_id,
+        created_at=created,
+        updated_at=updated,
+        expires_at=expires or (NOW + timedelta(days=1)),
+    )
+
+
+@time_machine.travel(NOW)
+def test_create_returns_usable_record(store):
+    record = _make(store, token_hash="abc")
+
+    # Readable after the session has closed (no DetachedInstanceError).
+    assert record.id is not None
+    assert record.token_hash == "abc"
+    assert record.user_id == "u1"
+    assert record.status == "active"
+
+
+def test_get_active_by_token_hash(store):
+    _make(store, token_hash="abc")
+
+    record = store.get(token_hash="abc", now=NOW)
+
+    assert record is not None
+    assert record.token_hash == "abc"
+
+
+def test_get_session_with_sliding_refresh_handles_naive_db_datetimes(store):
+    session_storage = cast(SessionStorage, store)
+    token, _ = create_session("u1", session_storage)
+
+    session = get_session(token, session_storage, {"update_age": 0})
+
+    assert session is not None
+    assert session.updated_at.tzinfo is not None
+
+
+def test_get_does_not_return_expired(store):
+    _make(store, token_hash="abc", expires=NOW - timedelta(seconds=1))
+
+    assert store.get(token_hash="abc", now=NOW) is None
+
+
+def test_get_active_at_exact_expiry_instant(store):
+    # Matches cross_auth.session_status: active up to and including expiry.
+    _make(store, token_hash="abc", expires=NOW)
+
+    assert store.get(token_hash="abc", now=NOW) is not None
+
+
+def test_get_does_not_return_revoked(store):
+    record = _make(store, token_hash="abc")
+    store.revoke(record.id, revoked_at=NOW)
+
+    assert store.get(token_hash="abc", now=NOW) is None
+
+
+def test_get_missing_returns_none(store):
+    assert store.get(token_hash="nope", now=NOW) is None
+
+
+def test_get_any_returns_regardless_of_status(store):
+    record = _make(store, token_hash="abc", expires=NOW - timedelta(days=1))
+    store.revoke(record.id, revoked_at=NOW)
+
+    fetched = store.get_any(record.id)
+
+    assert fetched is not None
+    assert fetched.id == record.id
+
+
+def test_get_any_missing_returns_none(store):
+    assert store.get_any(99999) is None
+
+
+def test_get_any_coerces_string_ids(store):
+    # Ids arrive as strings from HTTP path params; they must match the int
+    # primary key instead of raising a database error (Postgres) or silently
+    # matching nothing.
+    record = _make(store)
+
+    assert store.get_any(str(record.id)) is not None
+    assert store.get_any("abc") is None
+
+
+def test_get_any_out_of_range_id_returns_none(store):
+    # An id outside the int column's representable range must answer None
+    # rather than raising DataError (PostgreSQL) or OverflowError (SQLite).
+    assert store.get_any(10**100) is None
+    assert store.get_any("99999999999") is None
+
+
+def test_refresh_updates_timestamps(store):
+    record = _make(store)
+    new_updated = NOW + timedelta(hours=1)
+    new_expires = NOW + timedelta(days=2)
+
+    refreshed = store.refresh(
+        record.id,
+        updated_at=new_updated,
+        expires_at=new_expires,
+        last_active_at=new_updated,
+    )
+
+    assert refreshed is not None
+    assert refreshed.updated_at == new_updated
+    assert refreshed.expires_at == new_expires
+
+    # Re-read through a fresh session: the update must have been committed,
+    # not just applied to the in-memory instance refresh() returned.
+    persisted = store.get_any(record.id)
+    assert persisted is not None
+    assert persisted.updated_at == new_updated
+    assert persisted.expires_at == new_expires
+    assert persisted.last_active_at == new_updated
+
+
+def test_refresh_preserves_last_active_at_when_omitted(store):
+    record = store.create(
+        token_hash="hash",
+        user_id="u1",
+        created_at=NOW,
+        updated_at=NOW,
+        expires_at=NOW + timedelta(days=1),
+        last_active_at=NOW,
+    )
+
+    refreshed = store.refresh(
+        record.id,
+        updated_at=NOW + timedelta(hours=1),
+        expires_at=NOW + timedelta(days=2),
+    )
+
+    assert refreshed is not None
+    assert refreshed.last_active_at == NOW
+
+
+def test_refresh_missing_returns_none(store):
+    assert store.refresh(99999, updated_at=NOW, expires_at=NOW) is None
+
+
+def test_revoke_one(store):
+    record = _make(store)
+
+    store.revoke(record.id, revoked_at=NOW)
+
+    assert store.get_any(record.id).revoked_at is not None
+
+
+def test_revoke_missing_is_noop(store):
+    store.revoke(99999, revoked_at=NOW)  # should not raise
+    store.revoke("abc", revoked_at=NOW)  # uncastable id: also a no-op
+
+
+def test_revoke_twice_preserves_original_timestamp(store):
+    record = _make(store)
+
+    store.revoke(record.id, revoked_at=NOW)
+    store.revoke(record.id, revoked_at=NOW + timedelta(hours=1))
+
+    assert store.get_any(record.id).revoked_at == NOW
+
+
+def test_revoke_all_for_user(store):
+    affected = _make(store, token_hash="a", user_id="u1")
+    _make(store, token_hash="b", user_id="u1")
+    _make(store, token_hash="c", user_id="u2")
+
+    count = store.revoke_all_for_user("u1", revoked_at=NOW)
+
+    assert count == 2
+    assert store.get(token_hash="c", now=NOW) is not None
+    # Re-read through a fresh session: the revocation must have been
+    # committed, not just applied to the row objects the update touched.
+    assert store.get_any(affected.id).revoked_at is not None
+
+
+def test_revoke_all_except_one(store):
+    keep = _make(store, token_hash="a", user_id="u1")
+    _make(store, token_hash="b", user_id="u1")
+
+    count = store.revoke_all_for_user("u1", revoked_at=NOW, except_session_id=keep.id)
+
+    assert count == 1
+    assert store.get_any(keep.id).revoked_at is None
+
+
+def test_revoke_all_only_counts_active(store):
+    record = _make(store, token_hash="a", user_id="u1")
+    store.revoke(record.id, revoked_at=NOW)
+
+    count = store.revoke_all_for_user("u1", revoked_at=NOW + timedelta(hours=1))
+
+    assert count == 0
+
+
+def test_list_by_status(store):
+    active = _make(store, token_hash="a", user_id="u1")
+    _make(store, token_hash="b", user_id="u1", expires=NOW - timedelta(days=1))
+    revoked = _make(store, token_hash="c", user_id="u1")
+    store.revoke(revoked.id, revoked_at=NOW)
+
+    result = store.list_for_user("u1", now=NOW, status="active")
+
+    ids = [r.id for r in result.records]
+    assert ids == [active.id]
+
+
+def test_list_ordering_created_at_asc(store):
+    first = _make(store, token_hash="a", user_id="u1", created=NOW)
+    second = _make(
+        store, token_hash="b", user_id="u1", created=NOW + timedelta(hours=1)
+    )
+
+    result = store.list_for_user("u1", now=NOW, order_by="created_at_asc")
+
+    assert [r.id for r in result.records] == [first.id, second.id]
+
+
+@pytest.mark.parametrize(
+    ("order_by", "expected"),
+    [
+        ("updated_at_desc", ["a", "b", "c"]),
+        ("updated_at_asc", ["c", "b", "a"]),
+        ("created_at_desc", ["c", "b", "a"]),
+        ("created_at_asc", ["a", "b", "c"]),
+        ("expires_at_desc", ["c", "a", "b"]),
+        ("expires_at_asc", ["b", "a", "c"]),
+    ],
+)
+def test_list_ordering_supported_values(store, order_by, expected):
+    _make(
+        store,
+        token_hash="a",
+        user_id="u1",
+        created=NOW,
+        updated=NOW + timedelta(minutes=2),
+        expires=NOW + timedelta(days=20),
+    )
+    _make(
+        store,
+        token_hash="b",
+        user_id="u1",
+        created=NOW + timedelta(minutes=1),
+        updated=NOW + timedelta(minutes=1),
+        expires=NOW + timedelta(days=10),
+    )
+    _make(
+        store,
+        token_hash="c",
+        user_id="u1",
+        created=NOW + timedelta(minutes=2),
+        updated=NOW,
+        expires=NOW + timedelta(days=30),
+    )
+
+    result = store.list_for_user("u1", now=NOW, order_by=order_by)
+
+    assert [r.token_hash for r in result.records] == expected
+
+
+def test_list_rejects_non_positive_limit(store):
+    with pytest.raises(ValueError):
+        store.list_for_user("u1", now=NOW, limit=0)
+
+
+def test_pagination_with_cursor(store):
+    for i in range(5):
+        _make(
+            store,
+            token_hash=f"t{i}",
+            user_id="u1",
+            updated=NOW + timedelta(minutes=i),
+        )
+
+    page1 = store.list_for_user("u1", now=NOW, order_by="updated_at_desc", limit=2)
+    assert len(page1.records) == 2
+    assert page1.next_cursor is not None
+
+    page2 = store.list_for_user(
+        "u1", now=NOW, order_by="updated_at_desc", limit=2, cursor=page1.next_cursor
+    )
+    assert len(page2.records) == 2
+
+    seen = [r.token_hash for r in page1.records + page2.records]
+    assert seen == ["t4", "t3", "t2", "t1"]
+    assert page1.records[-1].token_hash != page2.records[0].token_hash
+
+
+def test_pagination_breaks_ties_with_id(store):
+    # All share the same updated_at; only the id tiebreaker separates them.
+    ids = [
+        _make(store, token_hash=f"t{i}", user_id="u1", updated=NOW).id for i in range(5)
+    ]
+
+    collected = []
+    cursor = None
+    for _ in range(3):
+        page = store.list_for_user(
+            "u1", now=NOW, order_by="updated_at_desc", limit=2, cursor=cursor
+        )
+        collected.extend(r.id for r in page.records)
+        cursor = page.next_cursor
+        if cursor is None:
+            break
+
+    assert sorted(collected) == sorted(ids)
+    assert len(collected) == len(set(collected))  # no duplicates across pages
+
+
+def test_pagination_supports_uuid_primary_keys(engine):
+    store = UuidSessionStore(session_factory=lambda: Session(engine))
+    for i in range(3):
+        store.create(
+            token_hash=f"t{i}",
+            user_id="u1",
+            created_at=NOW,
+            updated_at=NOW + timedelta(minutes=i),
+            expires_at=NOW + timedelta(days=1),
+        )
+
+    page1 = store.list_for_user("u1", now=NOW, limit=2)
+    page2 = store.list_for_user("u1", now=NOW, limit=2, cursor=page1.next_cursor)
+
+    assert page1.next_cursor is not None
+    assert [record.token_hash for record in page1.records + page2.records] == [
+        "t2",
+        "t1",
+        "t0",
+    ]
+
+
+def test_invalid_cursor_raises(store):
+    _make(store, user_id="u1")
+
+    with pytest.raises(ValueError):
+        store.list_for_user("u1", now=NOW, cursor="not-a-valid-cursor")
+
+
+def test_cursor_is_bound_to_its_order_by(store):
+    for i in range(3):
+        _make(
+            store,
+            token_hash=f"t{i}",
+            user_id="u1",
+            updated=NOW + timedelta(minutes=i),
+        )
+    page1 = store.list_for_user("u1", now=NOW, order_by="updated_at_desc", limit=2)
+
+    with pytest.raises(InvalidCursorError):
+        store.list_for_user(
+            "u1", now=NOW, order_by="created_at_asc", cursor=page1.next_cursor
+        )
+
+
+def test_crafted_cursor_id_raises_invalid_cursor(store):
+    _make(store, user_id="u1")
+    crafted = base64.urlsafe_b64encode(
+        json.dumps(
+            {"o": "updated_at_desc", "v": NOW.isoformat(), "id": {"x": 1}}
+        ).encode()
+    ).decode()
+
+    with pytest.raises(InvalidCursorError):
+        store.list_for_user("u1", now=NOW, cursor=crafted)
+
+
+def test_cursor_id_type_mismatch_raises_invalid_cursor(store):
+    _make(store, user_id="u1")
+    crafted = base64.urlsafe_b64encode(
+        json.dumps(
+            {"o": "updated_at_desc", "v": NOW.isoformat(), "id": "not-an-int"}
+        ).encode()
+    ).decode()
+
+    with pytest.raises(InvalidCursorError):
+        store.list_for_user("u1", now=NOW, cursor=crafted)
+
+
+def test_crafted_cursor_uuid_id_against_int_pk_raises_invalid_cursor(store):
+    # A uuid-shaped id (as decoded from a cursor built for a UUID pk) sent
+    # against this store's int pk must not reach the database as
+    # `integer < uuid` — it should be treated as a plain invalid cursor.
+    _make(store, user_id="u1")
+    crafted = base64.urlsafe_b64encode(
+        json.dumps(
+            {
+                "o": "updated_at_desc",
+                "v": NOW.isoformat(),
+                "id": {"t": "uuid", "v": str(uuid.uuid4())},
+            }
+        ).encode()
+    ).decode()
+
+    with pytest.raises(InvalidCursorError):
+        store.list_for_user("u1", now=NOW, cursor=crafted)
+
+
+def test_crafted_cursor_int_id_against_uuid_pk_raises_invalid_cursor(engine):
+    # The reverse mismatch: a plain int id sent against a UUID pk must not
+    # reach the database as `uuid < integer`.
+    store = UuidSessionStore(session_factory=lambda: Session(engine))
+    store.create(
+        token_hash="abc",
+        user_id="u1",
+        created_at=NOW,
+        updated_at=NOW,
+        expires_at=NOW + timedelta(days=1),
+    )
+    crafted = base64.urlsafe_b64encode(
+        json.dumps({"o": "updated_at_desc", "v": NOW.isoformat(), "id": 1}).encode()
+    ).decode()
+
+    with pytest.raises(InvalidCursorError):
+        store.list_for_user("u1", now=NOW, cursor=crafted)
+
+
+def test_crafted_cursor_out_of_range_id_raises_invalid_cursor(store):
+    _make(store, user_id="u1")
+    crafted = base64.urlsafe_b64encode(
+        json.dumps(
+            {"o": "updated_at_desc", "v": NOW.isoformat(), "id": 10**100}
+        ).encode()
+    ).decode()
+
+    with pytest.raises(InvalidCursorError):
+        store.list_for_user("u1", now=NOW, cursor=crafted)
+
+
+def test_crafted_cursor_deeply_nested_payload_raises_invalid_cursor(store):
+    # A deeply nested JSON payload makes json.loads raise RecursionError on
+    # some Python versions instead of a clean parse failure; the oversized
+    # cursor must be rejected before decoding is even attempted.
+    _make(store, user_id="u1")
+    crafted = base64.urlsafe_b64encode(("[" * 1500).encode()).decode()
+
+    with pytest.raises(InvalidCursorError):
+        store.list_for_user("u1", now=NOW, cursor=crafted)
+
+
+def test_model_passed_to_constructor(engine):
+    # No subclass needed: the model can be given directly to the constructor.
+    store = SQLModelSessionStorage(UserSession, session_factory=lambda: Session(engine))
+
+    record = store.create(
+        token_hash="abc",
+        user_id="u1",
+        created_at=NOW,
+        updated_at=NOW,
+        expires_at=NOW + timedelta(days=1),
+    )
+
+    assert record.id is not None
+    assert store.get(token_hash="abc", now=NOW) is not None
+
+
+def test_missing_session_model_raises_at_construction(engine):
+    class NoModel(SQLModelSessionStorage):
+        pass
+
+    with pytest.raises(TypeError, match="SessionModel"):
+        NoModel(session_factory=lambda: Session(engine))
+
+
+def test_constructor_without_model_mentions_both_options(engine):
+    with pytest.raises(TypeError, match="pass it to the constructor"):
+        SQLModelSessionStorage(session_factory=lambda: Session(engine))
+
+
+def test_model_missing_required_field_raises_at_construction(engine):
+    class NotASession:
+        id = None  # declares id but none of the other session columns
+
+    class BadStore(SQLModelSessionStorage):
+        SessionModel = NotASession
+
+    with pytest.raises(TypeError, match="token_hash"):
+        BadStore(session_factory=lambda: Session(engine))
+
+
+def test_model_missing_status_property_raises_at_construction(engine):
+    # `status` is part of the SessionRecord protocol even though the adapter
+    # never reads it; a model without it must fail at startup, not when a
+    # session listing is first serialized.
+    class NoStatusSession:
+        id = None
+        token_hash = None
+        user_id = None
+        created_at = None
+        updated_at = None
+        expires_at = None
+        last_active_at = None
+        revoked_at = None
+        client_id = None
+        client_name = None
+        user_agent = None
+        ip = None
+
+    class BadStore(SQLModelSessionStorage):
+        SessionModel = NoStatusSession
+
+    with pytest.raises(TypeError, match="status"):
+        BadStore(session_factory=lambda: Session(engine))
+
+
+def test_string_user_ids_coerced_to_int_column(engine):
+    # Cross-Auth passes user ids to the session layer as strings; an integer
+    # user_id column (e.g. a foreign key to an int user PK) must still work
+    # across create, list, and revoke.
+    store = IntUserIdSessionStore(session_factory=lambda: Session(engine))
+    record = store.create(
+        token_hash="abc",
+        user_id="7",
+        created_at=NOW,
+        updated_at=NOW,
+        expires_at=NOW + timedelta(days=1),
+    )
+
+    assert record.user_id == 7
+
+    listed = store.list_for_user("7", now=NOW)
+    assert [r.id for r in listed.records] == [record.id]
+
+    assert store.revoke_all_for_user("7", revoked_at=NOW) == 1
+
+
+def test_non_callable_session_factory_raises():
+    with pytest.raises(TypeError, match="session_factory"):
+        SessionStore(session_factory=cast(Any, None))
+
+
+def test_list_status_filter_at_exact_expiry_boundary(store):
+    # Matches cross_auth.session_status: active up to and including expiry, so a
+    # session expiring exactly at `now` is active, not expired.
+    boundary = _make(store, token_hash="boundary", user_id="u1", expires=NOW)
+    expired = _make(
+        store, token_hash="expired", user_id="u1", expires=NOW - timedelta(seconds=1)
+    )
+
+    active = [r.id for r in store.list_for_user("u1", now=NOW, status="active").records]
+    gone = [r.id for r in store.list_for_user("u1", now=NOW, status="expired").records]
+
+    assert boundary.id in active and boundary.id not in gone
+    assert expired.id in gone and expired.id not in active
+
+
+def test_renamed_columns_full_lifecycle(engine):
+    # Every operation must work when the model maps its attributes to differently
+    # named database columns — columns are resolved by attribute, not DB name.
+    store = RenamedColumnSessionStore(session_factory=lambda: Session(engine))
+    record = store.create(
+        token_hash="rt",
+        user_id="u1",
+        created_at=NOW,
+        updated_at=NOW,
+        expires_at=NOW + timedelta(days=1),
+        last_active_at=NOW,
+    )
+
+    assert record.id is not None
+    assert record.created_at == NOW
+    assert store.get(token_hash="rt", now=NOW) is not None
+    assert store.get_any(record.id) is not None
+    assert store.get_any(str(record.id)) is not None  # _coerce_id on the renamed pk
+    assert [r.id for r in store.list_for_user("u1", now=NOW).records] == [record.id]
+
+    refreshed = store.refresh(
+        record.id,
+        updated_at=NOW + timedelta(hours=1),
+        expires_at=NOW + timedelta(days=2),
+    )
+    assert refreshed is not None and refreshed.updated_at == NOW + timedelta(hours=1)
+
+    store.revoke(record.id, revoked_at=NOW)
+    assert store.get(token_hash="rt", now=NOW) is None
+
+
+def test_timezone_aware_columns_round_trip(engine):
+    # The documented timestamptz alternative to naive columns: aware values must
+    # survive the round trip with their tzinfo intact.
+    store = TzAwareSessionStore(session_factory=lambda: Session(engine))
+    expires = NOW + timedelta(days=1)
+    store.create(
+        token_hash="tz",
+        user_id="u1",
+        created_at=NOW,
+        updated_at=NOW,
+        expires_at=expires,
+        last_active_at=NOW,
+    )
+
+    fetched = store.get(token_hash="tz", now=NOW)
+
+    assert fetched is not None
+    assert fetched.created_at == NOW
+    assert fetched.expires_at == expires
+    assert fetched.created_at.tzinfo is not None

--- a/uv.lock
+++ b/uv.lock
@@ -64,6 +64,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -203,6 +212,95 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -350,6 +448,14 @@ dependencies = [
     { name = "pyjwt", extra = ["crypto"] },
 ]
 
+[package.optional-dependencies]
+redis = [
+    { name = "redis" },
+]
+sqlmodel = [
+    { name = "sqlmodel" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
@@ -357,11 +463,15 @@ dev = [
     { name = "httpx" },
     { name = "inline-snapshot" },
     { name = "nox" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "python-multipart" },
+    { name = "redis" },
     { name = "respx" },
+    { name = "sqlmodel" },
     { name = "starlette" },
+    { name = "testcontainers" },
     { name = "time-machine" },
     { name = "ty" },
 ]
@@ -374,7 +484,10 @@ requires-dist = [
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.11.3" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8.0" },
+    { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0" },
+    { name = "sqlmodel", marker = "extra == 'sqlmodel'", specifier = ">=0.0.28" },
 ]
+provides-extras = ["redis", "sqlmodel"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -383,11 +496,15 @@ dev = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "inline-snapshot", specifier = ">=0.20.10" },
     { name = "nox", specifier = ">=2024.10.9" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.1" },
     { name = "pytest", specifier = ">=9.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "python-multipart", specifier = ">=0.0.20" },
+    { name = "redis", specifier = ">=5.0" },
     { name = "respx", specifier = ">=0.22.0" },
+    { name = "sqlmodel", specifier = ">=0.0.28" },
     { name = "starlette", specifier = ">=0.46.1" },
+    { name = "testcontainers", specifier = ">=4.8" },
     { name = "time-machine", specifier = ">=2.16.0" },
     { name = "ty", specifier = ">=0.0.29" },
 ]
@@ -570,6 +687,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
 
 [[package]]
@@ -770,6 +901,69 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/6e/802acd792aebb2256fbbee8cacf2727faaeb6f240ac11008f09eae4414bc/greenlet-3.5.1.tar.gz", hash = "sha256:5a56aeb7d5d9cc4b3a735efb5095bd4b4f6f0e4f93e5ca876d0e2315137b7829", size = 197356, upload-time = "2026-05-20T15:05:03.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/3c/ff890b466eaba2b0f5e6bdfff025f8c75f41b8ffdc3dbc3d24ad261e764a/greenlet-3.5.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:73f78f9b9f0a5c06e5c946ba1e8e36f5114923b6be109ee618c54f079c3ea14f", size = 284764, upload-time = "2026-05-20T13:09:10.204Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0e/5e5457be3d256918f6a4756f073548a3f0190836e2cc94aa6d0d617a940b/greenlet-3.5.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a0cbed8bb44e23c5b199f888f4e4ce096b45ad9f25ff74a7ad0213875e936bb2", size = 603479, upload-time = "2026-05-20T14:00:04.757Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e1/f89a21d58d308298e6f275f13a1b472ed96c680b601a371b08be6a725989/greenlet-3.5.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a203a8bd0acb0701653d3bbb26e404854a68674139ed5cbb778830f42b09bb33", size = 615495, upload-time = "2026-05-20T14:05:40.87Z" },
+    { url = "https://files.pythonhosted.org/packages/75/de/af6cef182862d2ccd6975440d21c9058a77c3f9b469abf94e322dfd2e0e3/greenlet-3.5.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a271fcd66c74615cda6a964fda3f304267a12e50a084472218a39bb0376f563", size = 614754, upload-time = "2026-05-20T13:14:24.947Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c6/50e520283a9f19388a7326b05f9e8637e566003475eacaadad04f558c68d/greenlet-3.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ded7b068c7c31c1a8657d4fd42d886b3e051ae29f88b80c5ff9d502257b0f071", size = 1574097, upload-time = "2026-05-20T14:02:24.003Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1c/13abd1f4860d987fa5e1170a01930d6e6cd40d328de487a3c9fdaff0ffd0/greenlet-3.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d0932b81d72f552ded9d810d00021b64d89f2195a91ce115b893f943b7a4ab3c", size = 1641058, upload-time = "2026-05-20T13:14:31.83Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/56/5f332b7705545eac2dc01b4e9254d24a793f2656d55d5cc6b94ee59d22ae/greenlet-3.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:88e300d136eac057b2397aa1cfd7328b4c87c7eb66a09c7bc6a1292234db474e", size = 238089, upload-time = "2026-05-20T13:14:03.229Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a9/a3c2fa886c5b94863fb0e61b3bc14610b7aa94cf4f17f8741b11708305fc/greenlet-3.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:cc6ab7e555c8a112ad3a76e368e86e12a2754bcae1652a5602e133ec7b635523", size = 234989, upload-time = "2026-05-20T13:08:27.715Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
+    { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
+    { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f5/310d104ddf41eb5a70f4c268d22508dfb0c3c8e86fec152be34d0d2ed819/greenlet-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b", size = 238791, upload-time = "2026-05-20T13:10:39.018Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/ceca11f504cd23a8047a3dea31919adc48df9b626dd0c13f0d858734fdfd/greenlet-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:80eb4b04dadc4e67df3fae179a32c4706a3f495bc7f22fc8a81115d5f5512188", size = 235580, upload-time = "2026-05-20T13:08:45.056Z" },
+    { url = "https://files.pythonhosted.org/packages/27/69/7f7e5372d998b81001899b1c0823c957aa413ba0f2662e65821611cc31e4/greenlet-3.5.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:51518ff74664078fc51bffcc6fc529b0df5ae58da192691cee765d45ce944a2b", size = 285060, upload-time = "2026-05-20T13:08:51.899Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/bf/387f9b6b865fd2ae0d0be09e0004827295a01b71be76ed350dd1e28a91a4/greenlet-3.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a", size = 604370, upload-time = "2026-05-20T14:00:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f5/169ce3d4e4c67291bd18f8cbe0299c9f3e45102c7f1fb3c14780c93e4532/greenlet-3.5.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283", size = 616987, upload-time = "2026-05-20T14:05:44.237Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e5/7f2e41d5273be07e77560d61ea4e56485b4d6c316d2a84518c62d1364061/greenlet-3.5.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135", size = 613911, upload-time = "2026-05-20T13:14:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a4/fbdc67579b73615a1f91615e814303cc71e06128f7baaba87be79b8fb90c/greenlet-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd", size = 1570689, upload-time = "2026-05-20T14:02:27.225Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b4/77abbe35078be39718a46cd49caf16bceb35662f97a34101dca28aa98e47/greenlet-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1", size = 1635602, upload-time = "2026-05-20T13:14:36.344Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f7/129f27ca700845b8ee8ca88ce7f43435a1239c2eddb7677fc938822762cf/greenlet-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:110a1ca7b49b014b097f6078272c3f4ed31af45b254de5228b79adba879f6af9", size = 238683, upload-time = "2026-05-20T13:11:50.57Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/5c/a485a36e87df8d8fd0632ee01511244f5156a20ed3746cc6599340326395/greenlet-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f16ba1efc0715b680a18b8123d90dad887c6112ae3555b4b5c32c149540c6b4e", size = 235499, upload-time = "2026-05-20T13:12:42.028Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cb/c62454606daf5640369c94d8a9dd540599b1bfc090e2d2180cb77f4038d2/greenlet-3.5.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8ab31c9de8651a2facdd5c5bb0011f2380dd1a7af78ce2adf4b56095294fc07", size = 285579, upload-time = "2026-05-20T13:08:56.396Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e300185139abc337ade480c327183adf42a875ac7181bfe66d7d4efea31fbea", size = 651106, upload-time = "2026-05-20T14:00:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ab/71e34b78a44ec271fb5f550c17bc46d301ddc5953890d935f270b0dcdb5a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7ffdb990dcaa0234cf9845aead5df2e3c3a8b6507d409274dd87e0d5ab05ffc2", size = 663478, upload-time = "2026-05-20T14:05:45.88Z" },
+    { url = "https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f82b3597e9d83b63408affed0b48fd0f54935edac4302237b9a837be0dae33c", size = 660800, upload-time = "2026-05-20T13:14:29.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e0/6c71401a25cac7000261304e866a2f2cc04dc74810d40e2f118aa4799495/greenlet-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c0141e37414c10164e702b8fb1473304221ad98f71600850c6ef7ff4880feba0", size = 1617518, upload-time = "2026-05-20T14:02:28.662Z" },
+    { url = "https://files.pythonhosted.org/packages/41/26/c5c06643e8c0af9e7bf18e16cb51d0ab7625155f0392e1c9015d66d556cd/greenlet-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:50ae25a67bea74ea41fb14b960bc532df73eb713417b2d61892dced82fe8d3bc", size = 1681593, upload-time = "2026-05-20T13:14:39.417Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:8a17c42330e261299766b75ac1ea32caa437a9453c8f65d16a13140db378ecd3", size = 239800, upload-time = "2026-05-20T13:09:30.128Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/8e8e8417b7bf28639a5a56356ef934d0375e1d0c70a57e04d7701e870ffe/greenlet-3.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:7b5f5fae05b8ac6d176a61b60c394a8cbdc2b5b91b81793066e68745cf165e54", size = 236862, upload-time = "2026-05-20T13:09:10.498Z" },
+    { url = "https://files.pythonhosted.org/packages/90/12/41bf27fde4d3605d3773ae57751eda182b8be2f5398011c041173b1d9534/greenlet-3.5.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:ea8da1e900d758d078810d4255d8c6aa572181896a31ec79d779eb79c3adc9ad", size = 293637, upload-time = "2026-05-20T13:12:35.529Z" },
+    { url = "https://files.pythonhosted.org/packages/44/44/ba14b23e9757707050c2f397d305bbcae62e5d7cad122f8b6baec5ae4a1f/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a19570c52a21420dcbc94e661994bc325c0b5b11304540fed514586da5dc8f2e", size = 650840, upload-time = "2026-05-20T14:00:11.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/37/5ddc2b686a6844f91abecef43411842426da2e1573f60b49ecf2547f4ae1/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3d955c89b75eeca4723d7cc14135f393cd47c32e2a6cb4a8e4c6e760a26b0986", size = 656416, upload-time = "2026-05-20T14:05:47.118Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f0/d17510297c35a2992712f0bf84de3779749999f7d3d63aa1f09db7c62dbe/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2daaaebd1a5aa88c49045b6baf9310b3263796bd88db713edf37cf53e7bb4e", size = 654397, upload-time = "2026-05-20T13:14:30.696Z" },
+    { url = "https://files.pythonhosted.org/packages/37/eb/147387705bb89092645b012586e7273cb5ed3c90ef7eaf3a69173eaf0209/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bfbd69cc349e43bf3a8ae1c85548ff0718efc887615c2db16c3833d7b0b072d", size = 1614469, upload-time = "2026-05-20T14:02:30.192Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/4e/37ee0da7732b7aa9896f17e15579a9df34b9fcb9dd494f0adfa749af6623/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4378720dd888136c27215a0214d32a4d37c3852765d45bc37aad0623423cfd78", size = 1675115, upload-time = "2026-05-20T13:14:40.972Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f3/97dfcf4a6eb5077f8a672234216fb5923eb89f2cab7081cb10b2cf75b605/greenlet-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:45718441607f9325d948db98cbc691276059316d0358c188c246da4e1d4d23d2", size = 245246, upload-time = "2026-05-20T13:12:22.646Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/73/d7f72e34b582f694f4a9b248162db7b09cc458a259ba8f0c0bfa1a34ea7d/greenlet-3.5.1-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:2baee5ca02031757ffe8cc3d69f0cc0aec7065ce362622da74f32d3bcab1c541", size = 285575, upload-time = "2026-05-20T13:12:07.043Z" },
+    { url = "https://files.pythonhosted.org/packages/df/59/fa9c6e87dc8ad27a95dabe2f29f372b733d05a8a67470f6c901ed9975655/greenlet-3.5.1-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b1ec3274918a81d3ea778b9e75b56b72b33f300edb6cf7f3a7fe1dae56683de", size = 656428, upload-time = "2026-05-20T14:00:12.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f9/e753408871eaa61dfe35e619cfc67512b036fde99893685d50eea9e07146/greenlet-3.5.1-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:111e2390ffffc47d5840b01711dd7fac07d4c09283d0283e7f3264b14e284c64", size = 667064, upload-time = "2026-05-20T14:05:48.662Z" },
+    { url = "https://files.pythonhosted.org/packages/96/27/5565b5b40389f1c7753003a07e21892fda8660926787036d5bc0308b8113/greenlet-3.5.1-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e630136e905fe5ff43e86945ae41220b6d1470956a39220e708110ac48d01ea5", size = 665697, upload-time = "2026-05-20T13:14:32.943Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/82/e7de4178c0c2d1c9a5a3be3cc0b33e46a85b3ee4a77c071bf7ad8600e079/greenlet-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:975eac34b44a7077ca4d421348455b94f0f518246a7f14bc6d2fdcfe5b584368", size = 1621256, upload-time = "2026-05-20T14:02:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/00/10/f2dddcf7dacac17dfc68691809589adad06135eb28930429cf58a6467a2f/greenlet-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9ab3c3a0b2ae6198e67c898dad5215a49f9ae0d0081b3c3ec59f333e39eeca26", size = 1685956, upload-time = "2026-05-20T13:14:42.55Z" },
+    { url = "https://files.pythonhosted.org/packages/22/17/4a232b32133230ada52f70e9d7f5b65b0caef8772f01849bd8d149e7e4ca/greenlet-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:cbfc69be86e10dcfef5b1e6269d1d6926552aa89ee39e1de3353360c1b6989ab", size = 239802, upload-time = "2026-05-20T13:13:15.481Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ae/4e623a7e6d4d2a5f4cb8e4c82de4169fc637942caae68d6e676b8a128ac5/greenlet-3.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:92fd6d44ac5e5a887c8a5dc4a8ba0ba908527c31c12f78c6bc7dcfe8aab279f6", size = 236853, upload-time = "2026-05-20T13:15:37.301Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/57/816d9cff29119da3505b3d6a5e14a8af89006ac36f47f891ff293ee05af1/greenlet-3.5.1-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:a6fdf2433a5441ef9a95464f7c3e674775da1c8c1177fff311cee1acad4626ed", size = 293877, upload-time = "2026-05-20T13:10:19.078Z" },
+    { url = "https://files.pythonhosted.org/packages/23/a1/59b0a7c7d140ff1a75626680b9a9899b79a9176cab298b394968fb023295/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7546556f0d649f99f6a361098a55f761181bb2ea12ff150bb16d26092ad88244", size = 655333, upload-time = "2026-05-20T14:00:14.758Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/5efe127597625042218939d01855109f352779050768b670b52edcc16a6c/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5ee3ea898009fa898f85f9982255d35278c477bebe185beca249cab42d4526c", size = 659443, upload-time = "2026-05-20T14:05:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/6d/c404246ea4d22d097a7426d0efb5b781bd7eb67715f09e79001bd552ab18/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5c81f74d204d3edd136ebfd50dce53acbb776995d721a0fe801626cfc93b8cd", size = 658356, upload-time = "2026-05-20T13:14:35.091Z" },
+    { url = "https://files.pythonhosted.org/packages/51/02/f8ee37fb6d2219329f350af241c27fcf12df57e723d11f6fc6d3bacdadaa/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:2c18ef16bf6d4dd410e4dd52996888ea1497be26892fe5bbc73580aba4287b8e", size = 1619216, upload-time = "2026-05-20T14:02:33.403Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c5/3dc9475ace2c7a3680da12372cddd7f1ac874eb410a1ac48d3e9dab83782/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:17d86354f0ae6b61bf9be5148d0dd34e06c3cb7c602c671f79f29ac3b150e659", size = 1678427, upload-time = "2026-05-20T13:14:43.71Z" },
+    { url = "https://files.pythonhosted.org/packages/df/4e/750c15c317a41ffb36f0bf40b933e3d744a7dede61889f74443ea69690cf/greenlet-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:e7516cf6ae6b8a582c2770a0caed47b8a48373ed732c33d69a72913ae6ac923e", size = 245225, upload-time = "2026-05-20T13:13:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/fd/d3baea2eeb7b617efd47e87ca06e2ec2c6118d303aa9e918e0ce16eadc10/greenlet-3.5.1-cp315-cp315t-win_arm64.whl", hash = "sha256:5028648bf2253ec4745add746129d3904121fa7fe871a76bed23c5720573ce0a", size = 239590, upload-time = "2026-05-20T13:13:37.382Z" },
 ]
 
 [[package]]
@@ -1064,6 +1258,75 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813, upload-time = "2026-05-01T23:26:30.612Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799, upload-time = "2026-05-01T23:26:38.475Z" },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050, upload-time = "2026-05-01T23:26:47.061Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428, upload-time = "2026-05-01T23:26:56.708Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746, upload-time = "2026-05-01T23:27:07.023Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033, upload-time = "2026-05-01T23:27:12.221Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175, upload-time = "2026-05-01T23:27:18.248Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203, upload-time = "2026-05-01T23:27:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509, upload-time = "2026-05-01T23:27:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551, upload-time = "2026-05-01T23:27:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054, upload-time = "2026-05-01T23:27:45.455Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
 name = "pybun"
 version = "1.3.13"
 source = { registry = "https://pypi.org/simple" }
@@ -1317,6 +1580,28 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1369,6 +1654,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -1528,6 +1840,68 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlalchemy"
+version = "2.0.50"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/da/6fbf010c8ebb347679d0d100b22fe9ba5e13fd04046c5df7280d2f0bf706/sqlalchemy-2.0.50.tar.gz", hash = "sha256:af5607d11ef90fd6a5c0549fe0045dce1663d427426bcfb506dcb5346a85a3b9", size = 9907424, upload-time = "2026-05-24T19:20:04.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/5d/3172686af1770e4de2805f919a51441085f589ddadf3dd76ec582f84f497/sqlalchemy-2.0.50-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1aa6e403663a9c43c8fef7ce4bdb4cf48bcd8d352e91deda2a99f963270bd508", size = 2161366, upload-time = "2026-05-24T20:00:02.061Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/90/e98dedea3c3e663a17afcd003a34ba45efdac2cea3b6f2e4585e2b1e2537/sqlalchemy-2.0.50-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51b637a84f9fa35ae1f9017e786cb142974a25305085e1b378b3647a67f65ad3", size = 3318926, upload-time = "2026-05-24T20:07:42.369Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4f/501308c2babb62c11753ecb4ee88ba9eef019419a4d6cbf7cb13e2bad353/sqlalchemy-2.0.50-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2dab927761d9108550f0cf8e66ff21af56f907a0ce0a689793db615e2b55f62c", size = 3319199, upload-time = "2026-05-24T20:14:28.551Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/39/d88996c5e03ed6248c3a788d20f0b8d8b376b9f8a495e4bab9df7c72d2f8/sqlalchemy-2.0.50-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:545eae198d37bcf837a10ede3684e2af32458d6f35c597c35c2de7502dc38fc4", size = 3270301, upload-time = "2026-05-24T20:07:44.917Z" },
+    { url = "https://files.pythonhosted.org/packages/42/1b/1ae0e65161b51cc43e5ca75430ef79d80e23b5042d645586c2c342c3b92e/sqlalchemy-2.0.50-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0fec460e18cdbb4c7773531122ce9a27e96c6ca17af3933941d94da475ad2c86", size = 3293465, upload-time = "2026-05-24T20:14:30.501Z" },
+    { url = "https://files.pythonhosted.org/packages/83/29/17c0003f2c0dfa6d1b97672475707e3ec5980db09defd7fa20beb6833bbd/sqlalchemy-2.0.50-cp311-cp311-win32.whl", hash = "sha256:e6e814658818fd165e749e3d8490ef16cc7f379a118c37ada8b0589ffbaaac22", size = 2120694, upload-time = "2026-05-24T20:08:09.237Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/18/280d00654cc19d1fccf236fa5070f6dd04b84dde6f1b2e637bde0ff340a7/sqlalchemy-2.0.50-cp311-cp311-win_amd64.whl", hash = "sha256:1c5f858fe79c9f5d8fda065c06186356acb7f8df3cd52dbd5ee3f200e4b144f5", size = 2145315, upload-time = "2026-05-24T20:08:10.952Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b0/a9d19b43f38f878b1278bca5b00b909f7540d41494396dd2561f9ad0956d/sqlalchemy-2.0.50-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23ae23d8b9d344d30d0a92f06d45825024a5790f1c1dd4cf452636a50d3e58cb", size = 2159807, upload-time = "2026-05-24T19:27:53.086Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2c/191dd58a248fd2cfd4780fa82c375c505e4ad98c8b522fa69ec492130d77/sqlalchemy-2.0.50-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:47b71b933e7b4ebad407c8fdfd70d2c4f08b78b3238bb30eebdd6eb32ca51b89", size = 3343358, upload-time = "2026-05-24T20:09:29.279Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2b/514fce8a7df81cf5bad7ff7865de7ac0c5776a38cc043475c4703eb7fe8b/sqlalchemy-2.0.50-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:110fdac56ace278949f00de805edacbd6141e382d992f9ba28238b3a0827a600", size = 3357994, upload-time = "2026-05-24T20:17:13.495Z" },
+    { url = "https://files.pythonhosted.org/packages/35/a6/a0e283f5494f92b0d77e319ff77e437b1ffe4a051ba67c81d53234825475/sqlalchemy-2.0.50-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0f5e4ac70e9e757f6b3e87c0491ff034442ecd8dfd36d041a50564c322dafc0e", size = 3289399, upload-time = "2026-05-24T20:09:32.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/96/1b07325ba71752d6a028b77d07bed1483ad545f794e8b1dc89b3ba3b3c68/sqlalchemy-2.0.50-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:724f3dcbe53dd0151e3cb5e7ec4ba4c620bede579caacd16275dc35ce06e8615", size = 3321216, upload-time = "2026-05-24T20:17:15.581Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/8e/bad6ed253e8a99edfc99af02f7173ec48a1d3ed1b9b35a1b8bc1700900cc/sqlalchemy-2.0.50-cp312-cp312-win32.whl", hash = "sha256:1208050441471d003b7c8cb4054fb084f185cf35ac3f0ea270803865bca9939a", size = 2119194, upload-time = "2026-05-24T19:50:04.943Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2d/314a6690dda4b9cfc571eab1a63cf6fe6e1470aa3759ccda6aa016ee0f5a/sqlalchemy-2.0.50-cp312-cp312-win_amd64.whl", hash = "sha256:9d1af51558029a156a70986b7df88f042b3d158d7c8d8fb5072912d4b32d89c7", size = 2146186, upload-time = "2026-05-24T19:50:06.74Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c4/c42356b527296e9862f67990efce31ef78b4cf69cd3f80873a528a060320/sqlalchemy-2.0.50-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:06a9210bdc5f4298cff0781087e2ff45683922252dacc452846373a58761f093", size = 2156697, upload-time = "2026-05-24T19:27:54.764Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a1/b1a70e3c4365ac7fe9e347f3710f19b562c866fb96d45e3c891588789a7b/sqlalchemy-2.0.50-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b53784972ade4f8174b9aa661f31a06f8a936d2cfdd602913ff3c6dd40ae873", size = 3284260, upload-time = "2026-05-24T20:09:34.195Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/4a/f3ac3caa19f263d57b0a47f8c91bbf56583dc2d3fc63acfbf644abb24fe0/sqlalchemy-2.0.50-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31648fa14460537e768a7303b078e4344d208e0d23e06867c1f376a227ed82db", size = 3302280, upload-time = "2026-05-24T20:17:17.825Z" },
+    { url = "https://files.pythonhosted.org/packages/66/55/ccada3e3d62254587819749a0bc69f41173eb48a6e385d10e66d32a9c88e/sqlalchemy-2.0.50-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:03f4323c980ad0e918cc9e5369b015f759f4e534db5bbaf4dc36832c10d05064", size = 3231580, upload-time = "2026-05-24T20:09:36.406Z" },
+    { url = "https://files.pythonhosted.org/packages/05/f6/6809349130a2de0e109e7f00fd7d431da9565b9b2868b32ee684754f672b/sqlalchemy-2.0.50-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2b9dcc43afef8ac157cd92fce96985d6b8b0cfbd3df4d666f66b4d55a75d202f", size = 3269375, upload-time = "2026-05-24T20:17:20.34Z" },
+    { url = "https://files.pythonhosted.org/packages/48/84/278a811ef4e07be9c89dc5cdd7be833268509a66a68c4897cf585e67428f/sqlalchemy-2.0.50-cp313-cp313-win32.whl", hash = "sha256:60922d6599065ddca2c6f376b9aa2f41a6b85a271725e0909490bbc50b1998a5", size = 2117229, upload-time = "2026-05-24T19:50:08.215Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/1c/067cc6187ed32d2ec222fe6d2643acc1659a6d0659f8a7cbc5ad3ae83280/sqlalchemy-2.0.50-cp313-cp313-win_amd64.whl", hash = "sha256:287086e67275a212c4582d166a6fb03a65ccc5551d80866270ce0dd9f34eccd3", size = 2143126, upload-time = "2026-05-24T19:50:09.691Z" },
+    { url = "https://files.pythonhosted.org/packages/df/32/10ac51b4be7cdecd7e93d069251c86dfbf70b7adbd7c67b48ccea6c49e1c/sqlalchemy-2.0.50-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c966932507a4d7d0a37314927dbfcd89720e3f37d2a1e3352e7ae7939fa8e8a0", size = 2158519, upload-time = "2026-05-24T19:27:56.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/76/e703d2f7681d7d66c4c891af3f07c7ccf4c76ad7f18351de035b5eda007a/sqlalchemy-2.0.50-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:faffef4bcc20a1892e65e155293d99d60855bbbc79250ab712819cfd56a8e6bb", size = 3282063, upload-time = "2026-05-24T20:09:38.57Z" },
+    { url = "https://files.pythonhosted.org/packages/31/26/ef168b184a25701f9995e8fb7e503fafd7a99c1c77cda1bc1a26ea2ed486/sqlalchemy-2.0.50-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c206aec519a2e7bd08abbfb33436e325fd22c632d9c21a9047e376ce241646e", size = 3287069, upload-time = "2026-05-24T20:17:21.942Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/15/765acc2bc693bccc43ca4a95d5b69750da8aaf6db1b5c616536e087f8920/sqlalchemy-2.0.50-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bef4ac756363227ef6402a75fee025a4bc690f92328e825868939b3b3a446a6d", size = 3230453, upload-time = "2026-05-24T20:09:40.398Z" },
+    { url = "https://files.pythonhosted.org/packages/63/61/08e03c3adbf5db0087a0b6816746fec8f3032fb2f7fc899a9bb9b2a48ce4/sqlalchemy-2.0.50-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:96fbee6b19c19cd1556c8bf9419447cf2ec149ffcab7ab64348c23e54ef8547f", size = 3252413, upload-time = "2026-05-24T20:17:24.067Z" },
+    { url = "https://files.pythonhosted.org/packages/03/0c/370a1f2db38436c615e10134c8a37de3688e74084792380695f3f5083860/sqlalchemy-2.0.50-cp314-cp314-win32.whl", hash = "sha256:8f00e3eb43ba30eb1b238ee03a8a62309486d1321eda3328bb611e0340033ad8", size = 2120063, upload-time = "2026-05-24T19:50:11.08Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a0/fe92bb9817863bc13ba093bda931979a26cc2ca69f8e8f26d07add3d7c6f/sqlalchemy-2.0.50-cp314-cp314-win_amd64.whl", hash = "sha256:15708c613cd5005b7dffe1f66ee6a63ee8f5e46799f71c70ebad74178c676a39", size = 2145830, upload-time = "2026-05-24T19:50:12.452Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/ff/e5640a98a0b2f491eb8fde10fb6c773621a2e44340de231fafcc9370f4a9/sqlalchemy-2.0.50-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3699dac4be410e97049a1658e9480da9cde956594aa0f3aebc60b88f21c5ba70", size = 2178435, upload-time = "2026-05-24T19:42:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/85/337116e186f1236375b5fb70c21cfac98e8e8ab0d3a47be838dc47a59e08/sqlalchemy-2.0.50-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f96233858e3df43932ac11589e22520da6e8aeb624b03fedfeebb0e8ea213086", size = 3566059, upload-time = "2026-05-24T20:01:20.848Z" },
+    { url = "https://files.pythonhosted.org/packages/96/34/bb0e190e161c3c2c24314a65add57218be14a4a9486886b7f5047c1ff7c8/sqlalchemy-2.0.50-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c4e70c46fad30c3bcc6a4708bc0130a3173e11a5b25f0ea4a9d8911b450f1f52", size = 3535366, upload-time = "2026-05-24T20:03:56.768Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/a7f759f97e4fd499c5d4e4488c760d5a7fbecf3028b465a04274fcd52384/sqlalchemy-2.0.50-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1918a3cf564d16d95bca7301005f41ab2ad50b07cd3b9da50d3ed986db148d6a", size = 3474879, upload-time = "2026-05-24T20:01:23.058Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/d9/2907ea38eb60687d297bf9c39e5ee58053c87b57fe8a9cae97090cecbf10/sqlalchemy-2.0.50-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b00098cdbdbd38c7be3d568b0c9c3122b8c0ec62b911b57cd5e6e0254d60a76d", size = 3486117, upload-time = "2026-05-24T20:03:59.052Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e3/5aa06f167559f8c0bdae487e297d23ba548150ab016a3418265d617a4985/sqlalchemy-2.0.50-cp314-cp314t-win32.whl", hash = "sha256:1fbd55a969d7ac44a98e3dec75016074f809fa08f871585ace58dde110d1bf3e", size = 2150823, upload-time = "2026-05-24T20:08:58.644Z" },
+    { url = "https://files.pythonhosted.org/packages/65/9b/112fb8f977582d7489d036e409e3723948bcf5320b3ac465f3c481bbe8f9/sqlalchemy-2.0.50-cp314-cp314t-win_amd64.whl", hash = "sha256:c5c3cdb753a9004183e1ccb634b41611654c989e61bc68617ce878e46d6f1e51", size = 2185794, upload-time = "2026-05-24T20:09:00.319Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/10/f7220e9b784d295d241c86ed99aeb537f92afcd469a64861f2717e9bb077/sqlalchemy-2.0.50-py3-none-any.whl", hash = "sha256:92064363517a3ff8212b5a93b8c62876579d8dfd1ca5b561335f30152d884fa9", size = 1943861, upload-time = "2026-05-24T19:59:01.119Z" },
+]
+
+[[package]]
+name = "sqlmodel"
+version = "0.0.38"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/0d/26ec1329960ea9430131fe63f63a95ea4cb8971d49c891ff7e1f3255421c/sqlmodel-0.0.38.tar.gz", hash = "sha256:d583ec237b14103809f74e8630032bc40ab68cd6b754a610f0813c56911a547b", size = 86710, upload-time = "2026-04-02T21:03:55.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/c7/10c60af0607ab6fa136264f7f39d205932218516226d38585324ffda705d/sqlmodel-0.0.38-py3-none-any.whl", hash = "sha256:84e3fa990a77395461ded72a6c73173438ce8449d5c1c4d97fbff1b1df692649", size = 27294, upload-time = "2026-04-02T21:03:56.406Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1538,6 +1912,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
 ]
 
 [[package]]
@@ -1672,6 +2062,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]
@@ -1904,4 +2303,79 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/ac/4370bde262c0e633e6c4f0e56d55095710024cf9a5cecc20c59a10de483c/wrapt-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dd57607acc85678925940bd5df0385ff8332083a32fa8d7a43f8767f4997263c", size = 80321, upload-time = "2026-05-22T14:47:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/79/b8ff3a61e71babf58a8cf4c0d63358e8bad383e15bf7f35e62d2f6b6e4a4/wrapt-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1ae574d65c9fa8e86f64f6a7c2668f9fcd507b183e0e577619f504b883cb0a6c", size = 81216, upload-time = "2026-05-22T14:47:45.243Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fd/c0cac1f77c9c4f6fe58a920ca632ce379bb8be928720e11e8d73de28a5e9/wrapt-2.2.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9a04c28c10ba7fd12842b109d2edb0678872a2fe65277ca4ff06a0d61edee245", size = 159208, upload-time = "2026-05-22T14:47:47.176Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4f/744132a7b2fbefa6b81118ec5942eca5fc2e9a129f9055a0c5e46885a549/wrapt-2.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e2f02472a1cbbf3884b365714a810b5947134a95ad6952b554cb8cce9d492b0", size = 160322, upload-time = "2026-05-22T14:47:49.04Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/95/b7cd9a22a06cf93e6482904ee6afc956248983553593fd1009296d1b3b31/wrapt-2.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac2745950b2bff80219c15ebf2fa9d8427eba7e249739f97e55c9d169e47e9e1", size = 153243, upload-time = "2026-05-22T14:47:50.386Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4a/eb79423192015f46f0db2872e7e04a3dde8d359b83411e8959e7c9287eaa/wrapt-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67a97e5b6c457f0cd3cfc19ebb2d84463e60c3ece754cc831e4281a3ca29bb18", size = 159231, upload-time = "2026-05-22T14:47:51.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/dc/435015b58ce33c6fc4104158fa91ddb0e809ab03a5751fb7465d1d461456/wrapt-2.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:c803a3d331796255af51ba2c79ed0ac8275865b516c09e61f248d1e7aff31ce9", size = 152351, upload-time = "2026-05-22T14:47:53.214Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ac/5d203f98df8fd136b95c5227139aea02d34505e18baf812d0c005df61963/wrapt-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9b984d1eb252145d6302c1dbd5e87fc6d404d45531447c84eadec04bf1fcb027", size = 158347, upload-time = "2026-05-22T14:47:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2f/a92427dbdc74e54c1674abbed27e61b2cb5e7a94441b8c1270c70671d928/wrapt-2.2.1-cp311-cp311-win32.whl", hash = "sha256:8a983a603a18c8708f024f7f6991b2e66159219abbf894634c5056243c55f3cd", size = 77562, upload-time = "2026-05-22T14:47:56.275Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/56/987b9c13b3e1c1a3c6de71284076f996b79caec90e75a87c044a40c23db9/wrapt-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:9c210a6994b21aa9b29e81c8d11560e8fdab54c117e9cff37870d0a27bde1343", size = 80616, upload-time = "2026-05-22T14:47:57.854Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/25/d01f560888d99d94a959c85533de349ce68d71ace3f2591d6ea8f632cfed/wrapt-2.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:401229e9d63ca09f9b8891ecf83798d26c11bbb445d11ed9f1836b6d4585b38a", size = 79025, upload-time = "2026-05-22T14:47:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0c/bfae7b9401583b6d05938cd16dedc43857d96da2f8a3d50d78cc515bf6ff/wrapt-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ffad790d9d11d8ecf9f17c4bb671a5b4089e4d8b575c46c5129597f41f836b0", size = 81021, upload-time = "2026-05-22T14:48:00.313Z" },
+    { url = "https://files.pythonhosted.org/packages/26/58/80f6a6599f933f4caecc1cb3ee88a04faf81e8b9bddbd6109c688dd63e0f/wrapt-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:628f5220c7a904d5fc78f7075c8d7871433eb6d035c94728a22fdf85f193d2a8", size = 81692, upload-time = "2026-05-22T14:48:01.49Z" },
+    { url = "https://files.pythonhosted.org/packages/17/93/fb357cc7847c58a8ae790be718903afa81a28d23e642c843dc4129e8a0b2/wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:61acce4257a9883669703c525447c5b4c392edf0f987ae77ec32668440158f0e", size = 169364, upload-time = "2026-05-22T14:48:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0b/76b601ee309a8bd556af0eecb184394c20b3c49aa9c8e085aa1ffacc2568/wrapt-2.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:727ab4244622cd6ad2390f322642090c877d2e83a608d2653a7643ae5368d926", size = 171079, upload-time = "2026-05-22T14:48:04.22Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/87/ee3f32d5658e3e26d3e0e457922b47a36dd3bfbdfee7f97bb3e802344a66/wrapt-2.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03df9ebed4c73ab93fa8c07e3d41d818dfca1852b15731a3de59457b27814624", size = 160205, upload-time = "2026-05-22T14:48:05.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d0/ae2fd64277a67f5d7bffcf2d05eea1e476263fb2a072baf0b0129ab85984/wrapt-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0d9ff006f420b2ec8296aa56ade43ea7da3e997e85769f0aafc5e0661aacb710", size = 168922, upload-time = "2026-05-22T14:48:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f3/2d541a060c5bbafb9400bca4917e4d78bfd1f239f404782c86831a8f6b29/wrapt-2.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:844c858fc3bb7eacc0ba8efa904935d16aac6a4470948ad1e7e55c9f5a2a665f", size = 158388, upload-time = "2026-05-22T14:48:08.629Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/68/8d92c8800c57e93cb116ae9e9d6cbafc34fade5ee9f9107b6f203fb4dc35/wrapt-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87bacdaf225117a342a20d9c03438d701c02112f6e3f351ce9b7f32354f14797", size = 167682, upload-time = "2026-05-22T14:48:10.042Z" },
+    { url = "https://files.pythonhosted.org/packages/30/72/83ea3790ea352439442349388e29ff07b76e0686265f9088bbb505d1608d/wrapt-2.2.1-cp312-cp312-win32.whl", hash = "sha256:2f8c90c8afde51969487be4e1343ae049b268854877d415c2510baf833775052", size = 77857, upload-time = "2026-05-22T14:48:11.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/cb/99450668dd3502d62a54a1c8aa56e44f34cb8c1261b381cfe2e7926c3b75/wrapt-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ce32763ac31ce94fe9aada947e479b1975012bff166da409b4b9e4e376cf7e5", size = 80825, upload-time = "2026-05-22T14:48:13.046Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/87512881be64e743f9ee4c66f4cbe8e884974bef2a5989af71f999653ac7/wrapt-2.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d1b4d0e0c2119587a31f5c029abd547e0c81d93b89d394566fe1588659eb579", size = 79087, upload-time = "2026-05-22T14:48:14.323Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/a1b08f8f4fac8cbb156fa51cf64ee2c7f7f74f9875ba3cf70b3c58368694/wrapt-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d2beb1c7cab10603aecdc42f8edd6ff013f9a32e4543474e38e6b77ce9975aeb", size = 80831, upload-time = "2026-05-22T14:48:15.598Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ce/57890814991446a845e09b3445ce8b694f27eb0577004f2c2a36a9772ed4/wrapt-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0cb7e4dd71f4c32e5e84843cd3c4cd65dda034314004bbe1d7f99af2426ab80", size = 81375, upload-time = "2026-05-22T14:48:17.071Z" },
+    { url = "https://files.pythonhosted.org/packages/38/65/08d7a6c76ac4493bdb668205ee9c1de1bd5daca61717c3e9aa49b4c01499/wrapt-2.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95821352042722cd9f1108874579a47989d0a7e12a37d87d2fc4af20fd99ab8a", size = 167417, upload-time = "2026-05-22T14:48:18.303Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ce/f1ccbee7a1bfe5cdc6b3da6bab4b45713d628b9294da32a39f563d648140/wrapt-2.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abd621552ede77c4c69be7fac44ba911225b0c812b6ba604e5964cf98085b474", size = 166948, upload-time = "2026-05-22T14:48:19.768Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2a/f85d48d1cd4869aee6704028d257d740a47c1c467b457ce396b4b5b55d07/wrapt-2.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e3677c7146ce694874941ba82b57092cc4875445aadf29d72807351023105143", size = 158148, upload-time = "2026-05-22T14:48:21.96Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5c/93939ad11d4a12358ab1aab219a2ef5efa5612e0db6b9fc65af8af1a891b/wrapt-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9a5934eaea872e17936b5f45501eba5ab0bce9a74122e172b663d7c28c459c4a", size = 165905, upload-time = "2026-05-22T14:48:23.373Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/b8c2aa89862ff58605934d7abf4b70e6a5a1c33df96656f49035ccdf1c8a/wrapt-2.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f5b9daf6b629fce418e0cc3dd0436eac045188fa35deadb7a7f3941d5b8203f9", size = 156712, upload-time = "2026-05-22T14:48:24.767Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/bf00a7b02239c12bb02ddcc3c0b971bfcc36e578c5a44f1ccfef5b458545/wrapt-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f53ac9f3ef573326d009ed809beff4efcac6451931c2b8132586da4b9e53ff31", size = 166560, upload-time = "2026-05-22T14:48:26.83Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/93/6390ca9c5b787683cef588d04f57c8d41b9a2323b5597a65f18638c90ef2/wrapt-2.2.1-cp313-cp313-win32.whl", hash = "sha256:1ffa9cfd4bdb581539951b14ae661ff20ed0c3599b3e911a131ee0ec5ac11337", size = 77817, upload-time = "2026-05-22T14:48:28.221Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/ce10f0e71c0cfaa1a65faadb8efd4852028b3bb9ba28932b8889df769d38/wrapt-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:368eac1e20fd0bb03dd3cc42bf9887154c3861b60989389ccb5fac032617d215", size = 80736, upload-time = "2026-05-22T14:48:30.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/4c/89f4a6818fafbbd840330e4fa3873073e1bfc166133a64cac7f8fde7a5e3/wrapt-2.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:c754dafdf5aaf0b401b644a90a30046929a0dd1a536e0ff0ec959a59155d9c7f", size = 79099, upload-time = "2026-05-22T14:48:31.405Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f2/9a8741c46f8c208ac0a45b25ba170bcb4fb72a2781d5fb97dbd7b6be73cb/wrapt-2.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ed928d0fda15fc0adc8d13305c8b3c0f2fba5b0669950c9e6d019d9162a3b3e8", size = 82802, upload-time = "2026-05-22T14:48:33.307Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0d/e9c855716a3705eef1416456bdf062b60620726fdc59428ff670fc3c60dc/wrapt-2.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fafb4e739e43544d12cb4abd1605fd4683b6ca6a9ad682b7fd8f4d21973eafa8", size = 83329, upload-time = "2026-05-22T14:48:34.593Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d6/a88f1c13112b7831adac75cea65d8310e0d696d570c8961844c90a57b865/wrapt-2.2.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:74d6a0c31472fe5d814917266b9f46495d7c61ed890af08b468acea92fb89a8d", size = 202937, upload-time = "2026-05-22T14:48:35.859Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/e29d54aef06a4d898a5b8a25589a0b3769bde454f922fad8f6f89fbfb650/wrapt-2.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab5be648d5a0b86b7438864f8df3c705a65cef35a2fd3e5561e3e203167e0f27", size = 209997, upload-time = "2026-05-22T14:48:38.153Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/91/e4454263516cf0e12640912fbca9a83654e424f0a6ddb79f5cd7ce14bf33/wrapt-2.2.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d8f204c8e3a8bf9ece17e0a83d137fd807440977f8a5e762d59306795011440", size = 194856, upload-time = "2026-05-22T14:48:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d0/fe0ee202286afdf4a7f77dd29f195703145764d572aec209c5086e57d924/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d047f6498c973874ba08ac3f97c69a2c4b2211c8de6f4c205f75cb1c9522596e", size = 205654, upload-time = "2026-05-22T14:48:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/23/b6/87d860dfc6460c246af70b1fd5c8b76df77571b42a493459423ded94fd7d/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:7a4fdb9326aab4a5a477a1640e5ad786a8495901009d7e7b038371edd23a9d2b", size = 192206, upload-time = "2026-05-22T14:48:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/3eea8cde077d985f239a38c0257087b8064fd9ee9b1a99e282d2c86da4ef/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c8cc5094b08abeae52da9c73c8a32003623be691a5193df2f4e3eac3d557c394", size = 198428, upload-time = "2026-05-22T14:48:46.319Z" },
+    { url = "https://files.pythonhosted.org/packages/18/dc/b927ee9c7fc67adc3a5658f246a0d275425eb840ba36e7b702e70f18bde8/wrapt-2.2.1-cp313-cp313t-win32.whl", hash = "sha256:9907a4402ab6db12b7077a0ea5d7a4d028ecb22c8eee2b53527080d347cd1562", size = 79448, upload-time = "2026-05-22T14:48:47.901Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b3/fd30b473fe498c70e6b9a5f328b8d3fbaf1b8c3c481465f59724bba8eb70/wrapt-2.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:5590d63f5243251641cf543009b4c9314a79d0598fdb8a8e4cfc918494536c53", size = 83021, upload-time = "2026-05-22T14:48:49.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/96c39153a8737a6e9aa85adef254ac4195bea3f2d24efc60472ccc3c9e2e/wrapt-2.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:c318a64b53d97b841d7b5e637517e50a27be64bc695128422953d4b21710954e", size = 80295, upload-time = "2026-05-22T14:48:50.479Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a3/11d7f34ebbf3231bc907a3e6d5ee051b14d034c1bc7b65a97d5cc00516df/wrapt-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f56a647e4eaf5f0ca40330fb070f566bdf9f7b0db89a1af20d71c28dcd7a0ab", size = 80879, upload-time = "2026-05-22T14:48:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3c/b74cfd984cef560b900fb1a727af20352d89e1f06bf2e1114dd3f00f5f5a/wrapt-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:64b7deeda4b70408e382328d8bbe52a256fe9bc63ae3db86d804608367e5422c", size = 81462, upload-time = "2026-05-22T14:48:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a3/7c8f704b8dc07dfe0a5d01c2edbfd88317aa8e5e3fa7c743eb7a085ae767/wrapt-2.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9cf53ba90717db2e292401de290776c498d4bbfb0d4a559ca2895db8b9dcb5c", size = 167251, upload-time = "2026-05-22T14:48:54.562Z" },
+    { url = "https://files.pythonhosted.org/packages/80/85/a34d1888d97247da6c2ff6118c3a721c73ed8cc4dd198c00208bb73b6f80/wrapt-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf3638274ab9d9b724c9baa0b4c04e132cd6faefb78b4dd3dd1a02a4bdaad41e", size = 166316, upload-time = "2026-05-22T14:48:56.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d7/72ffaeb01eebc704afe3fb99e840480f4bda45f0fa66e3381b6a39251c8f/wrapt-2.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aed9658797d0b45d6c49adcfc6b41f66e6f2d0c6de3ec79e16cf4b1855df240f", size = 157952, upload-time = "2026-05-22T14:48:57.924Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5b/36f5d6b024e4edfdd90b140742d11ebcf7836daf5c9daf326c55c24db412/wrapt-2.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1d676ee388bc42a04d56dd7deb5605244dac2e35cc2fadbb43c9fa25bbd93508", size = 166130, upload-time = "2026-05-22T14:48:59.384Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/9296d9e97bfdef5483dfcc859d57b095b257144b2bc5300ab521e06f4bc7/wrapt-2.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e395f7bc31851ef9b612050368cb446e9bc14cd7454b025018980349caf25ae5", size = 156604, upload-time = "2026-05-22T14:49:00.921Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/16953929ed6776175720e58fc966e779926d8d71e2c7b2273230590ca71f/wrapt-2.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f1845c2a8cc1180ccccfa45785dd06f562730d19ef75be180334254012b6283", size = 166007, upload-time = "2026-05-22T14:49:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/20ee58c0612dae7c31131a7095345812ed2c7b389019e175f68cde34e5b4/wrapt-2.2.1-cp314-cp314-win32.whl", hash = "sha256:436addbc4bb4fc0a88c702577f51195d7d73683a7f3e0e5b253d8404d7847243", size = 78327, upload-time = "2026-05-22T14:49:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b3/ef7c3295d02e0448a71c639a36a057f46d524d057c9486291a7a3039e65c/wrapt-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:50972a1d974ea07725a7f6b1cec5f8759008afd030a0024843ebe7d52de47f2b", size = 81144, upload-time = "2026-05-22T14:49:05.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dc/7bdf336953f99f4ceb0a584bb8870e42c8f26f93ea10c87834dad62f1668/wrapt-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:1c9934ea5d92957e3cd0adbc0845539dccfd62710ebe16195a8c66c53954db36", size = 79569, upload-time = "2026-05-22T14:49:06.413Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6d/6dfae80150ff1919c356d1dd528f049bcdfaae29b4d284bc957e022caef4/wrapt-2.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17de18fc12cea55b8a9587314cb830573e37fb33b247a7515696350863714188", size = 82892, upload-time = "2026-05-22T14:49:07.925Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7b/4e34766a7d7804ffce9e71befe47e9b3225dc350c49c94493c4ab39fd3a5/wrapt-2.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9dec1aca52dddde7df94818310fa2fe79739c8f385b2014c4cb1035f5508199", size = 83333, upload-time = "2026-05-22T14:49:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/57/0b34db3e8de44ccfece62d7b337abd1631dd810f5adc5f3db571727836b5/wrapt-2.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69f2e9244542cb34dd59c7f073445b9e54ad9f3fce8d93606c368a1b499fc413", size = 202899, upload-time = "2026-05-22T14:49:10.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/ac0c459f154b99d92789a6cba7ca727185b83513b986f8ec7fe2aacddcbf/wrapt-2.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d83966dc7f4f45e8b97b5933685ac2e6e67fc0e19246ea314bceb9a8970c956", size = 209986, upload-time = "2026-05-22T14:49:12.229Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/77e37ff33ad018fa81ade52c25fa327b80b56f81d734279a63614fcb4cbc/wrapt-2.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78b0aa6bfb7be8deed0ab23e7aa028cc5210c29bc2d32a04d52b50e517a7307e", size = 194893, upload-time = "2026-05-22T14:49:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/7ea651d1ab032fc5fa222fbec91d0f8a1397f6ae04ebb93fa7219aa921d7/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:05d5cb74d1b232ec8cfa130a8f900708699ff2491d97b8f85a4cdc5996294b85", size = 205636, upload-time = "2026-05-22T14:49:15.714Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8e88031a701275b9085c54e64bc88c0b1cd55c77eadd400691c371cd76c4/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f6518b94edb9150452e9aba08027d4cc293433753ec1fbefb4629a21cbc74181", size = 192267, upload-time = "2026-05-22T14:49:17.283Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a8/e657ca876b06710194f243d81c4b0896ade646e244bdbec2d87c8c56a8bd/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed55af48b3eb28f43228ca2306788892bcb629eb2b5c4876e2a3659872c2f17a", size = 198378, upload-time = "2026-05-22T14:49:18.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/822efe4ea722a3961331bfa35b7d90937790d2c20f0616de1997ccc3aebd/wrapt-2.2.1-cp314-cp314t-win32.whl", hash = "sha256:2e08688ab16525897da6589d56d0aebaf417bbe91c2d8e3b96203b1efa596e85", size = 80226, upload-time = "2026-05-22T14:49:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
 ]

--- a/website/content/docs/installation.md
+++ b/website/content/docs/installation.md
@@ -17,9 +17,24 @@ uv add cross-auth
 pip install cross-auth
 ```
 
+## Storage adapters
+
+Cross-Auth ships optional storage adapters behind extras. Install the ones you
+need:
+
+```bash
+uv add 'cross-auth[redis]'      # RedisStorage for secondary storage
+uv add 'cross-auth[sqlmodel]'   # SQLModel accounts and session adapters
+uv add 'cross-auth[redis,sqlmodel]'
+```
+
+Without the extras, the core library does not depend on Redis or SQLModel. The
+Redis adapter needs a Redis server 6.2 or newer. See the
+[Storage](/docs/storage) guide for usage.
+
 ## Requirements
 
-- Python 3.10 or higher
+- Python 3.11 or higher
 - A web framework (FastAPI, Django, Flask, etc.)
-- A database for user storage (any ORM or driver that implements the storage
-  protocols)
+- A database for user storage (a built-in adapter, or any ORM or driver that
+  implements the storage protocols)

--- a/website/content/docs/quick-start.md
+++ b/website/content/docs/quick-start.md
@@ -13,41 +13,61 @@ application using Cross-Auth's `CrossAuth` class. The class provides high-level
 `login()` and `logout()` methods that handle session creation, deletion, and
 cookie management for you.
 
-## Step 1: Implement Storage
+## Step 1: Set Up Storage
 
-Cross-Auth uses protocol classes to abstract storage. For session login you need
-three implementations:
+Cross-Auth needs three storage backends:
 
-- **`AccountsStorage`** -- For looking up users by email or ID.
 - **`SecondaryStorage`** -- For transient OAuth data such as authorization
   codes, PKCE challenges, and link codes.
+- **`AccountsStorage`** -- For looking up and creating users.
 - **`SessionStorage`** -- For durable, revocable browser sessions and bearer
   tokens.
 
-```python
-from cross_auth import AccountsStorage, SecondaryStorage, SessionStorage
+The built-in adapters cover the common Redis + SQLModel setup. Install the
+extras:
 
-
-# Example: in-memory secondary storage (use Redis in production)
-class MemoryStorage:
-    def __init__(self):
-        self.data = {}
-
-    def set(self, key: str, value: str, ttl: int | None = None):
-        self.data[key] = value
-
-    def get(self, key: str) -> str | None:
-        return self.data.get(key)
-
-    def delete(self, key: str):
-        self.data.pop(key, None)
-
-    def pop(self, key: str) -> str | None:
-        return self.data.pop(key, None)
+```bash
+uv add 'cross-auth[redis,sqlmodel]'
 ```
 
-Implement `SessionStorage` with your database's normal row model. The
-[Storage](/docs/storage) guide shows the full protocol.
+Use `RedisStorage` for secondary storage, and the SQLModel adapters for your
+accounts and sessions. You own the models; the adapters implement the protocols.
+See the [Storage](/docs/storage) guide for the model definitions (`User`,
+`SocialAccount`, `UserSession`) used below.
+
+```python
+import redis
+from sqlmodel import Session, create_engine
+
+from cross_auth.storage.redis import RedisStorage
+from cross_auth.storage.sqlmodel import (
+    SQLModelAccountsStorage,
+    SQLModelSessionStorage,
+)
+
+# User, SocialAccount and UserSession are your own SQLModel models — see the
+# Storage guide for the definitions used here. The "+psycopg" driver needs a
+# database driver installed (e.g. `pip install psycopg`).
+engine = create_engine("postgresql+psycopg://localhost/myapp")
+
+secondary_storage = RedisStorage(redis.Redis.from_url("redis://localhost:6379"))
+
+
+accounts_storage = SQLModelAccountsStorage(
+    User, SocialAccount, session_factory=lambda: Session(engine)
+)
+session_storage = SQLModelSessionStorage(
+    UserSession, session_factory=lambda: Session(engine)
+)
+```
+
+Need invite checks, team creation, custom user construction, or post-signup
+telemetry? Subclass the accounts storage and override the signup hooks
+(`build_user`, `on_signup`, `after_signup`) — see the [Storage](/docs/storage)
+guide.
+
+Using a different ORM? The [Storage](/docs/storage) guide shows how to implement
+the protocols directly.
 
 ## Step 2: Create the CrossAuth Instance
 
@@ -62,6 +82,11 @@ auth = CrossAuth(
     trusted_origins=["https://myapp.com"],
 )
 ```
+
+Emails are trimmed and lowercased before every lookup and signup, so
+`Alice@Example.com` and `alice@example.com` are the same account. Pass a
+callable as `normalize_email=` to customize this (e.g. to also collapse Gmail
+dot-aliases).
 
 ## Step 3: Login
 

--- a/website/content/docs/storage.md
+++ b/website/content/docs/storage.md
@@ -1,28 +1,349 @@
 ---
 title: Storage
 description:
-  Implement the storage protocols to connect Cross-Auth to your database.
+  Connect Cross-Auth to your database with a built-in adapter or by implementing
+  the storage protocols.
 order: 1
 section: Guides
 ---
 
 ## Overview
 
-Cross-Auth uses Python protocol classes (structural subtyping) for storage. You
-don't need to inherit from a base class -- just implement the required methods
-and Cross-Auth will accept your objects.
-
-Cross-Auth separates transient OAuth state from durable session state:
+Cross-Auth keeps three storage concerns separate:
 
 - `SecondaryStorage` stores short-lived values such as authorization codes, PKCE
   challenges, and link codes.
-- `SessionStorage` stores revocable session records for browser cookies and
-  bearer tokens issued by `/token`.
+- `AccountsStorage` looks up and creates users and their social accounts.
+- `SessionStorage` stores durable, revocable session records for browser cookies
+  and bearer tokens issued by `/token`.
 
-## AccountsStorage
+There are two ways to provide them:
 
-The `AccountsStorage` protocol defines how Cross-Auth looks up and creates
-users.
+1. **Use a built-in adapter.** Cross-Auth ships a Redis adapter and subclassable
+   SQLModel adapters that implement the repetitive protocol code for you. You
+   keep ownership of your models and migrations. This is the recommended path
+   for most apps.
+2. **Implement the protocols directly.** The protocols are plain
+   [structural](https://docs.python.org/3/library/typing.html#typing.Protocol)
+   interfaces — implement the methods on any object and Cross-Auth will accept
+   it. Use this for ORMs without a built-in adapter, or for custom storage.
+
+## Built-in adapters
+
+The adapters are optional and live behind extras, so the core library never
+pulls in Redis or SQLModel:
+
+```bash
+uv add 'cross-auth[redis]'      # RedisStorage
+uv add 'cross-auth[sqlmodel]'   # SQLModel adapters
+uv add 'cross-auth[redis,sqlmodel]'
+```
+
+### RedisStorage
+
+`RedisStorage` implements `SecondaryStorage`. Pass it an existing redis client:
+
+```python
+import redis
+from cross_auth.storage.redis import RedisStorage
+
+secondary_storage = RedisStorage(redis.Redis.from_url("redis://localhost:6379"))
+```
+
+It requires a **synchronous** redis-py client with `GETDEL` support (redis-py >=
+4.2; the `redis` extra installs >= 5.0) against a **Redis server 6.2 or newer**.
+`RedisStorage` raises `TypeError` at construction for a client without `getdel`
+and for an async client (e.g. `redis.asyncio.Redis`) — an async client's methods
+would silently return an unawaited coroutine instead of doing anything, so it's
+rejected up front rather than failing on the first call.
+
+It stores values with optional TTL, normalizes byte and string responses to
+`str | None`, and uses Redis `GETDEL` for atomic `pop`. A `ttl` of zero or less
+means "already expired": the key is deleted instead of stored.
+
+### SQLModelAccountsStorage
+
+Pass your models to `SQLModelAccountsStorage` — it implements all of
+`AccountsStorage`, including a working `create_user`. App-specific signup
+behaviour (invite checks, team creation, profile defaults) goes in the optional
+`on_signup` hook.
+
+First, your user-owned models (you control the table names, columns, and
+migrations):
+
+```python
+from datetime import datetime
+
+from sqlmodel import Field, Relationship, SQLModel
+
+
+class SocialAccount(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id")
+    provider: str
+    provider_user_id: str
+    access_token: str | None = None
+    refresh_token: str | None = None
+    access_token_expires_at: datetime | None = None
+    refresh_token_expires_at: datetime | None = None
+    scope: str | None = None
+    provider_email: str | None = None
+    provider_email_verified: bool | None = None
+    is_login_method: bool = True
+
+    user: "User" = Relationship(back_populates="social_accounts")
+
+
+class User(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    email: str = Field(index=True, unique=True)
+    email_verified: bool = False
+    hashed_password: str | None = None
+
+    social_accounts: list[SocialAccount] = Relationship(back_populates="user")
+
+    @property
+    def has_usable_password(self) -> bool:
+        return self.hashed_password is not None
+```
+
+Then the adapter:
+
+```python
+from sqlmodel import Session, create_engine
+
+from cross_auth.storage.sqlmodel import SQLModelAccountsStorage
+
+# The "+psycopg" driver needs a database driver installed (e.g. `pip install psycopg`).
+engine = create_engine("postgresql+psycopg://localhost/myapp")
+
+accounts_storage = SQLModelAccountsStorage(
+    User, SocialAccount, session_factory=lambda: Session(engine)
+)
+```
+
+`create_user` runs the whole signup as one adapter-owned transaction, commits,
+and returns the user fully loaded (so it stays readable after the session
+closes), bypassing `filter_user_query` so a freshly created user is always
+returned.
+
+Real signup flows usually do more. Three hooks cover the phases of that
+transaction:
+
+- `build_user` **constructs** the instance. The default is
+  `UserModel(email=..., email_verified=...)` — override it when your model needs
+  more: generated fields (a unique username — the open session is provided for
+  lookups), or a differently-named column. This matters because SQLModel
+  silently ignores unknown constructor kwargs: a model that stores verification
+  under, say, `is_verified` must be constructed explicitly here or the flag is
+  silently lost.
+- `on_signup` runs **inside the transaction**, after the user is added but
+  before the commit. Raise to abort (everything rolls back), mutate `user` to
+  fill extra columns, or `session.add(...)` related rows so the whole signup
+  commits atomically. The user isn't flushed yet, so call `session.flush()` if
+  you need `user.id`.
+- `after_signup` runs **post-commit** with the final, fully-loaded user —
+  telemetry, welcome emails, queueing background work. Raising here does not
+  undo the signup.
+
+```python
+class AccountsStore(SQLModelAccountsStorage[User, SocialAccount]):
+    UserModel = User
+    SocialAccountModel = SocialAccount
+
+    def build_user(self, *, session, user_info, email, email_verified):
+        username = generate_unique_username(session, email)
+        return User(email=email, is_verified=email_verified, username=username)
+
+    def on_signup(self, *, session, user, user_info, email_verified):
+        if not is_invited(user.email):
+            # Aborts the signup: the transaction rolls back,
+            # nothing is persisted.
+            raise CrossAuthException("signup_not_allowed", "Invite only")
+        user.full_name = user_info.get("name")  # set extra columns
+        session.add(Team(owner=user))  # joins the same commit
+
+    def after_signup(self, *, user, user_info):
+        telemetry.capture("account_created", user_id=user.id)
+
+
+accounts_storage = AccountsStore(session_factory=lambda: Session(engine))
+```
+
+Everything else (`find_user_by_email`, `find_social_account`,
+`create_social_account`, `update_social_account`, `delete_social_account`, and
+the rest) is handled by the base.
+
+Configuration is validated at construction: a missing model declaration, a model
+missing an attribute the `User`/`SocialAccount` protocols require, or a
+non-callable `session_factory` raises a `TypeError` at startup rather than on
+the first login. The token columns the default payload builders write
+(`access_token`, `refresh_token`, their expiries, and `scope`) are checked too,
+because SQLModel silently ignores unknown constructor kwargs — without the
+check, a missing column would silently drop OAuth tokens. If you don't want to
+store tokens, override both payload builders to drop those fields.
+
+#### Customization hooks
+
+Override these methods instead of reimplementing whole protocol methods:
+
+- `build_user(*, session, user_info, email, email_verified)` - construct the
+  user instance (see above).
+- `on_signup(*, session, user, user_info, email_verified)` - signup behaviour
+  inside the signup transaction (see above).
+- `after_signup(*, user, user_info)` - post-commit side effects (see above).
+- `filter_user_query(statement)` - refine user lookups, e.g. exclude
+  soft-deleted users. (`create_user` deliberately skips this filter.)
+- `filter_social_account_query(statement)` - scope social accounts, e.g. by
+  tenant. Applied to reads **and** writes, so a scoped store can't be made to
+  update or delete rows its lookups would never return. It does **not** apply to
+  the eager-loaded `user.social_accounts` relationship on a returned user — that
+  collection is always loaded unfiltered; use `list_social_accounts` for a
+  filtered read.
+- `build_social_account_create_values(*, user_info, **fields)` - customize the
+  columns written when creating a social account (e.g. derive a provider
+  username from `user_info`).
+- `build_social_account_update_values(*, user_info, record, **fields)` - same,
+  for updates. `record` is the loaded row being updated, so derived columns can
+  read its current state (e.g. recompute a provider username from
+  `record.provider` and `record.provider_user_id`).
+
+```python
+class AccountsStore(SQLModelAccountsStorage[User, SocialAccount]):
+    UserModel = User
+    SocialAccountModel = SocialAccount
+
+    def filter_user_query(self, statement):
+        # Assumes your User model adds a deleted_at column.
+        return statement.where(User.deleted_at == None)  # noqa: E711
+```
+
+### SQLModelSessionStorage
+
+Pass your session model to `SQLModelSessionStorage` — it implements every
+`SessionStorage` method, including keyset cursor pagination and status
+filtering. No subclass is needed unless you want to override behaviour.
+
+Your session model must expose the attribute names the `SessionRecord` protocol
+reads, plus an internal `token_hash` column (only the hash is stored, never the
+raw token). Cross-Auth passes user ids to the session layer as strings
+(`login(user_id: str)`), but the adapter coerces them to your `user_id` column's
+type — declare it as `str`, `int`, or `UUID` to match your user table's primary
+key, so you keep a real foreign key:
+
+```python
+from datetime import datetime
+
+from sqlmodel import Field, SQLModel
+
+from cross_auth import session_status
+
+
+class UserSession(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    token_hash: str = Field(index=True)
+    user_id: int = Field(foreign_key="user.id", index=True)
+    created_at: datetime
+    updated_at: datetime
+    expires_at: datetime
+    last_active_at: datetime | None = None
+    revoked_at: datetime | None = None
+    client_id: str | None = None
+    client_name: str | None = None
+    user_agent: str | None = None
+    ip: str | None = None
+
+    @property
+    def status(self):
+        return session_status(self)
+```
+
+`session_status` is the canonical active/expired/revoked derivation — delegate
+to it rather than re-implementing the state machine, so your records always
+agree with the adapter's status filters.
+
+```python
+from cross_auth.storage.sqlmodel import SQLModelSessionStorage
+
+session_storage = SQLModelSessionStorage(
+    UserSession, session_factory=lambda: Session(engine)
+)
+```
+
+To override behaviour, subclass and declare the model as a class attribute
+instead:
+
+```python
+class SessionStore(SQLModelSessionStorage[UserSession]):
+    SessionModel = UserSession
+```
+
+Datetime columns may be plain (timezone-naive) as above — values are stored as
+UTC wall time and come back timezone-aware UTC, regardless of the database
+connection's time zone — or declared with `DateTime(timezone=True)` if you
+prefer `timestamptz` columns.
+
+#### Pagination cursors
+
+`list_for_user` pages with opaque keyset cursors. A cursor is bound to the
+`order_by` it was minted under; replaying it with a different ordering, or
+sending a malformed cursor, raises `InvalidCursorError` (a `ValueError` subclass
+from `cross_auth.exceptions`) — map it to a 400 in your session-listing
+endpoint:
+
+```python
+from cross_auth.exceptions import InvalidCursorError
+
+try:
+    result = auth.list_sessions(user_id, cursor=cursor)
+except InvalidCursorError:
+    raise HTTPException(status_code=400, detail="Invalid cursor")
+```
+
+### The session factory
+
+Both SQLModel adapters take a `session_factory` rather than a live `Session`. A
+SQLModel `Session` is a short-lived unit of work, while a `CrossAuth` instance
+usually lives for the whole application - accepting one shared session would
+make it easy to leak a session across requests. The factory must return a fresh
+`Session` each call:
+
+```python
+SQLModelSessionStorage(UserSession, session_factory=lambda: Session(engine))
+```
+
+The adapter opens a session per operation (with `expire_on_commit=False`, so
+committed rows keep their loaded values) and closes it before returning. When
+`social_accounts` is a relationship, user queries eager-load it, so returned
+instances remain safe to read after their session closes; a plain
+`social_accounts` property works too. If your models carry additional lazy
+relationships, load them yourself (`create_user` and the finders only guarantee
+scalar columns and `social_accounts`).
+
+## Implementing the protocols directly
+
+For ORMs without a built-in adapter, implement the protocols on your own
+objects. You don't inherit from anything — Cross-Auth accepts any object with
+the right methods.
+
+### SecondaryStorage
+
+```python
+class SecondaryStorage(Protocol):
+    def set(self, key: str, value: str, ttl: int | None = None): ...
+    def get(self, key: str) -> str | None: ...
+    def delete(self, key: str): ...
+    def pop(self, key: str) -> str | None: ...
+```
+
+**Implementations must honor `ttl`** (seconds until expiry). For some keys — the
+OAuth authorization-request state, in particular — the TTL is the only expiry
+mechanism: an implementation that ignores it leaves abandoned login state around
+forever. `RedisStorage` enforces it natively via Redis `EX`; a hand-rolled
+in-memory store must track and check expiry itself. The example app's
+`MemorySecondaryStorage` (`examples/fastapi/main.py`) shows the pattern.
+
+### AccountsStorage
 
 ```python
 class AccountsStorage(Protocol):
@@ -43,7 +364,11 @@ class AccountsStorage(Protocol):
     def delete_social_account(self, social_account_id: Any) -> None: ...
 ```
 
-### User Protocol
+Emails are normalized before they reach your storage: Cross-Auth trims and
+lowercases them ahead of every `find_user_by_email` and `create_user` call, so
+implementations can compare exactly against the stored (lowercase) value. Pass
+`normalize_email=` to `CrossAuth` to customize this — e.g. to also collapse
+Gmail dot-aliases.
 
 Your user model must expose these attributes:
 
@@ -61,52 +386,10 @@ class User(Protocol):
     def social_accounts(self) -> Iterable[SocialAccount]: ...
 ```
 
-## SecondaryStorage
+### SessionStorage
 
-The `SecondaryStorage` protocol is used for ephemeral OAuth data: authorization
-codes, PKCE challenges, and link codes.
-
-```python
-class SecondaryStorage(Protocol):
-    def set(self, key: str, value: str, ttl: int | None = None): ...
-    def get(self, key: str) -> str | None: ...
-    def delete(self, key: str): ...
-    def pop(self, key: str) -> str | None: ...
-```
-
-A Redis-backed implementation is a good fit for production:
-
-```python
-import redis
-
-
-class RedisStorage:
-    def __init__(self, url: str = "redis://localhost:6379"):
-        self.client = redis.from_url(url)
-
-    def set(self, key: str, value: str, ttl: int | None = None):
-        self.client.set(key, value, ex=ttl)
-
-    def get(self, key: str) -> str | None:
-        result = self.client.get(key)
-        return result.decode() if result else None
-
-    def delete(self, key: str):
-        self.client.delete(key)
-
-    def pop(self, key: str) -> str | None:
-        pipe = self.client.pipeline()
-        pipe.get(key)
-        pipe.delete(key)
-        result, _ = pipe.execute()
-        return result.decode() if result else None
-```
-
-## SessionStorage
-
-The `SessionStorage` protocol stores durable, revocable session records. Browser
-session cookies and OAuth bearer tokens both contain opaque session tokens; only
-the token hash is stored.
+Browser session cookies and OAuth bearer tokens both contain opaque session
+tokens; only the token hash is stored.
 
 ```python
 class SessionRecord(Protocol):
@@ -154,6 +437,10 @@ class SessionStorage(Protocol):
     def list_for_user(self, user_id: Any, **kwargs) -> SessionListResult: ...
     def revoke_all_for_user(self, user_id: Any, **kwargs) -> int: ...
 ```
+
+If `list_for_user` supports cursor pagination, raise
+`cross_auth.exceptions.InvalidCursorError` for malformed or mismatched cursors,
+so applications can handle bad cursors the same way for every backend.
 
 `session_storage` is optional when constructing `CrossAuth`, but session-backed
 features require it. `login()`, `logout()`, and session-management methods raise


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- **#44** (`2026-07-01-add-built-in-redis-and-sqlmodel-storage-adapters`) <-- this PR
- #47 (merged) (`2026-07-02-expire-and-single-use-transient-oauth-state`)
- #46 (merged) (`2026-07-02-normalize-emails-before-every-user-lookup-and-crea`)
- #45 (merged) (`2026-07-02-add-a-public-session-status-helper`)
<!-- shortcake:end -->

## Summary by Sourcery

Add optional Redis and SQLModel storage adapters with extensive documentation, configuration validation, and tests, including cursor-based session pagination and email normalization behaviour updates.

New Features:
- Introduce a Redis-backed SecondaryStorage adapter behind an optional redis extra.
- Introduce SQLModel-based AccountsStorage and SessionStorage adapters behind an optional sqlmodel extra, including signup hooks and cursor-based session listing.
- Add a reusable cursor encoding/decoding utility and an InvalidCursorError for storage backends that support paginated session listings.

Enhancements:
- Document built-in storage adapters, email normalization semantics, and TTL requirements for transient storage in the storage, quick-start, and installation guides.
- Strengthen datetime handling, ID coercion, and model validation in SQLModel storage adapters to avoid runtime errors and silent data loss across different databases.
- Re-export InvalidCursorError from the storage package for easier consumption by custom storage implementations.

Documentation:
- Expand storage guide with detailed usage of built-in Redis and SQLModel adapters and protocol implementation guidance.
- Update quick-start and installation docs to show configuring built-in storage adapters and clarify Python version and storage requirements.
- Add a release note summarizing storage adapters, email normalization, and transient OAuth state hardening.

Tests:
- Add comprehensive unit and integration tests for Redis and SQLModel storage adapters, including PostgreSQL container-based tests and internal helper coverage.
- Add cursor encoding/decoding tests and shared SQLModel test models to validate pagination and datetime behaviour across backends.