### PR TITLE
Normalize emails before every user lookup and creation

### DIFF
--- a/src/cross_auth/__init__.py
+++ b/src/cross_auth/__init__.py
@@ -1,4 +1,5 @@
 from cross_auth._context import Context
+from cross_auth._email import normalize_email
 from cross_auth._session import SessionConfig, SessionCookieConfig
 from cross_auth._storage import (
     AccountsStorage,
@@ -79,6 +80,7 @@ __all__ = [
     "SessionRecord",
     "SessionStatus",
     "SessionStorage",
+    "normalize_email",
     "session_status",
     "TokenExchangeParams",
     "TokenIssueRequest",

--- a/src/cross_auth/_auth_flow.py
+++ b/src/cross_auth/_auth_flow.py
@@ -829,12 +829,15 @@ def resolve_or_create_user(
 
     user: User | None = None
     created_user = False
+    # Lookups and creation use the normalized (canonical) form; the raw
+    # provider email is still stored on the social account as provider_email.
+    email = context.normalize_email(validated.email)
 
     if provider.can_auto_link(context, validated.email_verified):
-        user = context.accounts_storage.find_user_by_email(validated.email)
+        user = context.accounts_storage.find_user_by_email(email)
 
     if not user:
-        existing_user = context.accounts_storage.find_user_by_email(validated.email)
+        existing_user = context.accounts_storage.find_user_by_email(email)
         if existing_user:
             raise CrossAuthException(
                 "account_not_linked",
@@ -857,7 +860,7 @@ def resolve_or_create_user(
 
         user = context.accounts_storage.create_user(
             user_info=user_info,
-            email=validated.email,
+            email=email,
             email_verified=validated.email_verified or False,
         )
         created_user = True

--- a/src/cross_auth/_context.py
+++ b/src/cross_auth/_context.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 from cross_web import HTTPRequest, Cookie
 
 from ._config import Config
+from ._email import normalize_email as _default_normalize_email
 from ._session import (
     SessionConfig,
     SessionMetadata,
@@ -39,6 +40,7 @@ class Context:
         config: Config | None = None,
         default_next_url: str = "/",
         hooks: HookRegistry | None = None,
+        normalize_email: Callable[[str], str] | None = None,
     ):
         self.secondary_storage = secondary_storage
         self.accounts_storage = accounts_storage
@@ -47,6 +49,11 @@ class Context:
         self.get_user_from_request = get_user_from_request
         self.token_issuer = token_issuer
         self.base_url = base_url
+        # Applied to every user lookup/creation by email (not to the raw
+        # provider_email stored on social accounts).
+        self.normalize_email = (
+            normalize_email if normalize_email is not None else _default_normalize_email
+        )
         self.config: Config = config if config is not None else {}
         self.session_config: SessionConfig | None = self.config.get("session")
         self.default_next_url = default_next_url

--- a/src/cross_auth/_email.py
+++ b/src/cross_auth/_email.py
@@ -1,0 +1,11 @@
+def normalize_email(email: str) -> str:
+    """Default email normalization: trim surrounding whitespace and lowercase.
+
+    Cross-Auth applies this before every user lookup or creation by email, so
+    ``Alice@Example.com`` and ``alice@example.com`` resolve to the same
+    account. Pass ``normalize_email=`` to ``CrossAuth`` to replace it — e.g.
+    to also collapse Gmail dot-aliases — ideally composing with this default.
+    Provider-reported emails stored on social accounts (``provider_email``)
+    are kept raw.
+    """
+    return email.strip().lower()

--- a/src/cross_auth/_issuer.py
+++ b/src/cross_auth/_issuer.py
@@ -289,7 +289,9 @@ class Issuer:
         context: Context,
         http_request: HTTPRequest,
     ) -> Response:
-        user = context.accounts_storage.find_user_by_email(request.username)
+        user = context.accounts_storage.find_user_by_email(
+            context.normalize_email(request.username)
+        )
 
         try:
             context.hooks.run_before(

--- a/src/cross_auth/fastapi.py
+++ b/src/cross_auth/fastapi.py
@@ -12,6 +12,7 @@ from fastapi import Response as FastAPIResponse
 
 from ._config import Config
 from ._context import AccountsStorage, SecondaryStorage, User
+from ._email import normalize_email as _normalize_email
 from ._password import authenticate
 from ._request import make_http_request
 from ._session import (
@@ -89,12 +90,16 @@ class CrossAuth:
         base_url: str | None = None,
         config: Config | None = None,
         default_next_url: str = "/",
+        normalize_email: Callable[[str], str] | None = None,
     ):
         self._storage = storage
         self._accounts_storage = accounts_storage
         self._session_storage = session_storage
         self._session_config: SessionConfig | None = (config or {}).get("session")
         self._hooks = HookRegistry()
+        self._normalize_email = (
+            normalize_email if normalize_email is not None else _normalize_email
+        )
 
         self._get_user_from_request = (
             get_user_from_request or self._default_get_user_from_request
@@ -112,6 +117,7 @@ class CrossAuth:
             config=config,
             default_next_url=default_next_url,
             hooks=self._hooks,
+            normalize_email=normalize_email,
         )
 
     @property
@@ -251,7 +257,11 @@ class CrossAuth:
             BeforeAuthenticateEvent(email=email, password=password),
         )
 
-        user = authenticate(event.email, event.password, self._accounts_storage)
+        # Normalize at the lookup only: the hook events keep the email exactly
+        # as the client submitted it.
+        user = authenticate(
+            self._normalize_email(event.email), event.password, self._accounts_storage
+        )
 
         self._hooks.run_after(
             "authenticate",

--- a/src/cross_auth/router.py
+++ b/src/cross_auth/router.py
@@ -127,6 +127,7 @@ class AuthRouter(APIRouter):
         config: Config | None = None,
         default_next_url: str = "/",
         hooks: HookRegistry | None = None,
+        normalize_email: Callable[[str], str] | None = None,
     ):
         super().__init__()
 
@@ -144,6 +145,7 @@ class AuthRouter(APIRouter):
             config=config,
             default_next_url=default_next_url,
             hooks=hooks,
+            normalize_email=normalize_email,
         )
 
         provider_routes: list[Route] = []

--- a/src/cross_auth/social_providers/oauth.py
+++ b/src/cross_auth/social_providers/oauth.py
@@ -111,13 +111,15 @@ class OAuth2Provider:
 
         Returns True if:
         - Either email is missing (no comparison possible), OR
-        - Emails match (case-insensitive), OR
+        - Emails match after normalization (case-insensitive by default), OR
         - allow_different_emails is enabled
         """
         if not provider_email or not user_email:
             return True
 
-        if provider_email.lower() == user_email.lower():
+        if context.normalize_email(provider_email) == context.normalize_email(
+            user_email
+        ):
             return True
 
         account_linking = context.config.get("account_linking", {})

--- a/tests/fastapi/test_cross_auth.py
+++ b/tests/fastapi/test_cross_auth.py
@@ -252,6 +252,17 @@ def test_authenticate(
     assert user.email == "test@example.com"
 
 
+def test_authenticate_normalizes_email(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+    session_storage: SessionStorage,
+):
+    auth = _make_auth(secondary_storage, accounts_storage, session_storage)
+    user = auth.authenticate("  Test@Example.COM ", TEST_PASSWORD)
+    assert user is not None
+    assert user.email == "test@example.com"
+
+
 def test_authenticate_wrong_password(
     secondary_storage: SecondaryStorage,
     accounts_storage: AccountsStorage,

--- a/tests/router/conftest.py
+++ b/tests/router/conftest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Generator
+from typing import Any, Callable, Generator
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -63,6 +63,7 @@ def _build_auth(
     trusted_origins: list[str] | None = None,
     config: Config | None = None,
     default_next_url: str = "/",
+    normalize_email: Callable[[str], str] | None = None,
 ) -> CrossAuth:
     if config is None:
         config = {"session": {"cookies": {"auth": True}}}
@@ -75,6 +76,7 @@ def _build_auth(
         config=config,
         default_next_url=default_next_url,
         get_user_from_request=_bearer_user_resolver(accounts_storage),
+        normalize_email=normalize_email,
     )
 
 

--- a/tests/router/test_email_normalization.py
+++ b/tests/router/test_email_normalization.py
@@ -1,0 +1,65 @@
+import respx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cross_auth._storage import AccountsStorage
+
+from .conftest import mock_token_and_userinfo, start_provider_auth
+
+
+@respx.mock
+def test_signup_stores_normalized_email(
+    client: TestClient,
+    accounts_storage: AccountsStorage,
+):
+    mock_token_and_userinfo(email="  Alice@Example.COM ")
+    _, state = start_provider_auth(client, "/fake/login")
+
+    resp = client.get(
+        "/fake/callback", params={"code": "provider-code", "state": state}
+    )
+
+    assert resp.status_code == 302
+    assert accounts_storage.find_user_by_email("alice@example.com") is not None
+
+
+@respx.mock
+def test_mixed_case_provider_email_matches_existing_account(client: TestClient):
+    # The seeded user is test@example.com. Without account linking enabled the
+    # callback must recognize the differently-cased provider email as the same
+    # existing account (and refuse to create a duplicate), which proves the
+    # lookup is normalized.
+    mock_token_and_userinfo(email="Test@Example.COM")
+    _, state = start_provider_auth(client, "/fake/login")
+
+    resp = client.get(
+        "/fake/callback", params={"code": "provider-code", "state": state}
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "account_not_linked"
+
+
+@respx.mock
+def test_custom_normalizer_is_applied(build_auth, accounts_storage):
+    def collapse_gmail_dots(email: str) -> str:
+        email = email.strip().lower()
+        local, _, domain = email.partition("@")
+        if domain == "gmail.com":
+            local = local.replace(".", "")
+        return f"{local}@{domain}"
+
+    auth = build_auth(normalize_email=collapse_gmail_dots)
+    app = FastAPI()
+    app.include_router(auth.router)
+
+    with TestClient(app, follow_redirects=False) as client:
+        mock_token_and_userinfo(email="P.a.trick@Gmail.com")
+        _, state = start_provider_auth(client, "/fake/login")
+
+        resp = client.get(
+            "/fake/callback", params={"code": "provider-code", "state": state}
+        )
+
+    assert resp.status_code == 302
+    assert accounts_storage.find_user_by_email("patrick@gmail.com") is not None


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- #44 (`2026-07-01-add-built-in-redis-and-sqlmodel-storage-adapters`)
- #47 (`2026-07-02-expire-and-single-use-transient-oauth-state`)
- **#46** (`2026-07-02-normalize-emails-before-every-user-lookup-and-crea`) <-- this PR
- #45 (merged) (`2026-07-02-add-a-public-session-status-helper`)
<!-- shortcake:end -->

## Summary by Sourcery

Normalize email addresses for all user lookup and creation paths and make email normalization configurable.

New Features:
- Add a default email normalization helper that trims whitespace and lowercases addresses and export it from the public API.
- Allow injecting a custom normalize_email function into CrossAuth, Context, and router construction to customize email canonicalization.

Bug Fixes:
- Ensure password authentication and OAuth signup/login consistently normalize emails before user lookup and creation, preventing duplicate or mismatched accounts.
- Normalize emails when comparing provider and user emails in OAuth account-linking checks to avoid false mismatches.
- Normalize usernames in the password grant flow before looking up users by email.

Enhancements:
- Wire email normalization through the auth context so all storage lookups and creations by email use a canonical form while preserving raw provider_email on social accounts.

Tests:
- Add tests covering email normalization in password authentication, OAuth signup and account-linking flows, and custom normalizer injection via the router helpers.