### PR TITLE
Fix website package discovery

### DIFF
--- a/website/pyproject.toml
+++ b/website/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
 [dependency-groups]
 dev = []
 
+[tool.setuptools]
+py-modules = ["main"]
+
 [tool.cross-docs]
 content_dir = "content"
 prefix = "/docs"


### PR DESCRIPTION
## Summary

- configure setuptools to package the website's `main.py` module explicitly
- prevent flat-layout discovery from treating `static`, `content`, `frontend`, and `templates` as Python packages

## Why

FastAPI Cloud could upload the deployment, but failed while building the website package because setuptools found multiple top-level packages in the flat layout.

## Validation

- `bun run build`
- `uv sync --frozen --package cross-auth-website`
- `uv build website --out-dir <temp-dir>`
- `uv run --frozen --package cross-auth-website python -c "from main import app; print(app.title)"`
- commit hooks
