### PR TITLE
Redirect callback errors to default_next_url when no AuthRequest is available

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,6 @@
-Release type: minor
+---
+release type: minor
+---
 
 OAuth callback errors that occur when the stored auth request is missing or
 expired no longer return a bare JSON 400. The callback endpoint is a top-level

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+Release type: minor
+
+OAuth callback errors that occur when the stored auth request is missing or
+expired no longer return a bare JSON 400. The callback endpoint is a top-level
+browser navigation, so those responses stranded real users — anyone who idled
+past the state's 10-minute TTL on a provider's consent screen, resumed an
+abandoned tab, or refreshed the single-use callback URL — on a JSON document on
+the API origin with no way back to the app.
+
+These dead-ends now redirect (302) to `default_next_url` — the same
+operator-configured fallback the success paths already use — with the error in
+the query string:
+
+- an unknown or expired `state` redirects with `error=session_expired`,
+- a callback carrying no `state` at all redirects with `error=invalid_request`,
+- a provider-reported error arriving with an unknown `state` passes the
+  provider's own error code through.
+
+Each redirect also carries a human-readable `error_description`. Apps can match
+on `error=session_expired` to show a "your session expired, please try again"
+message. Callbacks whose auth request is still available are handled exactly as
+before.

--- a/src/cross_auth/_auth_flow.py
+++ b/src/cross_auth/_auth_flow.py
@@ -549,7 +549,9 @@ def handle_callback(
     The callback is a top-level browser navigation, so when the stored
     AuthRequest is missing or expired (and no flow-specific redirect target is
     known) errors redirect to `default_next_url` instead of returning a JSON
-    body that would strand the user on the API origin.
+    body that would strand the user on the API origin. `default_next_url` is
+    operator configuration fixed at construction time — never derived from the
+    request — so these fallback redirects cannot be attacker-controlled.
     """
     if intercepted := provider.intercept_callback(request, context):
         return intercepted

--- a/src/cross_auth/_auth_flow.py
+++ b/src/cross_auth/_auth_flow.py
@@ -545,6 +545,11 @@ def handle_callback(
     The provider can short-circuit via `intercept_callback` (for non-OAuth
     callback variants) and post-process the final redirect via
     `finalize_redirect`.
+
+    The callback is a top-level browser navigation, so when the stored
+    AuthRequest is missing or expired (and no flow-specific redirect target is
+    known) errors redirect to `default_next_url` instead of returning a JSON
+    body that would strand the user on the API origin.
     """
     if intercepted := provider.intercept_callback(request, context):
         return intercepted
@@ -587,19 +592,24 @@ def _handle_oauth_callback(
                 error_description=f"Authorization failed: {callback_data.error}",
             )
 
-        return Response.error(
-            callback_data.error,
+        return Response.error_redirect(
+            context.default_next_url,
+            error=callback_data.error,
             error_description=f"Authorization failed: {callback_data.error}",
         )
 
     if not state:
-        return Response.error(
-            "server_error", error_description="No state found in request"
+        return Response.error_redirect(
+            context.default_next_url,
+            error="invalid_request",
+            error_description="No state found in request",
         )
 
     if auth_request is None:
-        return Response.error(
-            "server_error", error_description="Provider data not found"
+        return Response.error_redirect(
+            context.default_next_url,
+            error="session_expired",
+            error_description="The authorization request has expired. Please try again.",
         )
 
     if auth_request.provider_id != provider.id:

--- a/tests/router/test_session_flow.py
+++ b/tests/router/test_session_flow.py
@@ -108,16 +108,18 @@ def test_session_callback_consumes_state(
     replay = client.get(
         "/fake/callback", params={"code": "provider-code", "state": state}
     )
-    assert replay.status_code == 400
-    assert replay.json()["error"] == "server_error"
+    assert replay.status_code == 302
+    qs = parse_qs(urlparse(replay.headers["location"]).query)
+    assert qs["error"] == ["session_expired"]
 
 
 @respx.mock
 def test_session_callback_rejects_missing_state(client: TestClient):
     mock_token_and_userinfo()
     resp = client.get("/fake/callback", params={"code": "provider-code"})
-    assert resp.status_code == 400
-    assert resp.json()["error"] == "server_error"
+    assert resp.status_code == 302
+    qs = parse_qs(urlparse(resp.headers["location"]).query)
+    assert qs["error"] == ["invalid_request"]
 
 
 @respx.mock
@@ -126,8 +128,38 @@ def test_session_callback_rejects_unknown_state(client: TestClient):
     resp = client.get(
         "/fake/callback", params={"code": "provider-code", "state": "never-seen"}
     )
-    assert resp.status_code == 400
-    assert resp.json()["error"] == "server_error"
+    assert resp.status_code == 302
+    qs = parse_qs(urlparse(resp.headers["location"]).query)
+    assert qs["error"] == ["session_expired"]
+
+
+def test_session_callback_expired_state_redirects_to_default_next_url(build_auth):
+    auth = build_auth(default_next_url="https://app.example/dashboard")
+    app = FastAPI()
+    app.include_router(auth.router)
+    with TestClient(app, follow_redirects=False) as client:
+        resp = client.get(
+            "/fake/callback", params={"code": "provider-code", "state": "never-seen"}
+        )
+    assert resp.status_code == 302
+    location = urlparse(resp.headers["location"])
+    assert (location.scheme, location.netloc, location.path) == (
+        "https",
+        "app.example",
+        "/dashboard",
+    )
+    assert parse_qs(location.query)["error"] == ["session_expired"]
+
+
+def test_session_callback_provider_error_with_unknown_state_redirects(
+    client: TestClient,
+):
+    resp = client.get(
+        "/fake/callback", params={"error": "access_denied", "state": "never-seen"}
+    )
+    assert resp.status_code == 302
+    qs = parse_qs(urlparse(resp.headers["location"]).query)
+    assert qs["error"] == ["access_denied"]
 
 
 @respx.mock


### PR DESCRIPTION
Based on `main` so it can merge independently. (fastapilabs/cloud currently pins `refs/pull/53/head`, so it picks this up once #53 rebases onto main after this merges — or when the pin moves.)

## Problem

Since the state became a single-use, 10-minute-TTL token, the callback endpoint has a browser-facing dead-end: when the stored `AuthRequest` is missing or expired, the flow-specific redirect target (`next_url` / `client_redirect_uri`) is gone with it, and the endpoint returns a raw JSON 400 (`Provider data not found`) — rendered as plain text in the user's browser on the API origin, with no way back to the app.

Real-world triggers: idling on a provider's consent/install screen past the TTL (e.g. GitHub App org/repo selection), resuming an abandoned tab, or refreshing/replaying the now single-use callback URL.

## Fix

The callback is always a top-level browser navigation, so the no-`AuthRequest` error branches now redirect to the already-configurable `default_next_url` (the same fallback the success paths use), with the error as query params:

| case | redirect |
|---|---|
| unknown/expired state | `?error=session_expired&error_description=…` |
| missing state | `?error=invalid_request&error_description=…` |
| provider error + unknown state | `?error=<provider error>&error_description=…` |

Branches where the `AuthRequest` is still available are unchanged (`_flow_error` already redirects for token flows and keeps JSON for session/link).

Apps can match on `error=session_expired` to show a "session expired, please try again" message.

## Tests

Updated the three session-flow tests asserting the old 400s; added coverage that the redirect honors a custom `default_next_url` and that provider errors with unknown state pass the provider's error code through. `397 passed` on main, ruff + ty clean.