### PR TITLE
Add a public session_status helper

### DIFF
--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -22,6 +22,7 @@ from cross_auth import (
     SessionListResult,
     SessionStatus,
     SessionStorage,
+    session_status,
 )
 from cross_auth import User as UserProtocol
 from cross_auth._session import get_current_user as get_session_user
@@ -254,12 +255,13 @@ class MemorySessionStorage(SessionStorage):
             return None
         record.updated_at = updated_at
         record.expires_at = expires_at
-        record.last_active_at = last_active_at
+        if last_active_at is not None:
+            record.last_active_at = last_active_at
         return record
 
     def revoke(self, session_id: Any, *, revoked_at: datetime) -> None:
         record = self.get_any(session_id)
-        if record is not None:
+        if record is not None and record.revoked_at is None:
             record.revoked_at = revoked_at
 
     def revoke_all_for_user(
@@ -458,14 +460,6 @@ def serialize_user(user: DemoUser) -> dict[str, Any]:
             for account in user.social_accounts
         ],
     }
-
-
-def session_status(record: DemoSessionRecord, *, now: datetime) -> SessionStatus:
-    if record.revoked_at is not None:
-        return "revoked"
-    if now > record.expires_at:
-        return "expired"
-    return "active"
 
 
 def session_access_label(record: DemoSessionRecord) -> str:

--- a/src/cross_auth/__init__.py
+++ b/src/cross_auth/__init__.py
@@ -9,6 +9,7 @@ from cross_auth._storage import (
     SessionStatus,
     SessionStorage,
     User,
+    session_status,
 )
 from cross_auth._tokens import TokenIssueRequest, TokenIssuer
 from cross_auth.hooks import (
@@ -78,6 +79,7 @@ __all__ = [
     "SessionRecord",
     "SessionStatus",
     "SessionStorage",
+    "session_status",
     "TokenExchangeParams",
     "TokenIssueRequest",
     "TokenIssuer",

--- a/src/cross_auth/_storage.py
+++ b/src/cross_auth/_storage.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Sequence
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Literal
 
 from pydantic import AwareDatetime
@@ -74,6 +74,31 @@ class SessionListResult(Protocol):
     next_cursor: str | None
 
 
+def session_status(
+    record: SessionRecord,
+    *,
+    now: datetime | None = None,
+) -> SessionStatus:
+    """Derive a session's status from its revocation and expiry timestamps.
+
+    This is the single source of truth for the active/expired/revoked state
+    machine: storage implementations and ``SessionRecord.status`` properties
+    should delegate here rather than re-deriving it. A session is ``active``
+    up to and including the exact expiry instant. Naive datetimes are assumed
+    to be UTC; ``now`` defaults to the current UTC time.
+    """
+    if record.revoked_at is not None:
+        return "revoked"
+    if now is None:
+        now = datetime.now(tz=timezone.utc)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    expires_at = record.expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return "expired" if now > expires_at else "active"
+
+
 class SessionStorage(Protocol):
     def create(
         self,
@@ -117,7 +142,10 @@ class SessionStorage(Protocol):
         updated_at: AwareDatetime,
         expires_at: AwareDatetime,
         last_active_at: AwareDatetime | None = None,
-    ) -> SessionRecord | None: ...
+    ) -> SessionRecord | None:
+        """Roll a session forward. When ``last_active_at`` is omitted (None),
+        the stored value is preserved rather than cleared."""
+        ...
 
     def revoke(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from cross_auth._storage import (
     SessionStatus,
     SessionStorage,
     User as UserProtocol,
+    session_status,
 )
 from cross_auth.exceptions import CrossAuthException
 
@@ -97,11 +98,7 @@ class MemorySessionRecord:
 
     @property
     def status(self) -> SessionStatus:
-        if self.revoked_at is not None:
-            return "revoked"
-        if datetime.now(tz=timezone.utc) > self.expires_at:
-            return "expired"
-        return "active"
+        return session_status(self)
 
 
 @dataclass
@@ -153,7 +150,7 @@ class MemorySessionStorage(SessionStorage):
             ),
             None,
         )
-        if record is None or record.revoked_at is not None or now > record.expires_at:
+        if record is None or session_status(record, now=now) != "active":
             return None
         return record
 
@@ -177,7 +174,7 @@ class MemorySessionStorage(SessionStorage):
             records = [
                 record
                 for record in records
-                if _session_status(record, now=now) == status
+                if session_status(record, now=now) == status
             ]
 
         field, direction = order_by.rsplit("_", 1)
@@ -203,12 +200,13 @@ class MemorySessionStorage(SessionStorage):
             return None
         record.updated_at = updated_at
         record.expires_at = expires_at
-        record.last_active_at = last_active_at
+        if last_active_at is not None:
+            record.last_active_at = last_active_at
         return record
 
     def revoke(self, session_id: Any, *, revoked_at: datetime) -> None:
         record = self.get_any(session_id)
-        if record is not None:
+        if record is not None and record.revoked_at is None:
             record.revoked_at = revoked_at
 
     def revoke_all_for_user(
@@ -228,14 +226,6 @@ class MemorySessionStorage(SessionStorage):
                 record.revoked_at = revoked_at
                 count += 1
         return count
-
-
-def _session_status(record: MemorySessionRecord, *, now: datetime) -> SessionStatus:
-    if record.revoked_at is not None:
-        return "revoked"
-    if now > record.expires_at:
-        return "expired"
-    return "active"
 
 
 class MemoryAccountsStorage:


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- #44 (`2026-07-01-add-built-in-redis-and-sqlmodel-storage-adapters`)
- #47 (`2026-07-02-expire-and-single-use-transient-oauth-state`)
- #46 (`2026-07-02-normalize-emails-before-every-user-lookup-and-crea`)
- **#45** (`2026-07-02-add-a-public-session-status-helper`) <-- this PR
<!-- shortcake:end -->

## Summary by Sourcery

Introduce a shared helper to derive session status and adopt it across in-memory and example session storage implementations.

New Features:
- Expose a public session_status helper to compute a session's active, expired, or revoked state based on its timestamps.

Enhancements:
- Centralize session status derivation to be the single source of truth for storage implementations and record status properties.
- Adjust in-memory and example session storage refresh logic to preserve last_active_at when omitted and avoid re-marking already revoked sessions.

Tests:
- Update test fixtures to use the new session_status helper and remove bespoke status calculation helpers.