### PR TITLE
Fix "Duplicate operationId"

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+---
+release type: patch
+---
+
+OAuth callback routes now use distinct OpenAPI operation IDs for GET and POST
+requests. This removes FastAPI's duplicate operation ID warning and allows
+OpenAPI client generators to produce unambiguous callback methods while
+preserving the existing operation ID for standard GET callbacks.

--- a/src/cross_auth/router.py
+++ b/src/cross_auth/router.py
@@ -86,9 +86,16 @@ def _provider_routes(provider: OAuth2Provider, *, cookie_auth: bool) -> list[Rou
             ),
             Route(
                 path=f"{prefix}/callback",
-                methods=["GET", "POST"],  # POST for Apple (response_mode=form_post)
+                methods=["GET"],
                 function=bound(handle_callback),
                 operation_id=f"{provider.id}_callback",
+                read_form_data=True,
+            ),
+            Route(
+                path=f"{prefix}/callback",
+                methods=["POST"],  # POST for Apple (response_mode=form_post)
+                function=bound(handle_callback),
+                operation_id=f"{provider.id}_callback_post",
                 read_form_data=True,
             ),
             Route(

--- a/src/cross_auth/router.py
+++ b/src/cross_auth/router.py
@@ -89,7 +89,6 @@ def _provider_routes(provider: OAuth2Provider, *, cookie_auth: bool) -> list[Rou
                 methods=["GET"],
                 function=bound(handle_callback),
                 operation_id=f"{provider.id}_callback",
-                read_form_data=True,
             ),
             Route(
                 path=f"{prefix}/callback",

--- a/tests/router/test_openapi.py
+++ b/tests/router/test_openapi.py
@@ -16,4 +16,6 @@ def test_callback_routes_have_unique_operation_ids(auth: CrossAuth):
     callback_operations = schema["paths"]["/fake/callback"]
 
     assert callback_operations["get"]["operationId"] == "fake_callback"
+    assert "requestBody" not in callback_operations["get"]
     assert callback_operations["post"]["operationId"] == "fake_callback_post"
+    assert "requestBody" in callback_operations["post"]

--- a/tests/router/test_openapi.py
+++ b/tests/router/test_openapi.py
@@ -1,0 +1,19 @@
+import warnings
+
+from fastapi import FastAPI
+
+from cross_auth.fastapi import CrossAuth
+
+
+def test_callback_routes_have_unique_operation_ids(auth: CrossAuth):
+    app = FastAPI()
+    app.include_router(auth.router)
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", message="Duplicate Operation ID.*")
+        schema = app.openapi()
+
+    callback_operations = schema["paths"]["/fake/callback"]
+
+    assert callback_operations["get"]["operationId"] == "fake_callback"
+    assert callback_operations["post"]["operationId"] == "fake_callback_post"


### PR DESCRIPTION
FastAPI doesn't work well with routes that have multiple methods - it produces invalid openapi schema where operations have duplicated `operationId`.

This results in warnings on app startup:

```
***/.venv/lib/python3.14/site-packages/fastapi/openapi/utils.py:255: UserWarning: Duplicate Operation ID github_callback for function wrapper at /home/****/2.fastapilabs/cloud/.venv/lib/python3.14/site-packages/cross_auth/_route.py
```
Also, client generators may not work well with such schemas:

```
Duplicate operationId: github_callback in POST /api/v1/github/callback. Please ensure your operation IDs are unique. This behavior is not supported and will likely lead to unexpected results.
```

To resolve this we need to make operation IDs distinct.

This is a little bit breaking change for project that use client generators, but it's easily resolvable (just several classes and functions should be renamed in user code if they are used)

## Summary by Sourcery

Bug Fixes:
- Split the combined GET/POST OAuth callback route into separate GET and POST routes with unique operation IDs to prevent OpenAPI schema conflicts.