### PR TITLE
Preserve stored provider credentials on token-less sign-ins

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+Release type: patch
+
+A token-less sign-in — `sign_in_with_id_token`, where no OAuth code exchange
+happens — no longer overwrites provider credentials stored on the social account
+by an earlier web flow. Previously a repeat sign-in through the native path
+nulled the stored access/refresh tokens and scope, silently breaking apps that
+call the provider's API later (e.g. a Google refresh token used for background
+calendar sync). Identity fields (`provider_email`, `provider_email_verified`,
+user info) still refresh from the new token's claims; a web code exchange, which
+always carries an access token, updates credentials exactly as before.
+
+The `SocialAccount` protocol now declares the credential fields (`access_token`,
+`refresh_token`, their expiries, and `scope`) as read-only properties. Storages
+were already required to accept them as
+`update_social_account`/`create_social_account` keyword arguments; declaring
+them readable is what lets core preserve stored values, and models built for the
+documented adapters already expose them.

--- a/src/cross_auth/_auth_flow.py
+++ b/src/cross_auth/_auth_flow.py
@@ -802,13 +802,22 @@ def resolve_or_create_user(
     )
 
     if social_account:
+        # A token-less sign-in (native id_token: no OAuth code exchange)
+        # refreshes identity fields but must not clobber credentials stored by
+        # an earlier web flow — e.g. a Google refresh token that background
+        # API calls depend on. A web exchange always carries an access_token.
+        source = (
+            token_response
+            if token_response.access_token is not None
+            else social_account
+        )
         social_account = context.accounts_storage.update_social_account(
             social_account.id,
-            access_token=token_response.access_token,
-            refresh_token=token_response.refresh_token,
-            access_token_expires_at=token_response.access_token_expires_at,
-            refresh_token_expires_at=token_response.refresh_token_expires_at,
-            scope=token_response.scope,
+            access_token=source.access_token,
+            refresh_token=source.refresh_token,
+            access_token_expires_at=source.access_token_expires_at,
+            refresh_token_expires_at=source.refresh_token_expires_at,
+            scope=source.scope,
             user_info=user_info,
             provider_email=validated.email,
             provider_email_verified=validated.email_verified,

--- a/src/cross_auth/_storage.py
+++ b/src/cross_auth/_storage.py
@@ -43,6 +43,24 @@ class SocialAccount(Protocol):
     @property
     def is_login_method(self) -> bool: ...
 
+    # Provider credentials. Core already writes these through
+    # update_social_account/create_social_account kwargs; declaring them
+    # readable lets token-less sign-ins preserve stored values.
+    @property
+    def access_token(self) -> str | None: ...
+
+    @property
+    def refresh_token(self) -> str | None: ...
+
+    @property
+    def access_token_expires_at(self) -> AwareDatetime | None: ...
+
+    @property
+    def refresh_token_expires_at(self) -> AwareDatetime | None: ...
+
+    @property
+    def scope(self) -> str | None: ...
+
 
 class User(Protocol):
     @property

--- a/tests/fastapi/test_id_token_sign_in.py
+++ b/tests/fastapi/test_id_token_sign_in.py
@@ -204,3 +204,49 @@ def test_nonce_matches_raw_or_hashed_claim(
     )
     with pytest.raises(OAuth2Exception):
         no_nonce.sign_in_with_id_token("stub", VALID_TOKEN, nonce=raw)
+
+
+def test_token_less_sign_in_preserves_credentials_from_a_web_flow(
+    secondary_storage: SecondaryStorage,
+    accounts_storage,
+):
+    """Web flow stores Google-style tokens; a later native sign-in for the
+    same account must refresh identity fields without clobbering them —
+    background API calls depend on the stored refresh token."""
+    provider = StubOIDCProvider(
+        {"sub": "mixed-1", "email": "renamed@example.com", "email_verified": True}
+    )
+    auth = _make_auth(secondary_storage, accounts_storage, provider)
+
+    # Simulate the earlier web callback: user + social account with tokens.
+    web_user = accounts_storage.create_user(
+        user_info={"id": "mixed-1"}, email="mixed@example.com", email_verified=True
+    )
+    accounts_storage.create_social_account(
+        user_id=web_user.id,
+        provider="stub",
+        provider_user_id="mixed-1",
+        access_token="web-access",
+        refresh_token="web-refresh",
+        access_token_expires_at=None,
+        refresh_token_expires_at=None,
+        scope="calendar.readonly",
+        user_info={"id": "mixed-1"},
+        provider_email="mixed@example.com",
+        provider_email_verified=True,
+        is_login_method=True,
+    )
+
+    user, created = auth.sign_in_with_id_token("stub", VALID_TOKEN)
+
+    assert created is False
+    assert user.id == web_user.id
+    account = accounts_storage.find_social_account(
+        provider="stub", provider_user_id="mixed-1"
+    )
+    # Credentials survived the token-less sign-in...
+    assert account.access_token == "web-access"
+    assert account.refresh_token == "web-refresh"
+    assert account.scope == "calendar.readonly"
+    # ...while identity fields refreshed from the new token's claims.
+    assert account.provider_email == "renamed@example.com"


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- **#51** (`2026-07-06-preserve-stored-provider-credentials-on-token-less`) <-- this PR
<!-- shortcake:end -->

Follow-up to #50, fixing a mixed-flow hazard before anyone hits it.

## Token-less sign-ins no longer clobber stored provider credentials

A repeat `sign_in_with_id_token` for an account that already has a social-account row runs the update branch of `resolve_or_create_user` — which wrote the "token response" fields unconditionally. The native flow has no token exchange, so it wrote NULLs: a user who connected Google on the web (refresh token stored for background API calls) and later signed in on their phone would silently lose those credentials.

Now the update branch picks its credential source: a web exchange always carries an `access_token`, so when it's present the response updates credentials exactly as before; when it's absent (token-less sign-in) the stored values are preserved. Identity fields — `provider_email`, `provider_email_verified`, user info — always refresh from the new token's claims.

To read the stored values without `getattr` games, the `SocialAccount` protocol now declares the five credential fields as read-only properties. That's a clarification more than an expansion: every storage was already required to *accept* them as `update_social_account`/`create_social_account` kwargs, and the SQLModel adapter already validates the columns exist — the record type just didn't admit they were readable.

Test: web-flow social account with `access_token`/`refresh_token`/`scope` → native sign-in for the same subject → credentials intact, `provider_email` refreshed from the new claims.

Ships as **0.20.1**.
