### PR TITLE
Move sliding-cookie rolling into SessionCookieMiddleware and fix storage protocol conformance

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,29 @@
+Release type: minor
+
+`get_current_user`, `require_current_user`, and `get_current_session` now take
+only the request, so one API serves FastAPI dependencies and direct calls
+(shared-context builders, GraphQL resolvers, template helpers) alike. Rolling
+the sliding-session cookie moved out of the read path into the new
+`SessionCookieMiddleware`: reads that refresh a session queue the rolled cookie
+on the request state, and the middleware delivers it on whatever response the
+handler produces — including responses returned directly (redirects, streaming,
+server-rendered pages), which the previous dependency-injected `Response`
+mechanism silently could not reach. If a session refreshes without the
+middleware installed, Cross-Auth warns instead of letting the browser cookie
+lapse silently.
+
+**Upgrade note:** drop the `response` argument from `get_current_user`,
+`require_current_user`, and `get_current_session` calls, and if you configure
+`update_age`, add `app.add_middleware(SessionCookieMiddleware)`. `login()` and
+`logout()` are unchanged. Without `update_age` the middleware is unnecessary.
+
+The storage record protocols (`SocialAccount`, `User`, `SessionRecord`) now
+declare their data members as read-only properties, so concrete models satisfy
+them structurally under precise type checkers like `ty`: attributes were checked
+invariantly, which rejected models that narrow a field (e.g. a non-nullable
+`provider_email_verified`) — including the built-in SQLModel adapters
+themselves. Core only ever reads these members, so nothing changes at runtime.
+`User.email` is now typed `str | None` to match reality (apps may hold users
+without an email; core never reads it — lookups go through
+`find_user_by_email`), and the `SocialAccount` protocol is now exported from
+`cross_auth`.

--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -8,7 +8,7 @@ from urllib.parse import urlencode
 
 import cross_auth
 from cross_web import HTTPRequest
-from fastapi import Depends, FastAPI, Form, Request, Response
+from fastapi import Depends, FastAPI, Form, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
@@ -25,7 +25,7 @@ from cross_auth import (
 from cross_auth import User as UserProtocol
 from cross_auth._session import get_current_user as get_session_user
 from cross_auth.exceptions import CrossAuthException
-from cross_auth.fastapi import CrossAuth
+from cross_auth.fastapi import CrossAuth, SessionCookieMiddleware
 from cross_auth.hooks import (
     AfterAuthenticateEvent,
     AfterLoginEvent,
@@ -508,6 +508,9 @@ def audit_token_exchange(event: AfterTokenAuthorizationCodeEvent) -> None:
 
 
 app = FastAPI(title="Cross-Auth FastAPI Hybrid Example")
+# Sessions use update_age (sliding expiry), so rolled cookies need a way onto
+# outgoing responses — including the RedirectResponses these handlers return.
+app.add_middleware(SessionCookieMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=SPA_CORS_ORIGINS,
@@ -586,7 +589,6 @@ def profile(
 @app.get("/sessions")
 def sessions_page(
     request: Request,
-    response: Response,
     user: Annotated[UserProtocol | None, Depends(auth.get_current_user)],
     status: SessionStatus | None = None,
     cursor: str | None = None,
@@ -594,7 +596,7 @@ def sessions_page(
     if user is None:
         return RedirectResponse(url="/", status_code=303)
 
-    current_session = auth.get_current_session(request, response)
+    current_session = auth.get_current_session(request)
     result = auth.list_sessions(
         str(user.id),
         status=status,
@@ -644,9 +646,8 @@ def revoke_session_form(
 def revoke_other_sessions_form(
     request: Request,
     user: Annotated[UserProtocol, Depends(auth.require_current_user)],
-    response: Response,
 ) -> RedirectResponse:
-    current_session = auth.get_current_session(request, response)
+    current_session = auth.get_current_session(request)
     if current_session is not None:
         auth.revoke_other_sessions(
             user_id=str(user.id),
@@ -696,12 +697,11 @@ def api_me_session(
 @app.get("/api/sessions")
 def api_sessions(
     request: Request,
-    response: Response,
     user: Annotated[UserProtocol, Depends(auth.require_current_user)],
     status: SessionStatus | None = None,
     cursor: str | None = None,
 ) -> JSONResponse:
-    current_session = auth.get_current_session(request, response)
+    current_session = auth.get_current_session(request)
     result = auth.list_sessions(
         str(user.id),
         status=status,
@@ -737,9 +737,8 @@ def api_revoke_session(
 def api_revoke_other_sessions(
     request: Request,
     user: Annotated[UserProtocol, Depends(auth.require_current_user)],
-    response: Response,
 ) -> JSONResponse:
-    current_session = auth.get_current_session(request, response)
+    current_session = auth.get_current_session(request)
     revoked = 0
     if current_session is not None:
         revoked = auth.revoke_other_sessions(

--- a/src/cross_auth/__init__.py
+++ b/src/cross_auth/__init__.py
@@ -9,6 +9,7 @@ from cross_auth._storage import (
     SessionRecord,
     SessionStatus,
     SessionStorage,
+    SocialAccount,
     User,
     session_status,
 )
@@ -80,6 +81,7 @@ __all__ = [
     "SessionRecord",
     "SessionStatus",
     "SessionStorage",
+    "SocialAccount",
     "normalize_email",
     "session_status",
     "TokenExchangeParams",

--- a/src/cross_auth/_storage.py
+++ b/src/cross_auth/_storage.py
@@ -17,21 +17,48 @@ SessionListOrder = Literal[
 
 
 class SocialAccount(Protocol):
-    id: Any
-    user_id: Any
-    provider_user_id: str
-    provider: str
-    provider_email: str | None
-    provider_email_verified: bool | None
+    # Data members on this and the other record protocols are read-only
+    # properties: core only reads them, and a plain protocol attribute would
+    # demand an exact invariant match where a property lets concrete models
+    # narrow the type (e.g. `provider_email_verified: bool`).
+    @property
+    def id(self) -> Any: ...
+
+    @property
+    def user_id(self) -> Any: ...
+
+    @property
+    def provider_user_id(self) -> str: ...
+
+    @property
+    def provider(self) -> str: ...
+
+    @property
+    def provider_email(self) -> str | None: ...
+
+    @property
+    def provider_email_verified(self) -> bool | None: ...
+
     # TODO: Add endpoint to toggle is_login_method for existing social accounts
-    is_login_method: bool
+    @property
+    def is_login_method(self) -> bool: ...
 
 
 class User(Protocol):
-    id: Any
-    email: str
-    email_verified: bool
-    hashed_password: str | None
+    @property
+    def id(self) -> Any: ...
+
+    # Nullable: apps may hold users without an email (created before email
+    # capture, or via providers that withhold it). Core never reads this —
+    # email lookups go through ``find_user_by_email``.
+    @property
+    def email(self) -> str | None: ...
+
+    @property
+    def email_verified(self) -> bool: ...
+
+    @property
+    def hashed_password(self) -> str | None: ...
 
     @property
     def has_usable_password(self) -> bool: ...
@@ -59,17 +86,38 @@ class SecondaryStorage(Protocol):
 
 
 class SessionRecord(Protocol):
-    id: Any
-    user_id: Any
-    created_at: AwareDatetime
-    updated_at: AwareDatetime
-    expires_at: AwareDatetime
-    last_active_at: AwareDatetime | None
-    revoked_at: AwareDatetime | None
-    client_id: str | None
-    client_name: str | None
-    user_agent: str | None
-    ip: str | None
+    @property
+    def id(self) -> Any: ...
+
+    @property
+    def user_id(self) -> Any: ...
+
+    @property
+    def created_at(self) -> AwareDatetime: ...
+
+    @property
+    def updated_at(self) -> AwareDatetime: ...
+
+    @property
+    def expires_at(self) -> AwareDatetime: ...
+
+    @property
+    def last_active_at(self) -> AwareDatetime | None: ...
+
+    @property
+    def revoked_at(self) -> AwareDatetime | None: ...
+
+    @property
+    def client_id(self) -> str | None: ...
+
+    @property
+    def client_name(self) -> str | None: ...
+
+    @property
+    def user_agent(self) -> str | None: ...
+
+    @property
+    def ip(self) -> str | None: ...
 
     @property
     def status(self) -> SessionStatus: ...

--- a/src/cross_auth/fastapi.py
+++ b/src/cross_auth/fastapi.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any, Literal, overload
@@ -9,6 +10,7 @@ from cross_web import Response as CrossWebResponse
 from fastapi import HTTPException
 from fastapi import Request as FastAPIRequest
 from fastapi import Response as FastAPIResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from ._config import Config
 from ._context import AccountsStorage, SecondaryStorage, User
@@ -16,7 +18,6 @@ from ._email import normalize_email as _normalize_email
 from ._password import authenticate
 from ._request import make_http_request
 from ._session import (
-    ResolvedSession,
     SessionConfig,
     SessionMetadata,
     create_session,
@@ -74,6 +75,12 @@ from .social_providers.oauth import OAuth2Provider
 
 # TODO: if we add more framework integrations, extract shared storage/session
 # logic into a private _BaseCrossAuth class that framework classes inherit from.
+
+# request.state slots shared between CrossAuth and SessionCookieMiddleware. The
+# middleware marks the sink on the way in; session reads queue rolled cookies
+# as they resolve; the middleware serializes them onto the outgoing response.
+_COOKIE_SINK_STATE_KEY = "cross_auth_cookie_sink"
+_ROLLED_COOKIES_STATE_KEY = "cross_auth_rolled_cookies"
 
 
 class CrossAuth:
@@ -143,17 +150,21 @@ class CrossAuth:
         async_request = AsyncHTTPRequest.from_fastapi(request)
         return self._get_user_from_request(make_http_request(async_request))
 
-    def get_current_user(
-        self, request: FastAPIRequest, response: FastAPIResponse
-    ) -> User | None:
-        # Roll the cookie before resolving the user so the refresh is captured
-        # here; the resolver then re-reads the (already refreshed) record.
-        self._roll_session_cookie(request, response)
+    def get_current_user(self, request: FastAPIRequest) -> User | None:
+        """Resolve the current user from the request's session.
+
+        Works both as a FastAPI dependency and called directly (shared-context
+        builders, GraphQL resolvers, template helpers). With sliding sessions
+        (``update_age``) the stored record refreshes on read; install
+        ``SessionCookieMiddleware`` so the rolled cookie also reaches the
+        browser.
+        """
+        # Refresh (and queue the rolled cookie) before resolving the user so
+        # the resolver re-reads the already-refreshed record.
+        self._queue_session_refresh(request)
         return self._resolve_user(request)
 
-    def get_current_session(
-        self, request: FastAPIRequest, response: FastAPIResponse
-    ) -> SessionRecord | None:
+    def get_current_session(self, request: FastAPIRequest) -> SessionRecord | None:
         session_storage = self._require_session_storage()
         async_request = AsyncHTTPRequest.from_fastapi(request)
         resolution = resolve_current_session(
@@ -163,36 +174,24 @@ class CrossAuth:
         )
         if resolution is None:
             return None
-        self._roll_cookie_for(resolution, response)
+        # Sliding sessions extend the stored expires_at on read; without
+        # re-sending the cookie the browser would still drop it at the
+        # original Max-Age. Bearer tokens have no cookie to roll.
+        if resolution.source == "cookie" and resolution.refreshed:
+            self._queue_rolled_cookie(
+                request, make_session_cookie(resolution.token, self._session_config)
+            )
         return resolution.record
 
-    def require_current_user(
-        self, request: FastAPIRequest, response: FastAPIResponse
-    ) -> User:
-        self._roll_session_cookie(request, response)
-        user = self._resolve_user(request)
+    def require_current_user(self, request: FastAPIRequest) -> User:
+        user = self.get_current_user(request)
         if user is None:
             raise HTTPException(status_code=401)
         return user
 
-    def _roll_cookie_for(
-        self, resolution: ResolvedSession, response: FastAPIResponse
-    ) -> None:
-        """Reissue Set-Cookie when a cookie-backed session was just refreshed.
-
-        Sliding sessions (``update_age``) extend the stored ``expires_at`` on
-        read; without re-sending the cookie the browser would still drop it at
-        the original Max-Age. Bearer tokens have no cookie to roll.
-        """
-        if resolution.source == "cookie" and resolution.refreshed:
-            cookie = make_session_cookie(resolution.token, self._session_config)
-            self._set_cookie_on_response(response, cookie)
-
-    def _roll_session_cookie(
-        self, request: FastAPIRequest, response: FastAPIResponse | None
-    ) -> None:
-        # No response to write to, no store, or no sliding window -> nothing to do.
-        if response is None or self._session_storage is None:
+    def _queue_session_refresh(self, request: FastAPIRequest) -> None:
+        # No store or no sliding window -> reads never refresh anything.
+        if self._session_storage is None:
             return
         if resolve_config(self._session_config).get("update_age") is None:
             return
@@ -202,8 +201,28 @@ class CrossAuth:
             self._session_storage,
             self._session_config,
         )
-        if resolution is not None:
-            self._roll_cookie_for(resolution, response)
+        if (
+            resolution is not None
+            and resolution.source == "cookie"
+            and resolution.refreshed
+        ):
+            self._queue_rolled_cookie(
+                request, make_session_cookie(resolution.token, self._session_config)
+            )
+
+    def _queue_rolled_cookie(self, request: FastAPIRequest, cookie: Cookie) -> None:
+        state = request.scope.setdefault("state", {})
+        if _COOKIE_SINK_STATE_KEY not in state:
+            warnings.warn(
+                "A sliding session refreshed but SessionCookieMiddleware is "
+                "not installed, so the rolled session cookie cannot reach the "
+                "browser and the user will be logged out at the cookie's "
+                "original Max-Age. Add "
+                "`app.add_middleware(SessionCookieMiddleware)`.",
+                stacklevel=2,
+            )
+            return
+        state.setdefault(_ROLLED_COOKIES_STATE_KEY, []).append(cookie)
 
     def list_sessions(
         self,
@@ -515,3 +534,65 @@ class CrossAuth:
             ),
         )
         self._apply_hook_response(event.response, response)
+
+
+def _serialize_cookie(cookie: Cookie) -> bytes:
+    # Reuse starlette's Set-Cookie serialization instead of hand-rolling it.
+    scratch = FastAPIResponse()
+    scratch.set_cookie(
+        key=cookie.name,
+        value=cookie.value,
+        max_age=cookie.max_age,
+        path=cookie.path or "/",
+        domain=cookie.domain,
+        secure=cookie.secure,
+        httponly=cookie.httponly,
+        samesite=cookie.samesite,
+    )
+    return scratch.headers["set-cookie"].encode("latin-1")
+
+
+class SessionCookieMiddleware:
+    """Delivers rolled sliding-session cookies on the outgoing response.
+
+    Install once when sessions are configured with ``update_age``::
+
+        app.add_middleware(SessionCookieMiddleware)
+
+    Session reads that refresh a cookie-backed session queue the rolled cookie
+    on the request state; this middleware serializes it onto whatever response
+    the handler produces — including responses returned directly (redirects,
+    streaming, server-rendered pages), which a dependency-injected ``Response``
+    can never reach. A cookie the handler already set itself (``logout``
+    clearing it, ``login`` replacing it) wins: the rolled copy is dropped
+    instead of fighting it. Without ``update_age`` reads never roll a cookie
+    and the middleware is inert.
+    """
+
+    def __init__(self, app: ASGIApp):
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        state = scope.setdefault("state", {})
+        state[_COOKIE_SINK_STATE_KEY] = True
+
+        async def send_with_rolled_cookies(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                for cookie in state.get(_ROLLED_COOKIES_STATE_KEY, []):
+                    _append_unless_cookie_set(message, cookie)
+            await send(message)
+
+        await self.app(scope, receive, send_with_rolled_cookies)
+
+
+def _append_unless_cookie_set(message: Message, cookie: Cookie) -> None:
+    headers: list[tuple[bytes, bytes]] = message.setdefault("headers", [])
+    prefix = f"{cookie.name}=".encode("latin-1")
+    for name, value in headers:
+        if name.lower() == b"set-cookie" and value.startswith(prefix):
+            return
+    headers.append((b"set-cookie", _serialize_cookie(cookie)))

--- a/tests/fastapi/test_cross_auth.py
+++ b/tests/fastapi/test_cross_auth.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 
 import pytest
-from fastapi import Depends, FastAPI, Request, Response
+from fastapi import Depends, FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
@@ -79,9 +79,8 @@ def test_get_current_session_requires_session_storage(
         trusted_origins=[],
     )
     request = Request({"type": "http", "method": "GET", "path": "/", "headers": []})
-    response = Response()
     with pytest.raises(RuntimeError, match="session_storage is required"):
-        auth.get_current_session(request, response)
+        auth.get_current_session(request)
 
 
 def _make_auth(
@@ -225,8 +224,8 @@ def test_auto_wired_get_user_from_request(
     app.include_router(auth.router)
 
     @app.get("/check")
-    async def check(request: Request, response: Response):
-        user = auth.get_current_user(request, response)
+    async def check(request: Request):
+        user = auth.get_current_user(request)
         if user is None:
             return {"user": None}
         return {"user": user.id}

--- a/tests/fastapi/test_hooks.py
+++ b/tests/fastapi/test_hooks.py
@@ -334,7 +334,7 @@ def test_oauth_callback_hooks(
         session_storage=session_storage,
         providers=[oauth_provider],
     )
-    seen: dict[str, str] = {}
+    seen: dict[str, str | None] = {}
 
     secondary_storage.set(
         "oauth:authorization_request:test_state",
@@ -420,7 +420,7 @@ def test_oauth_callback_hooks_run_for_session_flow(
         session_storage=session_storage,
         providers=[oauth_provider],
     )
-    seen: dict[str, str] = {}
+    seen: dict[str, str | None] = {}
 
     @auth.before("oauth.callback")
     def rewrite_session_email(

--- a/tests/test_durable_session.py
+++ b/tests/test_durable_session.py
@@ -25,7 +25,7 @@ from cross_auth._session import (
     hash_session_token,
 )
 from cross_auth._storage import AccountsStorage, SecondaryStorage
-from cross_auth.fastapi import CrossAuth
+from cross_auth.fastapi import CrossAuth, SessionCookieMiddleware
 
 from .conftest import MemorySessionStorage
 
@@ -427,6 +427,7 @@ def test_token_endpoint_errors_without_token_issuer_or_session_storage(
 
 def _sliding_app(auth: CrossAuth) -> FastAPI:
     app = FastAPI()
+    app.add_middleware(SessionCookieMiddleware)
 
     @app.get("/me")
     def me(user: Any = Depends(auth.get_current_user)) -> dict[str, Any]:
@@ -500,3 +501,127 @@ def test_bearer_session_refreshes_without_setting_cookie(
     assert resp.json() == {"user": "test"}
     assert "set-cookie" not in resp.headers
     assert record.expires_at == NOW + timedelta(seconds=80)
+
+
+@time_machine.travel(NOW, tick=False)
+def test_direct_call_rolls_cookie_through_middleware_on_direct_response(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+    session_storage: MemorySessionStorage,
+):
+    """The two cases a dependency-injected Response can never serve: a direct
+    ``get_current_user(request)`` call, and a handler returning a Response
+    instance (FastAPI drops the temporal response's headers then). The
+    middleware delivers the rolled cookie for both at once."""
+    auth = _make_auth(
+        secondary_storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        session_storage=session_storage,
+        config={
+            "session": {
+                "max_age": 60,
+                "update_age": 10,
+                "cookies": {"secure": False},
+            }
+        },
+    )
+    app = FastAPI()
+    app.add_middleware(SessionCookieMiddleware)
+
+    @app.get("/inline")
+    def inline(request: Request) -> JSONResponse:
+        user = auth.get_current_user(request)
+        return JSONResponse({"user": None if user is None else user.id})
+
+    token, record = create_session("test", session_storage, max_age=60)
+    client = TestClient(app)
+
+    with time_machine.travel(NOW + timedelta(seconds=20), tick=False):
+        resp = client.get("/inline", cookies={"session_id": token})
+
+    assert resp.json() == {"user": "test"}
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "session_id=" in set_cookie
+    assert "Max-Age=60" in set_cookie
+    assert record.expires_at == NOW + timedelta(seconds=80)
+
+
+@time_machine.travel(NOW, tick=False)
+def test_refresh_without_middleware_warns_and_skips_the_cookie(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+    session_storage: MemorySessionStorage,
+):
+    auth = _make_auth(
+        secondary_storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        session_storage=session_storage,
+        config={
+            "session": {
+                "max_age": 60,
+                "update_age": 10,
+                "cookies": {"secure": False},
+            }
+        },
+    )
+    app = FastAPI()  # no SessionCookieMiddleware
+
+    @app.get("/me")
+    def me(request: Request) -> dict[str, Any]:
+        user = auth.get_current_user(request)
+        return {"user": None if user is None else user.id}
+
+    token, record = create_session("test", session_storage, max_age=60)
+    client = TestClient(app)
+
+    with time_machine.travel(NOW + timedelta(seconds=20), tick=False):
+        with pytest.warns(UserWarning, match="SessionCookieMiddleware"):
+            resp = client.get("/me", cookies={"session_id": token})
+
+    # The stored record still slid; only the browser cookie was left behind.
+    assert resp.json() == {"user": "test"}
+    assert "set-cookie" not in resp.headers
+    assert record.expires_at == NOW + timedelta(seconds=80)
+
+
+@time_machine.travel(NOW, tick=False)
+def test_logout_clear_cookie_wins_over_queued_roll(
+    secondary_storage: SecondaryStorage,
+    accounts_storage: AccountsStorage,
+    session_storage: MemorySessionStorage,
+):
+    """Resolving the user (queues a roll) and then logging out in the same
+    request must not resurrect the session: the handler's clearing cookie
+    wins and the middleware drops the rolled copy."""
+    auth = _make_auth(
+        secondary_storage=secondary_storage,
+        accounts_storage=accounts_storage,
+        session_storage=session_storage,
+        config={
+            "session": {
+                "max_age": 60,
+                "update_age": 10,
+                "cookies": {"secure": False},
+            }
+        },
+    )
+    app = FastAPI()
+    app.add_middleware(SessionCookieMiddleware)
+
+    @app.post("/logout")
+    def logout(request: Request) -> JSONResponse:
+        auth.get_current_user(request)  # e.g. shared context resolving viewer
+        response = JSONResponse({"ok": True})
+        auth.logout(request, response=response)
+        return response
+
+    token, _ = create_session("test", session_storage, max_age=60)
+    client = TestClient(app)
+
+    with time_machine.travel(NOW + timedelta(seconds=20), tick=False):
+        resp = client.post("/logout", cookies={"session_id": token})
+
+    cookies = resp.headers.get_list("set-cookie")
+    assert len(cookies) == 1
+    assert 'session_id=""' in cookies[0]
+    assert "Max-Age=0" in cookies[0]

--- a/website/content/docs/session-authentication.md
+++ b/website/content/docs/session-authentication.md
@@ -59,7 +59,9 @@ auth.logout(request, response=response)
 
 ### Get Current User
 
-Use `get_current_user` or `require_current_user` as FastAPI dependencies:
+`get_current_user` and `require_current_user` take only the request, so they
+work as FastAPI dependencies and as plain calls — in shared-context builders,
+GraphQL resolvers, or template helpers — with a single API:
 
 ```python
 from typing import Annotated
@@ -75,7 +77,31 @@ def me(user: Annotated[User | None, Depends(auth.get_current_user)]): ...
 def protected(
     user: Annotated[User, Depends(auth.require_current_user)],
 ): ...  # raises 401 if not logged in
+
+
+def build_context(request: Request) -> dict:  # outside dependency injection
+    return {"user": auth.get_current_user(request)}
 ```
+
+### Sliding Sessions
+
+With `update_age` configured, reads refresh the stored session record — and the
+browser's cookie must be re-sent so its `Max-Age` slides too. Install
+`SessionCookieMiddleware` once and rolled cookies are delivered on whatever
+response the handler produces, including responses returned directly (redirects,
+streaming, server-rendered pages):
+
+```python
+from cross_auth.fastapi import SessionCookieMiddleware
+
+app.add_middleware(SessionCookieMiddleware)
+```
+
+Without `update_age` the middleware is inert and can be omitted. If a session
+refreshes and the middleware is missing, Cross-Auth emits a warning instead of
+silently letting the browser cookie lapse. A cookie the handler already set
+itself — `logout()` clearing it, `login()` replacing it — always wins over the
+rolled copy.
 
 `session_storage` is optional when constructing `CrossAuth`, but session-backed
 features require it. `login()`, `logout()`, and session-management methods raise

--- a/website/content/docs/storage.md
+++ b/website/content/docs/storage.md
@@ -370,12 +370,16 @@ implementations can compare exactly against the stored (lowercase) value. Pass
 `normalize_email=` to `CrossAuth` to customize this — e.g. to also collapse
 Gmail dot-aliases.
 
-Your user model must expose these attributes:
+Your user model must expose these attributes. Cross-Auth only ever reads them
+(the protocols declare read-only properties), so your model may narrow an
+optional type — a non-nullable `provider_email_verified: bool` on a social
+account, for example — and plain columns, properties, or ORM attributes all
+qualify:
 
 ```python
 class User(Protocol):
     id: Any
-    email: str
+    email: str | None
     email_verified: bool
     hashed_password: str | None
 


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- **#48** (`2026-07-05-make-response-optional-on-crossauth-reads-and-fix`) <-- this PR
<!-- shortcake:end -->

Two fixes surfaced by upgrading a real app (shot) to 0.17:

## One read API: session reads take only the request; middleware rolls the cookie

`get_current_user`, `require_current_user`, and `get_current_session` now take only the request, so a single API serves FastAPI dependencies and direct calls (shared-context builders, GraphQL resolvers, template helpers) alike — no more threading a throwaway `Response` through helper layers.

Rolling the sliding-session cookie moved out of the read path into the new **`SessionCookieMiddleware`** (pure ASGI): reads that refresh a cookie-backed session queue the rolled cookie on `request.state`, and the middleware serializes it onto whatever response the handler produces. That includes responses returned directly — redirects, streaming, server-rendered pages — which the previous dependency-injected `Response` mechanism **silently could not reach** (FastAPI only merges the temporal response's headers for plain-value returns; the example app's own `RedirectResponse` handlers were affected). A cookie the handler already set itself wins — `logout()` clearing the session drops the queued roll instead of resurrecting it (covered by a test). If a session refreshes with no middleware installed, Cross-Auth warns instead of letting the browser cookie lapse silently. Without `update_age` the middleware is inert and unnecessary.

Design history: an optional-`response` parameter was rejected (silent-degradation footgun, and FastAPI's DI chokes on a `Response | None` annotation at app definition time); a separate `peek_current_user` was rejected as a second API to learn. Middleware is how Django/Rails deliver session cookies, and it's the only shape that works for direct-return responses.

**Upgrade note:** drop the `response` argument from the three read methods; add `app.add_middleware(SessionCookieMiddleware)` if you configure `update_age`. `login()`/`logout()` unchanged.

## Storage record protocols now typecheck structurally

`SocialAccount`, `User`, and `SessionRecord` declared their data members as plain protocol attributes, which precise checkers (ty) match invariantly — rejecting any model that narrows a field (e.g. a non-nullable `provider_email_verified: bool`), **including our own SQLModel adapters**. `SessionListResult` already used read-only properties for exactly this reason; the other three now do too. Core only reads these members, so nothing changes at runtime.

Also:
- `User.email` is now `str | None`: apps legitimately hold users without an email, and core never reads it — lookups go through `find_user_by_email`.
- The `SocialAccount` protocol is now exported from `cross_auth`.

Verified downstream: with this branch installed into shot (call sites updated to single-arg reads), its `ty` protocol errors disappear, its full test suite behaves identically, and an un-mocked login → durable session → logout flow passes.

