### PR TITLE
Preserve recoverable OAuth token exchange errors

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+---
+release type: patch
+---
+
+OAuth token exchanges now preserve recoverable provider errors, such as GitHub's
+`bad_verification_code`, so expired authorization codes are returned to the
+client instead of being reported as server failures. Expected rejections are
+logged at info level, while genuine provider and response failures retain
+server-error handling.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,4 +6,6 @@ OAuth token exchanges now preserve recoverable provider errors, such as GitHub's
 `bad_verification_code`, so expired authorization codes are returned to the
 client instead of being reported as server failures. Expected rejections are
 logged at info level, while genuine provider and response failures retain
-server-error handling.
+server-error handling. Token requests now use a configurable 10-second timeout;
+timeouts are reported as `temporarily_unavailable` without retrying the one-time
+authorization code, so clients can restart the authorization flow safely.

--- a/src/cross_auth/__init__.py
+++ b/src/cross_auth/__init__.py
@@ -51,6 +51,7 @@ from cross_auth.social_providers.oauth import (
     CallbackData,
     OAuth2Exception,
     OAuth2Provider,
+    OAuth2TimeoutException,
     TokenExchangeParams,
     UserInfo,
 )
@@ -92,6 +93,7 @@ __all__ = [
     "BeforeUserCreateEvent",
     "OAuth2Exception",
     "OAuth2Provider",
+    "OAuth2TimeoutException",
     "OIDCProvider",
     "SecondaryStorage",
     "SessionConfig",

--- a/src/cross_auth/social_providers/apple.py
+++ b/src/cross_auth/social_providers/apple.py
@@ -3,12 +3,14 @@ import logging
 import time
 from typing import Annotated, Any, Literal
 
+import httpx
 import jwt
 from cross_web import HTTPRequest
 from pydantic import BaseModel, BeforeValidator, EmailStr
 
 from .oauth import (
     CallbackData,
+    DEFAULT_TOKEN_EXCHANGE_TIMEOUT,
     OAuth2Exception,
     TokenExchangeParams,
     UserInfo,
@@ -116,11 +118,17 @@ class AppleProvider(OIDCProvider):
         team_id: str,
         key_id: str,
         private_key: str,
+        token_exchange_timeout: float | httpx.Timeout | None = (
+            DEFAULT_TOKEN_EXCHANGE_TIMEOUT
+        ),
     ):
         self.team_id = team_id
         self.key_id = key_id
         self.private_key = private_key
-        super().__init__(client_id=client_id)
+        super().__init__(
+            client_id=client_id,
+            token_exchange_timeout=token_exchange_timeout,
+        )
 
     def generate_client_secret(self) -> str:
         """Generate a JWT client secret for Apple.

--- a/src/cross_auth/social_providers/github.py
+++ b/src/cross_auth/social_providers/github.py
@@ -10,7 +10,7 @@ from pydantic import AnyUrl, BaseModel, EmailStr, Field
 from cross_auth._context import Context
 from cross_auth.models.oauth_token_response import TokenResponse
 
-from .oauth import OAuth2Provider, UserInfo
+from .oauth import DEFAULT_TOKEN_EXCHANGE_TIMEOUT, OAuth2Provider, UserInfo
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +104,9 @@ class GitHubProvider(OAuth2Provider):
         authorization_endpoint: str | None = None,
         token_endpoint: str | None = None,
         api_base_url: str | None = None,
+        token_exchange_timeout: float | httpx.Timeout | None = (
+            DEFAULT_TOKEN_EXCHANGE_TIMEOUT
+        ),
     ):
         """
         Initialize the GitHub OAuth2 provider.
@@ -117,8 +120,15 @@ class GitHubProvider(OAuth2Provider):
             token_endpoint: Custom token exchange URL (for server-to-server calls).
             api_base_url: Custom API base URL for user info and emails
                 (for server-to-server calls). Should not include trailing slash.
+            token_exchange_timeout: Timeout for the provider token request. Set to
+                None to disable it.
         """
-        super().__init__(client_id, client_secret, trust_email)
+        super().__init__(
+            client_id,
+            client_secret,
+            trust_email,
+            token_exchange_timeout=token_exchange_timeout,
+        )
 
         if authorization_endpoint is not None:
             self.authorization_endpoint = authorization_endpoint

--- a/src/cross_auth/social_providers/google.py
+++ b/src/cross_auth/social_providers/google.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from .oauth import UserInfo
+import httpx
+
+from .oauth import DEFAULT_TOKEN_EXCHANGE_TIMEOUT, UserInfo
 from .oidc import OIDCProvider
 
 
@@ -30,6 +32,9 @@ class GoogleProvider(OIDCProvider):
         authorization_endpoint: str | None = None,
         token_endpoint: str | None = None,
         jwks_uri: str | None = None,
+        token_exchange_timeout: float | httpx.Timeout | None = (
+            DEFAULT_TOKEN_EXCHANGE_TIMEOUT
+        ),
     ):
         """
         Initialize the Google OAuth2 / OIDC provider.
@@ -49,12 +54,15 @@ class GoogleProvider(OIDCProvider):
             authorization_endpoint: Custom authorization URL (for browser redirects).
             token_endpoint: Custom token exchange URL (for server-to-server calls).
             jwks_uri: Custom JWKS URL (for server-to-server ID token validation).
+            token_exchange_timeout: Timeout for the provider token request. Set to
+                None to disable it.
         """
         super().__init__(
             client_id,
             client_secret,
             trust_email,
             extra_authorization_params=extra_authorization_params,
+            token_exchange_timeout=token_exchange_timeout,
         )
 
         if authorization_endpoint is not None:

--- a/src/cross_auth/social_providers/oauth.py
+++ b/src/cross_auth/social_providers/oauth.py
@@ -18,6 +18,8 @@ from ..models.oauth_token_response import (
 
 logger = logging.getLogger(__name__)
 
+RECOVERABLE_TOKEN_EXCHANGE_ERRORS = {"bad_verification_code"}
+
 
 class UserInfo(TypedDict, total=True):
     email: str | None
@@ -281,7 +283,6 @@ class OAuth2Provider:
         try:
             return OAuth2TokenEndpointResponse.model_validate_json(response.text)
         except ValidationError as e:
-            logger.error("Failed to parse token response: %s", e)
             raise OAuth2Exception(
                 error="server_error",
                 error_description="Failed to parse token response",
@@ -307,9 +308,17 @@ class OAuth2Provider:
             params = self.build_token_exchange_params(code, redirect_uri, code_verifier)
 
             response = self.send_token_request(params)
-            response.raise_for_status()
+            try:
+                token_response = self.parse_token_response(response)
+            except OAuth2Exception as e:
+                if response.is_error:
+                    response.raise_for_status()
 
-            token_response = self.parse_token_response(response)
+                logger.error(
+                    "Failed to parse token response: %s",
+                    e.__cause__ or e.error_description,
+                )
+                raise
 
             if token_response.is_error():
                 if not isinstance(token_response.root, TokenErrorResponse):
@@ -318,12 +327,32 @@ class OAuth2Provider:
                         error_description="Unexpected token response format",
                     )
 
-                logger.error("Token exchange failed: %s", token_response.root.error)
+                token_error = token_response.root
+
+                if token_error.error in RECOVERABLE_TOKEN_EXCHANGE_ERRORS:
+                    logger.info(
+                        "Token exchange rejected by provider: %s",
+                        token_error.error,
+                        extra={
+                            "oauth_provider": self.id,
+                            "oauth_error": token_error.error,
+                        },
+                    )
+                    raise OAuth2Exception(
+                        error=token_error.error,
+                        error_description=token_error.error_description
+                        or "The authorization code is invalid or expired. Please try again.",
+                    )
+
+                response.raise_for_status()
+                logger.error("Token exchange failed: %s", token_error.error)
 
                 raise OAuth2Exception(
                     error="server_error",
-                    error_description=f"Token exchange failed: {token_response.root.error}",
+                    error_description=f"Token exchange failed: {token_error.error}",
                 )
+
+            response.raise_for_status()
 
             if not isinstance(token_response.root, TokenResponse):
                 raise OAuth2Exception(

--- a/src/cross_auth/social_providers/oauth.py
+++ b/src/cross_auth/social_providers/oauth.py
@@ -18,6 +18,7 @@ from ..models.oauth_token_response import (
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_TOKEN_EXCHANGE_TIMEOUT = 10.0
 RECOVERABLE_TOKEN_EXCHANGE_ERRORS = {"bad_verification_code"}
 
 
@@ -46,8 +47,13 @@ class TokenExchangeParams(TypedDict, total=False):
 
 class OAuth2Exception(Exception):
     def __init__(self, error: str, error_description: str):
+        super().__init__(error_description)
         self.error = error
         self.error_description = error_description
+
+
+class OAuth2TimeoutException(OAuth2Exception):
+    pass
 
 
 class CallbackData(BaseModel):
@@ -72,6 +78,9 @@ class OAuth2Provider:
         trust_email: bool = True,
         *,
         extra_authorization_params: dict[str, str] | None = None,
+        token_exchange_timeout: float | httpx.Timeout | None = (
+            DEFAULT_TOKEN_EXCHANGE_TIMEOUT
+        ),
     ):
         """
         Initialize the OAuth2 provider.
@@ -87,11 +96,14 @@ class OAuth2Provider:
                 the authorization URL (e.g., Google's ``access_type=offline``,
                 ``prompt=consent``, ``hd``, ``include_granted_scopes``). Keys that
                 conflict with provider-controlled params are ignored.
+            token_exchange_timeout: Timeout for the provider token request. Set to
+                None to disable it.
         """
         self.client_id = client_id
         self.client_secret = client_secret
         self.trust_email = trust_email
         self.extra_authorization_params = extra_authorization_params
+        self.token_exchange_timeout = token_exchange_timeout
 
     def can_auto_link(self, context: Context, email_verified: bool | None) -> bool:
         """Check if auto-linking by email is allowed.
@@ -268,6 +280,7 @@ class OAuth2Provider:
                 "Content-Type": "application/x-www-form-urlencoded",
             },
             data=data,
+            timeout=self.token_exchange_timeout,
         )
 
     def parse_token_response(
@@ -378,6 +391,21 @@ class OAuth2Provider:
             raise OAuth2Exception(
                 error="server_error",
                 error_description="Token exchange failed",
+            ) from e
+        except httpx.TimeoutException as e:
+            logger.warning(
+                "Token exchange timed out",
+                extra={
+                    "oauth_provider": self.id,
+                    "oauth_error": "temporarily_unavailable",
+                },
+            )
+            raise OAuth2TimeoutException(
+                error="temporarily_unavailable",
+                error_description=(
+                    "The OAuth provider timed out. Please restart the authorization "
+                    "flow."
+                ),
             ) from e
         except (httpx.RequestError, ValidationError) as e:
             logger.error("Failed to exchange code for token: %s", e)

--- a/tests/providers/test_provider.py
+++ b/tests/providers/test_provider.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 import httpx
 import pytest
@@ -7,7 +8,7 @@ from cross_web import HTTPRequest, TestingHTTPRequestAdapter
 
 from cross_auth._auth_flow import handle_callback, start_token_flow
 from cross_auth._context import Context
-from cross_auth.social_providers.oauth import OAuth2Provider
+from cross_auth.social_providers.oauth import OAuth2Exception, OAuth2Provider, logger
 
 
 class ExampleProvider(OAuth2Provider):
@@ -55,18 +56,99 @@ def test_exchange_code_success(example_provider: ExampleProvider) -> None:
 
 
 @respx.mock
-def test_exchange_code_github_down(example_provider: ExampleProvider):
-    from cross_auth.social_providers.oauth import OAuth2Exception
-
+def test_exchange_code_github_down(
+    example_provider: ExampleProvider,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     respx.post("https://example.com/login/oauth/access_token").mock(
         return_value=respx.MockResponse(503)
     )
 
-    with pytest.raises(OAuth2Exception) as exc_info:
+    with (
+        caplog.at_level(logging.WARNING, logger=logger.name),
+        pytest.raises(OAuth2Exception) as exc_info,
+    ):
         example_provider.exchange_code("test_code", "https://example.com/callback")
 
     assert exc_info.value.error == "server_error"
     assert "Token exchange failed" in exc_info.value.error_description
+    provider_records = [
+        record for record in caplog.records if record.name == logger.name
+    ]
+    assert len(provider_records) == 1
+    assert provider_records[0].levelno == logging.WARNING
+    assert provider_records[0].getMessage() == (
+        "HTTP error during token exchange: 503 - "
+    )
+
+
+@respx.mock
+def test_exchange_code_logs_malformed_success_response(
+    example_provider: ExampleProvider,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    respx.post("https://example.com/login/oauth/access_token").mock(
+        return_value=respx.MockResponse(200)
+    )
+
+    with (
+        caplog.at_level(logging.ERROR, logger=logger.name),
+        pytest.raises(OAuth2Exception) as exc_info,
+    ):
+        example_provider.exchange_code("test_code", "https://example.com/callback")
+
+    assert exc_info.value.error == "server_error"
+    assert exc_info.value.error_description == "Failed to parse token response"
+    provider_records = [
+        record for record in caplog.records if record.name == logger.name
+    ]
+    assert len(provider_records) == 1
+    assert provider_records[0].levelno == logging.ERROR
+    assert (
+        provider_records[0]
+        .getMessage()
+        .startswith("Failed to parse token response: 1 validation error")
+    )
+
+
+@pytest.mark.parametrize(
+    "status_code",
+    [200, 400],
+)
+@respx.mock
+def test_exchange_code_preserves_recoverable_provider_error(
+    example_provider: ExampleProvider,
+    caplog: pytest.LogCaptureFixture,
+    status_code: int,
+) -> None:
+    error = "bad_verification_code"
+    respx.post("https://example.com/login/oauth/access_token").mock(
+        return_value=respx.MockResponse(
+            status_code,
+            json={
+                "error": error,
+                "error_description": "The code is invalid or expired.",
+            },
+        )
+    )
+
+    with (
+        caplog.at_level(logging.INFO, logger=logger.name),
+        pytest.raises(OAuth2Exception) as exc_info,
+    ):
+        example_provider.exchange_code("test_code", "https://example.com/callback")
+
+    assert exc_info.value.error == error
+    assert exc_info.value.error_description == "The code is invalid or expired."
+    assert len(caplog.records) == 1
+    assert caplog.records[0].name == logger.name
+    assert caplog.records[0].levelno == logging.INFO
+    assert getattr(caplog.records[0], "oauth_provider") == "example"
+    assert getattr(caplog.records[0], "oauth_error") == error
+    assert (
+        caplog.records[0].getMessage()
+        == f"Token exchange rejected by provider: {error}"
+    )
 
 
 @pytest.fixture

--- a/tests/providers/test_provider.py
+++ b/tests/providers/test_provider.py
@@ -8,7 +8,12 @@ from cross_web import HTTPRequest, TestingHTTPRequestAdapter
 
 from cross_auth._auth_flow import handle_callback, start_token_flow
 from cross_auth._context import Context
-from cross_auth.social_providers.oauth import OAuth2Exception, OAuth2Provider, logger
+from cross_auth.social_providers.oauth import (
+    OAuth2Exception,
+    OAuth2Provider,
+    OAuth2TimeoutException,
+    logger,
+)
 
 
 class ExampleProvider(OAuth2Provider):
@@ -109,6 +114,39 @@ def test_exchange_code_logs_malformed_success_response(
         .getMessage()
         .startswith("Failed to parse token response: 1 validation error")
     )
+
+
+@respx.mock
+def test_exchange_code_reports_timeout_without_retrying(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    provider = ExampleProvider(
+        client_id="test_client_id",
+        client_secret="test_client_secret",
+        token_exchange_timeout=15.0,
+    )
+    token_route = respx.post(provider.token_endpoint).mock(
+        side_effect=httpx.ReadTimeout("provider timed out")
+    )
+
+    with (
+        caplog.at_level(logging.WARNING, logger=logger.name),
+        pytest.raises(OAuth2TimeoutException) as exc_info,
+    ):
+        provider.exchange_code("test_code", "https://example.com/callback")
+
+    assert token_route.call_count == 1
+    assert token_route.calls[0].request.extensions["timeout"]["read"] == 15.0
+    assert exc_info.value.error == "temporarily_unavailable"
+    assert exc_info.value.error_description == (
+        "The OAuth provider timed out. Please restart the authorization flow."
+    )
+    assert str(exc_info.value) == exc_info.value.error_description
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.WARNING
+    assert getattr(caplog.records[0], "oauth_provider") == "example"
+    assert getattr(caplog.records[0], "oauth_error") == "temporarily_unavailable"
+    assert caplog.records[0].getMessage() == "Token exchange timed out"
 
 
 @pytest.mark.parametrize(

--- a/tests/router/test_token_flow.py
+++ b/tests/router/test_token_flow.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 from cross_auth._auth_flow import logger as auth_flow_logger
 from cross_auth._issuer import AuthorizationCodeGrantData
 from cross_auth._storage import SecondaryStorage
+from cross_auth.social_providers.oauth import logger as oauth_provider_logger
 
 from .conftest import (
     load_auth_request,
@@ -129,6 +130,46 @@ def test_token_callback_reports_provider_error_to_client(client: TestClient, cap
     assert len(flow_records) == 1
     assert flow_records[0].levelno == logging.INFO
     assert flow_records[0].getMessage() == "OAuth error: access_denied"
+
+
+@respx.mock
+def test_token_callback_reports_expired_provider_code_to_client(
+    client: TestClient, caplog
+):
+    respx.post("https://fake.example/oauth/token").mock(
+        return_value=respx.MockResponse(
+            200,
+            json={
+                "error": "bad_verification_code",
+                "error_description": "The code passed is incorrect or expired.",
+            },
+        )
+    )
+    _, state = start_provider_auth(client, "/fake/authorize", params=_AUTHZ_PARAMS)
+
+    with caplog.at_level(logging.INFO, logger=oauth_provider_logger.name):
+        resp = client.get(
+            "/fake/callback", params={"code": "expired-code", "state": state}
+        )
+
+    assert resp.status_code == 302
+    location = urlparse(resp.headers["location"])
+    qs = parse_qs(location.query)
+    assert qs["error"] == ["bad_verification_code"]
+    assert qs["error_description"] == ["The code passed is incorrect or expired."]
+    assert qs["state"] == ["client-csrf-state"]
+
+    provider_records = [
+        record for record in caplog.records if record.name == oauth_provider_logger.name
+    ]
+    assert len(provider_records) == 1
+    assert provider_records[0].levelno == logging.INFO
+    assert getattr(provider_records[0], "oauth_provider") == "fake"
+    assert getattr(provider_records[0], "oauth_error") == "bad_verification_code"
+    assert (
+        provider_records[0].getMessage()
+        == "Token exchange rejected by provider: bad_verification_code"
+    )
 
 
 @respx.mock


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- **#57** (`2026-08-17-preserve-recoverable-oauth-token-exchange-errors`) <-- this PR
<!-- shortcake:end -->

## Summary by Sourcery

Preserve and surface recoverable OAuth token exchange errors while refining provider error handling and logging.

Bug Fixes:
- Ensure recoverable OAuth provider errors like expired or invalid authorization codes are propagated to clients instead of being treated as server failures.

Enhancements:
- Introduce explicit handling for recoverable token exchange errors with structured info-level logging and provider/error metadata.
- Refine token response parsing and error logging so malformed or unexpected responses are logged appropriately while preserving server-error semantics.

Documentation:
- Add release notes documenting the new behavior for recoverable OAuth token exchange errors and associated logging changes.

Tests:
- Extend OAuth provider and token callback tests to cover recoverable provider errors, malformed token responses, and logging expectations for each path.