### PR TITLE
Expire and single-use transient OAuth state

### DIFF
--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 import uuid
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
@@ -103,20 +104,28 @@ class DemoUser:
 
 class MemorySecondaryStorage(SecondaryStorage):
     def __init__(self) -> None:
-        self.data: dict[str, str] = {}
+        self.data: dict[str, tuple[str, float | None]] = {}
 
     def set(self, key: str, value: str, ttl: int | None = None) -> None:
-        del ttl
-        self.data[key] = value
+        expires_at = time.monotonic() + ttl if ttl is not None else None
+        self.data[key] = (value, expires_at)
 
     def get(self, key: str) -> str | None:
-        return self.data.get(key)
+        if (entry := self.data.get(key)) is None:
+            return None
+        value, expires_at = entry
+        if expires_at is not None and time.monotonic() >= expires_at:
+            del self.data[key]
+            return None
+        return value
 
     def delete(self, key: str) -> None:
         self.data.pop(key, None)
 
     def pop(self, key: str) -> str | None:
-        return self.data.pop(key, None)
+        value = self.get(key)
+        self.data.pop(key, None)
+        return value
 
 
 @dataclass

--- a/src/cross_auth/_auth_flow.py
+++ b/src/cross_auth/_auth_flow.py
@@ -122,17 +122,23 @@ _LINK_CODE_KEY = "oauth:link_request:{code}"
 _AUTH_CODE_KEY = "oauth:code:{code}"
 _AUTH_CODE_TTL = timedelta(minutes=10)
 _LINK_CODE_TTL = timedelta(minutes=10)
+# How long a user has to complete the redirect dance at the provider. Also the
+# TTL of the stored state, so abandoned flows don't accumulate in storage.
+_AUTH_REQUEST_TTL = timedelta(minutes=10)
 
 
 def _store_auth_request(context: Context, data: AuthRequest) -> None:
     context.secondary_storage.set(
         _AUTH_REQUEST_KEY.format(state=data.state),
         data.model_dump_json(),
+        ttl=int(_AUTH_REQUEST_TTL.total_seconds()),
     )
 
 
 def _load_auth_request(context: Context, state: str) -> AuthRequest | None:
-    raw = context.secondary_storage.get(_AUTH_REQUEST_KEY.format(state=state))
+    # pop, not get: the state is a single-use CSRF token, so consume it on the
+    # callback to close the replay window rather than waiting for the TTL.
+    raw = context.secondary_storage.pop(_AUTH_REQUEST_KEY.format(state=state))
     if raw is None:
         return None
     try:
@@ -1020,6 +1026,7 @@ def _complete_token(
     context.secondary_storage.set(
         _AUTH_CODE_KEY.format(code=code),
         grant_data.model_dump_json(),
+        ttl=int(_AUTH_CODE_TTL.total_seconds()),
     )
 
     query_params: dict[str, str] = {"code": code}
@@ -1062,6 +1069,7 @@ def _complete_link(
     context.secondary_storage.set(
         _LINK_CODE_KEY.format(code=code),
         data.model_dump_json(),
+        ttl=int(_LINK_CODE_TTL.total_seconds()),
     )
 
     return Response.redirect(

--- a/src/cross_auth/_storage.py
+++ b/src/cross_auth/_storage.py
@@ -41,11 +41,17 @@ class User(Protocol):
 
 
 class SecondaryStorage(Protocol):
-    def set(self, key: str, value: str, ttl: int | None = None): ...
+    def set(self, key: str, value: str, ttl: int | None = None) -> None:
+        """Store a value.
+
+        ``ttl`` is in seconds and must be enforced when provided; for some keys
+        it is the only thing that expires the stored value.
+        """
+        ...
 
     def get(self, key: str) -> str | None: ...
 
-    def delete(self, key: str): ...
+    def delete(self, key: str) -> None: ...
 
     def pop(self, key: str) -> str | None:
         """Atomically get and delete a key. Returns None if key doesn't exist."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import time
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -64,21 +65,30 @@ class User:
 
 
 class MemoryStorage(SecondaryStorage):
-    def __init__(self):
-        self.data = {}
+    def __init__(self) -> None:
+        self.data: dict[str, tuple[str, float | None]] = {}
 
-    def set(self, key: str, value: str, ttl: int | None = None):
-        self.data[key] = value
+    def set(self, key: str, value: str, ttl: int | None = None) -> None:
+        expires_at = time.monotonic() + ttl if ttl is not None else None
+        self.data[key] = (value, expires_at)
 
     def get(self, key: str) -> str | None:
-        return self.data.get(key)
+        if (entry := self.data.get(key)) is None:
+            return None
+        value, expires_at = entry
+        if expires_at is not None and time.monotonic() >= expires_at:
+            del self.data[key]
+            return None
+        return value
 
-    def delete(self, key: str):
-        del self.data[key]
+    def delete(self, key: str) -> None:
+        self.data.pop(key, None)
 
     def pop(self, key: str) -> str | None:
         """Atomically get and delete a key. Returns None if key doesn't exist."""
-        return self.data.pop(key, None)
+        value = self.get(key)
+        self.data.pop(key, None)
+        return value
 
 
 @dataclass

--- a/tests/router/test_session_flow.py
+++ b/tests/router/test_session_flow.py
@@ -90,6 +90,29 @@ def test_session_callback_creates_session_and_redirects_to_next(
 
 
 @respx.mock
+def test_session_callback_consumes_state(
+    client: TestClient,
+    secondary_storage: SecondaryStorage,
+):
+    # The state is a single-use CSRF token: a successful callback consumes it,
+    # so replaying the same callback is rejected as an unknown state.
+    mock_token_and_userinfo(email="alice@example.com")
+    _, state = start_provider_auth(client, "/fake/login")
+
+    first = client.get(
+        "/fake/callback", params={"code": "provider-code", "state": state}
+    )
+    assert first.status_code == 302
+    assert secondary_storage.get(f"oauth:authorization_request:{state}") is None
+
+    replay = client.get(
+        "/fake/callback", params={"code": "provider-code", "state": state}
+    )
+    assert replay.status_code == 400
+    assert replay.json()["error"] == "server_error"
+
+
+@respx.mock
 def test_session_callback_rejects_missing_state(client: TestClient):
     mock_token_and_userinfo()
     resp = client.get("/fake/callback", params={"code": "provider-code"})


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- #44 (`2026-07-01-add-built-in-redis-and-sqlmodel-storage-adapters`)
- **#47** (`2026-07-02-expire-and-single-use-transient-oauth-state`) <-- this PR
- #46 (merged) (`2026-07-02-normalize-emails-before-every-user-lookup-and-crea`)
- #45 (merged) (`2026-07-02-add-a-public-session-status-helper`)
<!-- shortcake:end -->

## Summary by Sourcery

Enforce expiry and single-use semantics for transient OAuth data stored in secondary storage.

New Features:
- Expire stored OAuth authorization requests after a fixed TTL to avoid accumulation of abandoned flows.
- Store auth and link codes in secondary storage with explicit TTLs so they automatically expire.

Bug Fixes:
- Consume OAuth state on callback to prevent replay attacks using the same state token.

Enhancements:
- Document TTL requirements and semantics on the SecondaryStorage protocol and implement a TTL-aware in-memory storage used in tests and examples.

Tests:
- Add a session callback test ensuring OAuth state is single-use and rejected on replay.